### PR TITLE
Fix flaky component tests: register RTL cleanup for every test file

### DIFF
--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,12 @@
+/*
+Registered via `test.setupFiles` in vite.config.js, so it applies to every test
+file. Needed because of `isolate: false`: @testing-library/react's automatic
+afterEach(cleanup) registers as a module-evaluation side effect, and with the
+module cache shared per worker it only takes effect in the first test file that
+imports it there. Later files in the same worker would accumulate rendered DOM
+across tests ("Found multiple elements" flakes). Registering cleanup here makes
+it run after every test in every file.
+*/
+import { cleanup } from '@testing-library/react';
+
+afterEach(() => cleanup());

--- a/vite.config.js
+++ b/vite.config.js
@@ -44,9 +44,11 @@ export default defineConfig(() => ({
     clearMocks: true,
     restoreMocks: true,
     // Reuse one context per worker instead of a fresh one per file (~40% faster).
-    // These are pure-logic and cleanly-torn-down component tests, so no cross-file
-    // state leaks. The strict per-file-isolated behaviour is still a `vitest run
-    // --isolate` away if a leak is ever suspected.
-    isolate: false
+    // Requires the setup file below: with a shared module cache, testing-library's
+    // own auto-cleanup only registers in the first file per worker, so per-file
+    // teardown must be provided explicitly. The strict per-file-isolated behaviour
+    // is still a `vitest run --isolate` away if a leak is ever suspected.
+    isolate: false,
+    setupFiles: ['./src/test-setup.ts']
   }
 }));


### PR DESCRIPTION
With isolate: false the module cache is shared per worker, so @testing-library/react's automatic afterEach(cleanup) — a module-eval side effect — only registers in the first test file that imports it in that worker. Later files in the same worker accumulated rendered DOM across tests, causing intermittent "Found multiple elements" failures (most often the overview spec, depending on file-to-worker scheduling).

Reproducible deterministically with a single worker:
  npx vitest run --fileParallelism=false \
    src/components/game-factory/game-parts/game-sidebar.spec.tsx \
    src/components/overview/overview.spec.tsx

A setupFiles entry now registers afterEach(cleanup) explicitly, which applies to every file. Verified: the repro above passes, the full suite passes with --fileParallelism=false (maximum context sharing), and 8/8 parallel runs are green (previously roughly every 3rd-6th run failed).


Claude-Session: https://claude.ai/code/session_0142qbJLrqTvSn1SyoZuaqxK