### PR TITLE
Refact: add set/clear primitives to useHoverPreview, convert 2 imperative-hover games

### DIFF
--- a/src/components/games/chocolate-breaking/chocolate-breaking.tsx
+++ b/src/components/games/chocolate-breaking/chocolate-breaking.tsx
@@ -1,7 +1,6 @@
-import { useState } from 'react';
 import { range } from 'lodash';
 import {
-  strategyGameFactory, type BoardClientProps, type Ctx, type Events, GameBoard
+  strategyGameFactory, type BoardClientProps, type Ctx, type Events, GameBoard, useHoverPreview
 } from '../../strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import {
@@ -12,22 +11,19 @@ import {
 const CELL = 30; // px per chocolate cell
 const CUT = 18; // px hit area of a cut line
 
-type HoveredCut = (Move & { moveCount: number }) | null;
-
-const PieceView = ({ piece, ctx, hovered, setHovered, onActivate }: {
+const PieceView = ({ piece, ctx, hovered, setHovered, clearHovered, onActivate }: {
   piece: Piece;
   ctx: Ctx;
-  hovered: HoveredCut;
-  setHovered: (h: HoveredCut) => void;
+  hovered: Move | null;
+  setHovered: (h: Move) => void;
+  clearHovered: () => void;
   onActivate: (move: Move) => void;
 }) => {
   const { w, h } = piece;
   const breaks = safeBreaks(piece);
 
-  const hoveredHere = ctx.isClientMoveAllowed
-    && hovered?.moveCount === ctx.moveCount
-    && hovered?.id === piece.id
-    ? breaks.find(br => br.dir === hovered!.dir && br.pos === hovered!.pos)
+  const hoveredHere = ctx.isClientMoveAllowed && hovered?.id === piece.id
+    ? breaks.find(br => br.dir === hovered.dir && br.pos === hovered.pos)
     : undefined;
 
   const label = hoveredHere
@@ -66,10 +62,10 @@ const PieceView = ({ piece, ctx, hovered, setHovered, onActivate }: {
               style={style}
               aria-label={`${w}×${h} → ${br.a.w}×${br.a.h} + ${br.b.w}×${br.b.h}`}
               onClick={() => onActivate(cut)}
-              onFocus={() => setHovered({ ...cut, moveCount: ctx.moveCount })}
-              onBlur={() => setHovered(null)}
-              onPointerEnter={e => { if (e.pointerType === 'mouse') setHovered({ ...cut, moveCount: ctx.moveCount }); }}
-              onPointerLeave={e => { if (e.pointerType === 'mouse') setHovered(null); }}
+              onFocus={() => setHovered(cut)}
+              onBlur={clearHovered}
+              onPointerEnter={e => { if (e.pointerType === 'mouse') setHovered(cut); }}
+              onPointerLeave={e => { if (e.pointerType === 'mouse') clearHovered(); }}
             >
               <span className={`transition-colors ${line}`} />
             </button>
@@ -84,7 +80,7 @@ const PieceView = ({ piece, ctx, hovered, setHovered, onActivate }: {
 };
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
-  const [hovered, setHovered] = useState<HoveredCut>(null);
+  const { value: hovered, set: setHovered, clear: clearHovered } = useHoverPreview<Move>(ctx.moveCount);
 
   const onBreak = (move: Move) => {
     if (!ctx.isClientMoveAllowed) return;
@@ -96,10 +92,10 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   // first tap highlights (showing the preview) and the second tap confirms.
   const onActivate = (move: Move) => {
     if (!ctx.isClientMoveAllowed) return;
-    const isSelected = hovered?.moveCount === ctx.moveCount
-      && hovered?.id === move.id && hovered?.dir === move.dir && hovered?.pos === move.pos;
+    const isSelected = hovered?.id === move.id
+      && hovered?.dir === move.dir && hovered?.pos === move.pos;
     if (isSelected) onBreak(move);
-    else setHovered({ ...move, moveCount: ctx.moveCount });
+    else setHovered(move);
   };
 
   return (
@@ -112,6 +108,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
             ctx={ctx}
             hovered={hovered}
             setHovered={setHovered}
+            clearHovered={clearHovered}
             onActivate={onActivate}
           />
         ))}

--- a/src/components/games/remove-row-or-column/board-client.tsx
+++ b/src/components/games/remove-row-or-column/board-client.tsx
@@ -1,7 +1,6 @@
-import { useState } from 'react';
 import { range } from 'lodash';
 import {
-  type BoardClientProps, type Events, type Ctx, GameBoard
+  type BoardClientProps, type Events, type Ctx, GameBoard, useHoverPreview
 } from '../../strategy-game-factory';
 import { useTranslation } from '../../../language';
 import {
@@ -15,18 +14,19 @@ export const BoardClient = ({ board, ctx, events, moves }: BoardClientProps<Boar
   const { t } = useTranslation();
   const { grid } = board;
   const selected = ctx.turnState as Selected;
-  const [hoverOrientation, setHoverOrientation] = useState<Orientation | null>(null);
+  const { value: hoverOrientation, hoverProps, clear: clearHover } = useHoverPreview<Orientation>(ctx.moveCount);
   const rect = selected ? getRectangleAt(grid, selected.r, selected.c) : null;
 
   const clickDisc = (r: number, c: number) => {
     if (!ctx.isClientMoveAllowed) return;
-    setHoverOrientation(null);
+    // Picking another disc keeps moveCount unchanged, so drop the hover
+    // preview explicitly — it belonged to the previous selection.
+    clearHover();
     events.setTurnState(selected && selected.r === r && selected.c === c ? null : { r, c });
   };
 
   const removeLine = (orientation: Orientation) => {
     if (!ctx.isClientMoveAllowed || !selected) return;
-    setHoverOrientation(null);
     moves.removeLine(board, { ...selected, orientation });
   };
 
@@ -98,10 +98,7 @@ export const BoardClient = ({ board, ctx, events, moves }: BoardClientProps<Boar
               key={orientation}
               className="primary-button w-auto grow"
               onClick={() => removeLine(orientation)}
-              onPointerEnter={() => setHoverOrientation(orientation)}
-              onPointerLeave={() => setHoverOrientation(null)}
-              onFocus={() => setHoverOrientation(orientation)}
-              onBlur={() => setHoverOrientation(null)}
+              {...hoverProps(orientation)}
             >
               {t(label)} ({count})
             </button>

--- a/src/components/strategy-game-factory/hooks/use-hover-preview.spec.ts
+++ b/src/components/strategy-game-factory/hooks/use-hover-preview.spec.ts
@@ -38,4 +38,22 @@ describe('useHoverPreview', () => {
     act(() => result.current.hoverProps('b').onPointerEnter());
     expect(result.current.value).toBe('b');
   });
+
+  it('exposes imperative set/clear with the same moveCount stamp', () => {
+    const { result, rerender } = renderHook(
+      ({ moveCount }) => useHoverPreview<string>(moveCount),
+      { initialProps: { moveCount: 1 } }
+    );
+
+    act(() => result.current.set('tap'));
+    expect(result.current.value).toBe('tap');
+
+    act(() => result.current.clear());
+    expect(result.current.value).toBeNull();
+
+    // an imperatively set value is also invalidated by the next move
+    act(() => result.current.set('tap'));
+    rerender({ moveCount: 2 });
+    expect(result.current.value).toBeNull();
+  });
 });

--- a/src/components/strategy-game-factory/hooks/use-hover-preview.ts
+++ b/src/components/strategy-game-factory/hooks/use-hover-preview.ts
@@ -17,23 +17,27 @@ import { useState } from 'react';
  * that shouldn't drive a preview (e.g. a currently disabled one). It is safe on
  * a container with focusable children too: React's onFocus/onBlur bubble, so a
  * child's focus previews the container — matching pointer hover.
+ *
+ * `set`/`clear` are the imperative escape hatch for flows `hoverProps` can't
+ * express — e.g. a touch two-tap flow where the first tap (onClick) sets the
+ * preview, or handlers that filter by `pointerType`. Values set this way get
+ * the same moveCount stamp, so they are invalidated by the next move too.
  */
 export function useHoverPreview<T>(moveCount: number) {
   const [hovered, setHovered] = useState<{ value: T; moveCount: number } | null>(null);
 
   const value = hovered?.moveCount === moveCount ? hovered.value : null;
 
-  const hoverProps = (v: T) => {
-    const set = () => setHovered({ value: v, moveCount });
-    const clear = () => setHovered(null);
-    return {
-      onPointerEnter: set,
-      onPointerMove: set,
-      onPointerLeave: clear,
-      onFocus: set,
-      onBlur: clear
-    };
-  };
+  const set = (v: T) => setHovered({ value: v, moveCount });
+  const clear = () => setHovered(null);
 
-  return { value, hoverProps };
+  const hoverProps = (v: T) => ({
+    onPointerEnter: () => set(v),
+    onPointerMove: () => set(v),
+    onPointerLeave: clear,
+    onFocus: () => set(v),
+    onBlur: clear
+  });
+
+  return { value, hoverProps, set, clear };
 }


### PR DESCRIPTION
Part of #315 (split 1 of 5 — all five are independent, based on `main`, and mergeable in any order).

Extends `useHoverPreview` to also return imperative `set`/`clear` primitives (stamped with the same `moveCount`, so imperatively set values are likewise invalidated by the next move), for flows `hoverProps` cannot express. New spec cases cover the primitives including move-invalidation.

Converts the two games that need them:

- **chocolate-breaking**: `set`/`clear` keep the touch two-tap confirm flow (first tap previews via `onClick`, second confirms) and the `pointerType === 'mouse'` filtering; the hand-rolled moveCount stamp on `HoveredCut` is gone.
- **remove-row-or-column**: the row/column buttons use plain `hoverProps`; one explicit `clear()` stays in `clickDisc` because re-selecting a disc does not bump `moveCount`.

**Testing**: `npm run test` green on this branch (lint + typecheck + 556 unit tests). Manual check: in both games the preview follows hover/focus, disappears after a move, and chocolate-breaking's two-tap flow on touch still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012rVnTq1zDHHi9Tmsmr691J

---
_Generated by [Claude Code](https://claude.ai/code/session_012rVnTq1zDHHi9Tmsmr691J)_