### PR TITLE
Refact: use useHoverPreview in matchstick-piles and matches-on-edges

### DIFF
--- a/src/components/games/matches-on-edges/board-client.tsx
+++ b/src/components/games/matches-on-edges/board-client.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { range } from 'lodash';
 import { useTranslation } from '../../../language';
-import { GameBoard, type BoardClientProps } from '../../strategy-game-factory';
+import { GameBoard, type BoardClientProps, useHoverPreview } from '../../strategy-game-factory';
 import { type Board, boundaryEdgesToPlace, currentWindowSize, legalMoves } from './helpers';
 
 const Matchstick = ({ ghost = false }: { ghost?: boolean }) => (
@@ -33,12 +33,12 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const validStarts = new Set(legalMoves(board).map(m => m.a));
 
   const [selectedStart, setSelectedStart] = useState<number | null>(null);
-  const [hoverStart, setHoverStart] = useState<number | null>(null);
+  const { value: hoverStart, hoverProps } = useHoverPreview<number>(ctx.moveCount);
 
-  // Drop the in-progress selection whenever the board advances (own or bot move).
+  // Drop the in-progress selection whenever the board advances (own or bot
+  // move). The hover preview needs no reset: its moveCount stamp expires.
   useEffect(() => {
     setSelectedStart(null);
-    setHoverStart(null);
   }, [ctx.moveCount]);
 
   const canInteract = ctx.isClientMoveAllowed;
@@ -76,10 +76,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
               key={`cell-${i}`}
               disabled={!selectable}
               onClick={() => selectStart(i)}
-              onMouseEnter={() => selectable && setHoverStart(i)}
-              onMouseLeave={() => setHoverStart(null)}
-              onFocus={() => selectable && setHoverStart(i)}
-              onBlur={() => setHoverStart(null)}
+              {...(selectable ? hoverProps(i) : {})}
               aria-pressed={selectedStart === i}
               aria-label={t({
                 hu: `${i + 1}. mező${selectable ? `, ${k} hosszú résztábla kezdete` : ''}`,

--- a/src/components/games/matchstick-piles/matchstick-piles.tsx
+++ b/src/components/games/matchstick-piles/matchstick-piles.tsx
@@ -1,18 +1,17 @@
-import { Fragment, useState } from 'react';
+import { Fragment } from 'react';
 import { range, sample, random } from 'lodash';
 import {
   strategyGameFactory,
   type Events, type StrategyArgs, type GameMoves, type BoardClientProps,
-  GameBoard
+  GameBoard, useHoverPreview
 } from '../../strategy-game-factory';
 
 // A board is the list of pile sizes; every pile has at least one match.
 export type Board = number[];
 
 type Hover =
-  | { pileId: number; kind: 'remove'; moveCount: number }
-  | { pileId: number; kind: 'split'; splitAfter: number; moveCount: number }
-  | null;
+  | { pileId: number; kind: 'remove' }
+  | { pileId: number; kind: 'split'; splitAfter: number };
 
 const Matchstick = ({ removed }: { removed: boolean }) => (
   <span className="relative block w-2 h-9">
@@ -28,9 +27,7 @@ const Matchstick = ({ removed }: { removed: boolean }) => (
 );
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
-  const [hover, setHover] = useState<Hover>(null);
-  const activeHover =
-    ctx.isClientMoveAllowed && hover?.moveCount === ctx.moveCount ? hover : null;
+  const { value: activeHover, hoverProps } = useHoverPreview<Hover>(ctx.moveCount);
 
   const clickRemove = (pileId: number) => {
     if (!ctx.isClientMoveAllowed) return;
@@ -41,12 +38,6 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     if (!ctx.isClientMoveAllowed) return;
     moves.splitPile(board, pileId, splitAfter + 1);
   };
-
-  const hoverSplit = (pileId: number, splitAfter: number) =>
-    setHover({ pileId, kind: 'split', splitAfter, moveCount: ctx.moveCount });
-  const hoverRemove = (pileId: number) =>
-    setHover({ pileId, kind: 'remove', moveCount: ctx.moveCount });
-  const clearHover = () => setHover(null);
 
   const pileDescription = (pileId: number, size: number) => {
     if (!activeHover || activeHover.pileId !== pileId) return `${size}`;
@@ -89,10 +80,9 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
                       disabled={!ctx.isClientMoveAllowed}
                       className="self-stretch w-4 flex items-center justify-center group"
                       onClick={() => clickSplit(pileId, matchId - 1)}
-                      onFocus={() => hoverSplit(pileId, matchId - 1)}
-                      onBlur={clearHover}
-                      onPointerEnter={() => hoverSplit(pileId, matchId - 1)}
-                      onPointerLeave={clearHover}
+                      {...(ctx.isClientMoveAllowed
+                        ? hoverProps({ pileId, kind: 'split', splitAfter: matchId - 1 })
+                        : {})}
                     >
                       <span className={`
                         w-0.5 h-9 rounded-full transition-colors
@@ -112,10 +102,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
                       enabled:focus:bg-slate-200 dark:enabled:focus:bg-slate-700
                     `}
                     onClick={() => clickRemove(pileId)}
-                    onFocus={() => hoverRemove(pileId)}
-                    onBlur={clearHover}
-                    onPointerEnter={() => hoverRemove(pileId)}
-                    onPointerLeave={clearHover}
+                    {...(ctx.isClientMoveAllowed ? hoverProps({ pileId, kind: 'remove' }) : {})}
                   >
                     <Matchstick removed={isMatchRemoved(pileId, matchId, size)} />
                   </button>


### PR DESCRIPTION
Part of #315 (split 3 of 5 — all five are independent, based on `main`, and mergeable in any order).

- **matchstick-piles**: turned out to need only `hoverProps` after all — the split/remove hover payloads become the hook values (`{ pileId, kind: 'split', splitAfter }` / `{ pileId, kind: 'remove' }`), and the `isClientMoveAllowed` fold moves into conditional attachment, matching the hook's "don't attach to disabled elements" convention.
- **matches-on-edges**: only the hover-preview half converts. The committed `selectedStart` selection keeps its `useEffect` reset (it's Pattern-2 selection state, not hover); the effect no longer needs to touch hover since the moveCount stamp expires on its own.

**Testing**: `npm run test` green on this branch (lint + typecheck + 556 unit tests). Manual check: matchstick split-line/remove previews and the matches-on-edges window preview follow hover/focus and clear after a move; the selected window in matches-on-edges still resets when the board advances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012rVnTq1zDHHi9Tmsmr691J

---
_Generated by [Claude Code](https://claude.ai/code/session_012rVnTq1zDHHi9Tmsmr691J)_