### PR TITLE
Refact: use useHoverPreview in 3 button-driven single-pile games

### DIFF
--- a/src/components/games/single-pile-removal/prime-exponentials/prime-exponentials.tsx
+++ b/src/components/games/single-pile-removal/prime-exponentials/prime-exponentials.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import {
-  strategyGameFactory, type Events, type StrategyArgs, type BoardClientProps, GameBoard
+  strategyGameFactory, type Events, type StrategyArgs, type BoardClientProps, GameBoard, useHoverPreview
 } from '../../../strategy-game-factory';
 import { sample, random } from 'lodash';
 import { useTranslation } from '../../../../language';
@@ -43,7 +43,7 @@ const generateStartBoard = () => {
 
 const generateSmallStartBoard = () => random(12, 72);
 
-const PrimePowerButton = ({ entry, board, isClientMoveAllowed, chooseEntry, setHovered }) => {
+const PrimePowerButton = ({ entry, board, isClientMoveAllowed, chooseEntry, hoverProps }) => {
   const { prime, exponent, value } = entry;
   const isAboveBoard = value > board;
   const isActive = !isAboveBoard && isClientMoveAllowed;
@@ -56,11 +56,7 @@ const PrimePowerButton = ({ entry, board, isClientMoveAllowed, chooseEntry, setH
         enabled:hocus:bg-blue-100 dark:enabled:hocus:bg-blue-900 enabled:hocus:border-blue-300
       `}
       onClick={() => isActive && chooseEntry(entry)}
-      onPointerEnter={() => isActive && setHovered(entry)}
-      onPointerMove={() => isActive && setHovered(entry)}
-      onPointerLeave={() => setHovered(null)}
-      onFocus={() => isActive && setHovered(entry)}
-      onBlur={() => setHovered(null)}
+      {...(isActive ? hoverProps(entry) : {})}
     >
       <span className="block text-xs text-slate-500" aria-hidden={exponent <= 1}>
         {exponent > 1 ? <>{prime}<sup>{exponent}</sup></> : <>&nbsp;</>}
@@ -70,7 +66,7 @@ const PrimePowerButton = ({ entry, board, isClientMoveAllowed, chooseEntry, setH
   );
 };
 
-const PrimePowerGrid = ({ board, visiblePowers, isClientMoveAllowed, chooseEntry, setHovered }) => {
+const PrimePowerGrid = ({ board, visiblePowers, isClientMoveAllowed, chooseEntry, hoverProps }) => {
   return (
     <div className="flex flex-wrap gap-1 items-end">
       {visiblePowers.map(entry => (
@@ -80,7 +76,7 @@ const PrimePowerGrid = ({ board, visiblePowers, isClientMoveAllowed, chooseEntry
           board={board}
           isClientMoveAllowed={isClientMoveAllowed}
           chooseEntry={chooseEntry}
-          setHovered={setHovered}
+          hoverProps={hoverProps}
         />
       ))}
     </div>
@@ -102,28 +98,23 @@ const HoverPreview = ({ hovered, board, isClientMoveAllowed }) => {
 };
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
-  const [hovered, setHovered] = useState<{ entry: typeof allPrimePowers[0]; moveCount: number } | null>(null);
-  const validHovered = hovered?.moveCount === ctx.moveCount ? hovered.entry : null;
+  const { value: hovered, hoverProps } = useHoverPreview<typeof allPrimePowers[0]>(ctx.moveCount);
   const [visiblePowers] = useState(() => allPrimePowers.filter(e => e.value <= board));
 
   const chooseEntry = ({ prime, exponent }) => {
     moves.subtractPrimeExponent(board, { prime, exponent });
   };
 
-  type PrimePower = typeof allPrimePowers[0];
-  const setHoveredEntry = (entry: PrimePower | null) =>
-    setHovered(entry ? { entry, moveCount: ctx.moveCount } : null);
-
   return (
     <GameBoard>
       <p className='w-full text-8xl font-bold text-center mb-4'>{board}</p>
-      <HoverPreview hovered={validHovered} board={board} isClientMoveAllowed={ctx.isClientMoveAllowed} />
+      <HoverPreview hovered={hovered} board={board} isClientMoveAllowed={ctx.isClientMoveAllowed} />
       <PrimePowerGrid
         board={board}
         visiblePowers={visiblePowers}
         isClientMoveAllowed={ctx.isClientMoveAllowed}
         chooseEntry={chooseEntry}
-        setHovered={setHoveredEntry}
+        hoverProps={hoverProps}
       />
     </GameBoard>
   );

--- a/src/components/games/single-pile-removal/take-1-or-halve/take-1-or-halve.tsx
+++ b/src/components/games/single-pile-removal/take-1-or-halve/take-1-or-halve.tsx
@@ -1,6 +1,5 @@
-import { useState } from 'react';
 import {
-  strategyGameFactory, type Events, type StrategyArgs, type BoardClientProps, GameBoard
+  strategyGameFactory, type Events, type StrategyArgs, type BoardClientProps, GameBoard, useHoverPreview
 } from '../../../strategy-game-factory';
 import { random, range } from 'lodash';
 import { useTranslation } from '../../../../language';
@@ -28,7 +27,9 @@ const CoinPile = ({ count, hoveredAction }: { count: number, hoveredAction: Hove
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
-  const [hoveredAction, setHoveredAction] = useState<HoveredAction>(null);
+  const { value: hoveredAction, hoverProps } = useHoverPreview<'take1' | 'halve'>(ctx.moveCount);
+  const canTake1 = ctx.isClientMoveAllowed;
+  const canHalve = ctx.isClientMoveAllowed && board % 2 === 0;
   return(
     <GameBoard>
       <h2 className="text-center">{board}</h2>
@@ -36,17 +37,15 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
       <div className="flex flex-wrap gap-2">
         <button
           className="primary-button w-auto grow"
-          disabled={!ctx.isClientMoveAllowed}
+          disabled={!canTake1}
           onClick={() => moves.take1(board)}
-          onMouseEnter={() => setHoveredAction('take1')}
-          onMouseLeave={() => setHoveredAction(null)}
+          {...(canTake1 ? hoverProps('take1') : {})}
         >{t({ hu: 'Elveszek egyet', en: 'Take one' })}</button>
         <button
           className="primary-button w-auto grow"
-          disabled={!ctx.isClientMoveAllowed || board % 2 === 1}
+          disabled={!canHalve}
           onClick={() => moves.halve(board)}
-          onMouseEnter={() => setHoveredAction('halve')}
-          onMouseLeave={() => setHoveredAction(null)}
+          {...(canHalve ? hoverProps('halve') : {})}
         >{t({ hu: 'Elveszem a felét', en: 'Take half' })}</button>
       </div>
     </GameBoard>

--- a/src/components/games/single-pile-removal/take-power-of-two/take-power-of-two.tsx
+++ b/src/components/games/single-pile-removal/take-power-of-two/take-power-of-two.tsx
@@ -1,6 +1,5 @@
-import { useState } from 'react';
 import {
-  strategyGameFactory, type Events, type StrategyArgs, type BoardClientProps, GameBoard
+  strategyGameFactory, type Events, type StrategyArgs, type BoardClientProps, GameBoard, useHoverPreview
 } from '../../../strategy-game-factory';
 import { range, random, reverse, sample } from 'lodash';
 import { useTranslation } from '../../../../language';
@@ -15,7 +14,7 @@ const generateStartBoard = () => {
 
 type Board = number
 
-const ExponentsTable = ({ disabled, board, choosePower, hovered, setHovered }) => {
+const ExponentsTable = ({ disabled, board, choosePower, hovered, hoverProps }) => {
   const { t } = useTranslation();
   const availableExponents = getAvailableExponents(board);
 
@@ -30,11 +29,7 @@ const ExponentsTable = ({ disabled, board, choosePower, hovered, setHovered }) =
           disabled={disabled}
           className="secondary-button w-auto min-w-12"
           onClick={() => choosePower(e)}
-          onPointerEnter={() => setHovered(e)}
-          onPointerMove={() => setHovered(e)}
-          onPointerLeave={() => setHovered(null)}
-          onFocus={() => setHovered(e)}
-          onBlur={() => setHovered(null)}
+          {...(disabled ? {} : hoverProps(e))}
         >{2 ** e}</button>
       )}
     </div>
@@ -49,13 +44,7 @@ const ExponentsTable = ({ disabled, board, choosePower, hovered, setHovered }) =
 
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
-  const [hoveredPower, setHoveredPower] = useState<{ value: number; moveCount: number } | null>(null);
-  const validHoveredPower = hoveredPower?.moveCount === ctx.moveCount ? hoveredPower.value : null;
-
-  const choosePower = (e: number) => {
-    moves.subtractPowerOfTwo(board, e);
-    setHoveredPower(null);
-  }
+  const { value: hoveredPower, hoverProps } = useHoverPreview<number>(ctx.moveCount);
 
   return (
     <GameBoard>
@@ -63,9 +52,9 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
       <ExponentsTable
         disabled={!ctx.isClientMoveAllowed}
         board={board}
-        choosePower={choosePower}
-        hovered={validHoveredPower}
-        setHovered={(e: number | null) => setHoveredPower(e !== null ? { value: e, moveCount: ctx.moveCount } : null)}
+        choosePower={(e: number) => moves.subtractPowerOfTwo(board, e)}
+        hovered={hoveredPower}
+        hoverProps={hoverProps}
       />
     </GameBoard>
   );


### PR DESCRIPTION
Part of #315 (split 2 of 5 — all five are independent, based on `main`, and mergeable in any order).

Straightforward `hoverProps` conversions, no hook changes needed:

- **take-power-of-two**, **prime-exponentials**: the parent `BoardClient` calls the hook and threads `hoverProps` down to the child table/grid, replacing the hand-rolled moveCount-stamped `useState` and the five inline handlers per button. Handlers are now attached only to enabled buttons, per the hook's convention.
- **take-1-or-halve**: fixes a real sticky-hover bug — the buttons used mouse-only handlers with no moveCount stamp, so on touch the coin-dimming preview stuck after a move. Also gains keyboard-focus previews.

**Testing**: `npm run test` green on this branch (lint + typecheck + 556 unit tests). Manual check: previews follow hover/focus and disappear after a move; on take-1-or-halve, tapping "Take one" on touch no longer leaves the top coin dimmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012rVnTq1zDHHi9Tmsmr691J

---
_Generated by [Claude Code](https://claude.ai/code/session_012rVnTq1zDHHi9Tmsmr691J)_