### PR TITLE
Refact: convert the 2 scalar-hover games to useHoverPreview via pile-id values

### DIFF
--- a/src/components/games/pile-union/pile-union.tsx
+++ b/src/components/games/pile-union/pile-union.tsx
@@ -1,6 +1,8 @@
-import { useState } from 'react';
+import { useState, type ComponentProps } from 'react';
 import { range, random } from 'lodash';
-import { strategyGameFactory, type Events, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import {
+  strategyGameFactory, type Events, type BoardClientProps, GameBoard, useHoverPreview
+} from '../../strategy-game-factory';
 import { useTranslation } from '../../../language';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 
@@ -10,6 +12,7 @@ type TurnState = { firstSelectedPile: number } | null
 
 const BoardClient = ({ board, ctx, events, moves }: BoardClientProps<Board>) => {
   const [moveType, setMoveType] = useState<MoveType>('remove');
+  const { value: hoveredPile, hoverProps } = useHoverPreview<number>(ctx.moveCount);
   const turnState = ctx.turnState as TurnState;
 
   const handlePileClick = (pileIndex) => {
@@ -49,7 +52,8 @@ const BoardClient = ({ board, ctx, events, moves }: BoardClientProps<Board>) => 
             isSelected={moveType === 'merge' && turnState?.firstSelectedPile === pileIndex}
             moveType={moveType}
             onClick={() => handlePileClick(pileIndex)}
-            moveCount={ctx.moveCount}
+            hovered={hoveredPile === pileIndex}
+            hoverProps={ctx.isClientMoveAllowed ? hoverProps(pileIndex) : {}}
           />
         ))}
       </div>
@@ -111,28 +115,23 @@ const MoveTypeSelector = ({ moveType, isClientMoveAllowed, canMerge, onSelect }:
   );
 };
 
-const Pile = ({ size, disabled, isSelected, moveType, onClick, moveCount }: {
+const Pile = ({ size, disabled, isSelected, moveType, onClick, hovered, hoverProps }: {
   size: number
   disabled: boolean
   isSelected: boolean
   moveType: MoveType
   onClick: () => void
-  moveCount: number
+  hovered: boolean
+  hoverProps: ComponentProps<'button'>
 }) => {
-  const [hovered, setHovered] = useState<number | null>(null);
-  const validHovered = hovered === moveCount;
-  const isRemoveHovered = moveType === 'remove' && validHovered;
-  const isMergeHovered = moveType === 'merge' && validHovered;
+  const isRemoveHovered = moveType === 'remove' && hovered;
+  const isMergeHovered = moveType === 'merge' && hovered;
 
   return (
     <button
       disabled={disabled}
       onClick={onClick}
-      onPointerEnter={() => setHovered(moveCount)}
-      onPointerMove={() => setHovered(moveCount)}
-      onPointerLeave={() => setHovered(null)}
-      onFocus={() => setHovered(moveCount)}
-      onBlur={() => setHovered(null)}
+      {...hoverProps}
       className={`
         flex flex-col items-center gap-1 p-2 rounded-lg border-2 transition-colors
         ${isSelected ? 'border-blue-300 bg-blue-600/40' :

--- a/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
+++ b/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
@@ -1,17 +1,14 @@
-import { useState } from 'react';
 import {
   strategyGameFactory,
   type Ctx, type Events, type StrategyArgs, type BoardClientProps,
-  GameBoard
+  GameBoard, useHoverPreview
 } from '../../strategy-game-factory';
 import { cloneDeep, isEqual, sample, random, range } from 'lodash';
 import { useTranslation } from '../../../language';
 
 type Board = { piles: [number, number], leftRestriction: [boolean, boolean] }
 
-const StonePile = ({ count, onClick, disabled, restricted, moveCount }) => {
-  const [hovered, setHovered] = useState<number | null>(null);
-  const validHovered = hovered === moveCount;
+const StonePile = ({ count, onClick, disabled, restricted, hovered, hoverProps }) => {
   return (
     <button
       className={`w-full flex-1 flex flex-wrap content-start justify-center gap-2 p-2
@@ -19,17 +16,13 @@ const StonePile = ({ count, onClick, disabled, restricted, moveCount }) => {
       style={{ transform: 'scaleY(-1)' }}
       onClick={onClick}
       disabled={disabled}
-      onPointerEnter={() => setHovered(moveCount)}
-      onPointerMove={() => setHovered(moveCount)}
-      onPointerLeave={() => setHovered(null)}
-      onFocus={() => setHovered(moveCount)}
-      onBlur={() => setHovered(null)}
+      {...hoverProps}
     >
       {range(count).map(i => (
         <div
           key={i}
           className={`w-[20%] aspect-square rounded-full bg-stone-500 shadow-md shadow-stone-700
-            transition-opacity ${validHovered && !disabled && i === count - 1 ? 'opacity-30' : ''}`}
+            transition-opacity ${hovered && i === count - 1 ? 'opacity-30' : ''}`}
           style={{ transform: 'scaleY(-1)' }}
         />
       ))}
@@ -39,6 +32,7 @@ const StonePile = ({ count, onClick, disabled, restricted, moveCount }) => {
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
+  const { value: hoveredPile, hoverProps } = useHoverPreview<number>(ctx.moveCount);
 
   const isMoveAllowed = pileId => {
     if (!ctx.isClientMoveAllowed) return false;
@@ -61,7 +55,8 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
               onClick={() => moves.removeStone(board, pileId)}
               disabled={!isMoveAllowed(pileId)}
               restricted={ctx.isClientMoveAllowed && !isMoveAllowed(pileId)}
-              moveCount={ctx.moveCount}
+              hovered={hoveredPile === pileId}
+              hoverProps={isMoveAllowed(pileId) ? hoverProps(pileId) : {}}
             />
           </div>
         ))}


### PR DESCRIPTION
Part of #315 (split 4 of 5 — all five are independent, based on `main`, and mergeable in any order).

**stones-remove-one-not-twice-from-left** and **pile-union** stored their hover as a per-pile scalar (`hovered === moveCount`) — effectively a boolean flag, which the issue noted would only fit the hook as an odd `useHoverPreview<true>`. Instead of forcing that, the state is reworked to carry a meaningful value: the hovered pile id, lifted to the parent as `useHoverPreview<number>`. Each `StonePile`/`Pile` child now receives a plain `hovered` boolean plus a spreadable `hoverProps` object, and loses its own `useState` and `moveCount` prop entirely.

Behavior is unchanged, with one deliberate tightening: hover handlers are only attached to piles that are currently clickable (previously they were attached even to disabled piles).

**Testing**: `npm run test` green on this branch (lint + typecheck + 556 unit tests). Manual check: top-stone dimming (stones game) and remove/merge highlights (pile-union) follow hover/focus, respect the left-pile restriction and merge selection, and clear after a move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012rVnTq1zDHHi9Tmsmr691J

---
_Generated by [Claude Code](https://claude.ai/code/session_012rVnTq1zDHHi9Tmsmr691J)_