### PR TITLE
Add optional per-move validate legality layer to strategyGameFactory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,8 @@ simplicity trade-off — don't "fix" them piecemeal.
 - Starting positions representative of the game's complexity; each player wins
   with ~50% probability across random starting boards
 - Player cannot win with a non-winning strategy (i.e. AI is truly optimal)
+- Moves with non-trivial legality define `validate` (single source of truth for
+  the engine, the `BoardClient`'s `disabled` state and the bot)
 - Clear what the player should do next (`getPlayerStepDescription`)
 - Interactions disabled during the other player's turn (`ctx.isClientMoveAllowed`)
 - Mobile-friendly and keyboard-navigable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,8 +80,7 @@ strategyGameFactory({
   },
   BoardClient,                 // React component receiving { board, ctx, events, moves }
   gameplay: {
-    moves,                     // object of move functions: (board, { ctx, events }, ...args) => { nextBoard }
-    moveValidators?,           // optional: { [moveName]: (board, { ctx }, ...args) => boolean } — see below
+    moves,                     // { [name]: apply | { apply, validate? } } — see below
     endOfTurnMove?,            // optional move name auto-executed after moves with autoEndOfTurn: true
   },
   variants,                    // see below
@@ -95,25 +94,29 @@ omitted on a variant, the default variant's `botStrategy` is used as fallback.
 If multiple variants are provided, exactly one must be `isDefault: true`. A
 single-entry array needs no `isDefault` flag.
 
-**`moves`** — each move is `(board, { ctx, events }, ...args) => { nextBoard }`.
-Always pass the current `board` as first arg when chaining moves within a turn.
-Moves trust their arguments and apply them blindly; legality is enforced by
-`moveValidators` (below) and/or the `BoardClient`'s `disabled` gating.
+**`moves`** — each move is either a plain apply function
+`(board, { ctx, events }, ...args) => { nextBoard }` (shorthand), or a long-form
+object `{ apply, validate? }` colocating it with a legality predicate. Always
+pass the current `board` as first arg when chaining moves within a turn. `apply`
+trusts its arguments and applies them blindly; legality is enforced by
+`validate` (below) and/or the `BoardClient`'s `disabled` gating.
 
-**`moveValidators`** (optional) — a map keyed by move name of pure, side-effect-free
-legality predicates `(board, { ctx }, ...args) => boolean`. When present for a
-move, the engine rejects any dispatch whose args fail the predicate (in dev it
-throws loudly to surface the bug; in prod it warns, fires an `illegal-move`
-analytics event, and no-ops so a stray call cannot corrupt the board). A missing
-key means "always legal", so this is fully opt-in and games that predate it keep
-working unchanged. Prefer defining the validator once and reusing it as the
-**single source of truth**: the same function should drive the `BoardClient`'s
-button `disabled` state (combined with `ctx.isClientMoveAllowed` for turn
-ownership), the bot's legal-move enumeration, and — being React-free — a possible
-future server-side authoritative check. Do **not** put the "whose turn is it"
-check (`ctx.isClientMoveAllowed`) inside a validator; that is the engine's
-concern, not per-move legality. See `coins-in-3-piles` (two-phase turn) and
-`cube-coloring` (reuses the existing `isAllowedStep` helper) for examples.
+**`validate`** (optional, per move) — a pure, side-effect-free legality predicate
+`(board, { ctx }, ...args) => boolean` sitting right next to its `apply`. When
+present, the engine rejects any dispatch whose args fail it (in dev it throws
+loudly to surface the bug; in prod it warns, fires an `illegal-move` analytics
+event, and no-ops so a stray call cannot corrupt the board). The function
+shorthand means "always legal", so this is fully opt-in and games that predate
+it keep working unchanged. The validator is the **single source of truth** for
+legality: the engine also exposes it on the wrapped move with `ctx` already
+bound, so the `BoardClient` drives button `disabled` state via
+`moves.<name>.validate(board, ...args)` (combined with `ctx.isClientMoveAllowed`
+for turn ownership); bots and — being React-free — a possible future
+server-side authoritative check can reuse the same predicate. Do **not** put the
+"whose turn is it" check (`ctx.isClientMoveAllowed`) inside `validate`; that is
+the engine's concern, not per-move legality. See `coins-in-3-piles` (two-phase
+turn) and `cube-coloring` (reuses the existing `isAllowedStep` helper) for
+examples.
 
 **`ctx`** fields available in moves and `BoardClient`:
 - `currentPlayer`: 0/1 — use this for game logic in both modes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ strategyGameFactory({
   BoardClient,                 // React component receiving { board, ctx, events, moves }
   gameplay: {
     moves,                     // object of move functions: (board, { ctx, events }, ...args) => { nextBoard }
+    moveValidators?,           // optional: { [moveName]: (board, { ctx }, ...args) => boolean } — see below
     endOfTurnMove?,            // optional move name auto-executed after moves with autoEndOfTurn: true
   },
   variants,                    // see below
@@ -96,6 +97,23 @@ single-entry array needs no `isDefault` flag.
 
 **`moves`** — each move is `(board, { ctx, events }, ...args) => { nextBoard }`.
 Always pass the current `board` as first arg when chaining moves within a turn.
+Moves trust their arguments and apply them blindly; legality is enforced by
+`moveValidators` (below) and/or the `BoardClient`'s `disabled` gating.
+
+**`moveValidators`** (optional) — a map keyed by move name of pure, side-effect-free
+legality predicates `(board, { ctx }, ...args) => boolean`. When present for a
+move, the engine rejects any dispatch whose args fail the predicate (in dev it
+throws loudly to surface the bug; in prod it warns, fires an `illegal-move`
+analytics event, and no-ops so a stray call cannot corrupt the board). A missing
+key means "always legal", so this is fully opt-in and games that predate it keep
+working unchanged. Prefer defining the validator once and reusing it as the
+**single source of truth**: the same function should drive the `BoardClient`'s
+button `disabled` state (combined with `ctx.isClientMoveAllowed` for turn
+ownership), the bot's legal-move enumeration, and — being React-free — a possible
+future server-side authoritative check. Do **not** put the "whose turn is it"
+check (`ctx.isClientMoveAllowed`) inside a validator; that is the engine's
+concern, not per-move legality. See `coins-in-3-piles` (two-phase turn) and
+`cube-coloring` (reuses the existing `isAllowedStep` helper) for examples.
 
 **`ctx`** fields available in moves and `BoardClient`:
 - `currentPlayer`: 0/1 — use this for game logic in both modes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,10 @@ it keep working unchanged. The validator is the **single source of truth** for
 legality: it drives the engine's enforcement, and — being React-free — a
 possible future server-side authoritative check can reuse the same predicate.
 Do **not** put the "whose turn is it" check (`ctx.isClientMoveAllowed`) inside
-`validate`; the engine folds that in for the UI (below). See `coins-in-3-piles`
+`validate`; the engine folds that in for the UI (below). Note the engine
+therefore enforces argument legality only — it cannot tell a bot dispatch from
+a client one, so out-of-turn protection stays with the `BoardClient`'s
+`isAllowed`/`disabled` gating. See `coins-in-3-piles`
 (two-phase turn) and `cube-coloring` (reuses the existing `isAllowedStep`
 helper) for examples.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,38 @@ bots enumerate legal moves via the raw `validate`/helpers instead.
 
 **`events`**: `endTurn()`, `endGame(winnerIndex?)`, `setTurnState(stage)`.
 
+### Known limitation: React state staleness in multi-move turns
+
+The engine keeps authoritative game state (`board`, `turnState`,
+`currentPlayer`) in React render state, but bots and chained dispatches run in
+`setTimeout` closures that captured a snapshot from an earlier render. Anything
+they need that is newer than their snapshot must reach them some other way.
+Two workarounds exist for two symptoms of this one root cause:
+
+- **`board`** — threaded explicitly by convention: every move returns
+  `nextBoard`, and a multi-move bot must pass the intermediate `nextBoard` to
+  its next calculation/dispatch instead of its (stale) `board` argument. Fails
+  loudly when violated (visibly wrong moves).
+- **`ctx.turnState`** — shadowed engine-side: move validation reads `ctx`
+  through a ref that is re-synced every render *and* patched synchronously by
+  `events.setTurnState`, because a chained dispatch (e.g. a bot's 0-delay
+  `setTimeout`) can fire before React re-renders. See `ctxRef` in
+  `strategy-game-factory.tsx` and the two-phase bot regression tests.
+
+The asymmetry matters when reviewing new games: a validator that depends on
+some *other* mid-turn-changing `ctx` field (e.g. `moveCount`) would need the
+same ref treatment — there is no general mechanism, only per-field shadows.
+
+There is no fully robust fix within the current shape. The known-robust
+architecture is a boardgame.io-style imperative game-state store outside React
+(React subscribing via `useSyncExternalStore`): moves would read/write current
+state synchronously, `board` threading and the ctx ref would both become
+unnecessary by construction. That refactor converges with the possible future
+server-side authoritative check (a server needs the React-free state machine
+anyway), so if that check is ever built, do both together rather than bolting
+on more per-field shadows. Until then, the current conventions are a deliberate
+simplicity trade-off — don't "fix" them piecemeal.
+
 ### New game checklist
 
 - Game works correctly in both `vsComputer` and `vsHuman` mode

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,15 +108,19 @@ loudly to surface the bug; in prod it warns, fires an `illegal-move` analytics
 event, and no-ops so a stray call cannot corrupt the board). The function
 shorthand means "always legal", so this is fully opt-in and games that predate
 it keep working unchanged. The validator is the **single source of truth** for
-legality: the engine also exposes it on the wrapped move with `ctx` already
-bound, so the `BoardClient` drives button `disabled` state via
-`moves.<name>.validate(board, ...args)` (combined with `ctx.isClientMoveAllowed`
-for turn ownership); bots and — being React-free — a possible future
-server-side authoritative check can reuse the same predicate. Do **not** put the
-"whose turn is it" check (`ctx.isClientMoveAllowed`) inside `validate`; that is
-the engine's concern, not per-move legality. See `coins-in-3-piles` (two-phase
-turn) and `cube-coloring` (reuses the existing `isAllowedStep` helper) for
-examples.
+legality: it drives the engine's enforcement, and — being React-free — a
+possible future server-side authoritative check can reuse the same predicate.
+Do **not** put the "whose turn is it" check (`ctx.isClientMoveAllowed`) inside
+`validate`; the engine folds that in for the UI (below). See `coins-in-3-piles`
+(two-phase turn) and `cube-coloring` (reuses the existing `isAllowedStep`
+helper) for examples.
+
+**`moves.<name>.isAllowed(board, ...args)`** — for moves with a `validate`, the
+engine exposes this on the wrapped move: `ctx.isClientMoveAllowed` (turn
+ownership) AND `validate`, with `ctx` already bound. This is exactly what a
+`BoardClient`'s button `disabled` state should ask, with no gating boilerplate.
+Not for bots: during the bot's turn `isClientMoveAllowed` is false by design, so
+bots enumerate legal moves via the raw `validate`/helpers instead.
 
 **`ctx`** fields available in moves and `BoardClient`:
 - `currentPlayer`: 0/1 — use this for game logic in both modes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,12 @@ anyway), so if that check is ever built, do both together rather than bolting
 on more per-field shadows. Until then, the current conventions are a deliberate
 simplicity trade-off — don't "fix" them piecemeal.
 
+Note "boardgame.io-style" means the architecture only. **Do not propose
+adopting boardgame.io itself**: it is a good library but effectively
+unmaintained (no meaningful releases for years, and its React client pins
+React versions well behind the one used here). Borrow its ideas — the
+long-form move shape already does — and build the rest in-repo.
+
 ### New game checklist
 
 - Game works correctly in both `vsComputer` and `vsHuman` mode

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,19 +111,26 @@ it keep working unchanged. The validator is the **single source of truth** for
 legality: it drives the engine's enforcement, and — being React-free — a
 possible future server-side authoritative check can reuse the same predicate.
 Do **not** put the "whose turn is it" check (`ctx.isClientMoveAllowed`) inside
-`validate`; the engine folds that in for the UI (below). Note the engine
-therefore enforces argument legality only — it cannot tell a bot dispatch from
-a client one, so out-of-turn protection stays with the `BoardClient`'s
-`isAllowed`/`disabled` gating. See `coins-in-3-piles`
+`validate`; the engine folds that in for the client (below). The engine hands
+out two wrappings of the same moves: the `moves` object the `BoardClient`
+receives **silently ignores** any dispatch that fails `isAllowed` (so a stray
+click — even on a button a browser failed to disable — is a harmless no-op),
+while bot and auto `endOfTurnMove` dispatches are checked against `validate`
+alone and fail loudly (dev: throw; prod: warn + `illegal-move` analytics event
++ no-op), since there an illegal move is a bug. See `coins-in-3-piles`
 (two-phase turn) and `cube-coloring` (reuses the existing `isAllowedStep`
 helper) for examples.
 
-**`moves.<name>.isAllowed(board, ...args)`** — for moves with a `validate`, the
-engine exposes this on the wrapped move: `ctx.isClientMoveAllowed` (turn
-ownership) AND `validate`, with `ctx` already bound. This is exactly what a
-`BoardClient`'s button `disabled` state should ask, with no gating boilerplate.
-Not for bots: during the bot's turn `isClientMoveAllowed` is false by design, so
-bots enumerate legal moves via the raw `validate`/helpers instead.
+**`moves.<name>.isAllowed(board, ...args)`** — exposed on every move of the
+`BoardClient`'s wrapped `moves` object: `ctx.isClientMoveAllowed` (turn
+ownership) AND the move's `validate` (when defined), with `ctx` already bound.
+Drive button `disabled` state with it. Because the engine applies the same
+check to every client dispatch, click handlers need no `if (!allowed) return`
+guards — keep one only when the handler couples local UI state to a successful
+move (see `cube-coloring`'s colour-selection reset). Not for bots: their
+`moves` copy carries no `isAllowed` (during the bot's turn
+`isClientMoveAllowed` is false by design), so bots enumerate legal moves via
+the raw `validate`/helpers instead.
 
 **`ctx`** fields available in moves and `BoardClient`:
 - `currentPlayer`: 0/1 — use this for game logic in both modes

--- a/README.md
+++ b/README.md
@@ -158,14 +158,11 @@ const moves = {
 };
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
-  const clickNumber = (number) => {
-    if (!ctx.isClientMoveAllowed) return;
-    moves.addNumber(board, number);
-  };
-
+  // no handler guard needed: the framework ignores dispatches that are not
+  // allowed; `disabled` is for the player's benefit
   return <GameBoard>
-    <button onClick={() => clickNumber(1)}>1</button>
-    <button onClick={() => clickNumber(2)}>2</button>
+    <button disabled={!ctx.isClientMoveAllowed} onClick={() => moves.addNumber(board, 1)}>1</button>
+    <button disabled={!ctx.isClientMoveAllowed} onClick={() => moves.addNumber(board, 2)}>2</button>
   </GameBoard>
 };
 
@@ -249,14 +246,15 @@ bound) for the `BoardClient`'s `disabled` state. Full contract in
 <details>
 <summary>Details</summary>
 
-- Enforcement: in development an illegal dispatch throws; in production it
-  warns, records an `illegal-move` analytics event, and no-ops so a stray or
-  tampered call cannot corrupt the board.
-- A shorthand move (plain function) is always accepted — fully opt-in.
+- Enforcement: the `moves` object the `BoardClient` receives silently ignores
+  any dispatch that fails `isAllowed` — click handlers need no
+  `if (!allowed) return` guards (keep one only when the handler couples local
+  UI state to a successful move, see `cube-coloring`). Bot and auto
+  end-of-turn dispatches failing `validate` throw in development, and warn +
+  record an `illegal-move` analytics event + no-op in production.
+- A shorthand move (plain function) has no argument validation — fully opt-in.
 - Keep the "whose turn is it" check out of `validate` — `isAllowed` folds
-  `ctx.isClientMoveAllowed` in for you. The engine consequently enforces
-  argument legality only (it cannot tell a bot dispatch from a client one);
-  out-of-turn protection stays with the `BoardClient`'s `disabled` gating.
+  `ctx.isClientMoveAllowed` in for you.
 - `isAllowed` is not for bots: during the bot's turn `isClientMoveAllowed` is
   false by design, so bots enumerate legal moves via the raw `validate`/helpers.
 - `validate` is React-free, so a future authoritative/competition server could

--- a/README.md
+++ b/README.md
@@ -235,27 +235,30 @@ lives in `validate`, right next to it.
 
 ### validate (optional, per move)
 
-`validate` is a pure, side-effect-free predicate
-`(board, { ctx }, ...args) => boolean`. When a move has one, the framework
-checks it before applying the move: in development it throws (surfacing bot/UI
-bugs loudly), and in production it warns, records an `illegal-move` analytics
-event, and no-ops (so a stray or tampered call cannot corrupt the board). A
-shorthand move (plain function) is always accepted, so this is fully opt-in.
+`validate` is a pure predicate `(board, { ctx }, ...args) => boolean` colocated
+with `apply` — the single source of truth for move legality. The framework
+rejects dispatches that fail it, and exposes it on the wrapped move as
+`moves.<name>.isAllowed(board, ...args)` (turn ownership AND `validate`, `ctx`
+bound) for the `BoardClient`'s `disabled` state. Full contract in
+[AGENTS.md](AGENTS.md#strategygamefactory-api).
 
-The validator is the **single source of truth** for legality: it drives the
-framework's enforcement, and because it is React-free the exact same function
-could run server-side in a future authoritative/competition mode. Keep the
-"whose turn is it" check out of the validator — that belongs to the framework,
-not to per-move legality.
+<details>
+<summary>Details</summary>
 
-For the UI, the framework exposes `moves.<name>.isAllowed(board, ...args)` on
-the wrapped move: `ctx.isClientMoveAllowed` (turn ownership) AND `validate`,
-with `ctx` already bound. A `BoardClient` computes button `disabled` state
-directly from it, with no gating boilerplate. It is not meant for bots — during
-the bot's turn `isClientMoveAllowed` is false by design, so bots enumerate legal
-moves via the raw `validate`/helpers. See `coins-in-3-piles` (two-phase turn)
-and `cube-coloring` (reuses its existing `isAllowedStep` helper) for worked
-examples.
+- Enforcement: in development an illegal dispatch throws; in production it
+  warns, records an `illegal-move` analytics event, and no-ops so a stray or
+  tampered call cannot corrupt the board.
+- A shorthand move (plain function) is always accepted — fully opt-in.
+- Keep the "whose turn is it" check out of `validate` — `isAllowed` folds
+  `ctx.isClientMoveAllowed` in for you.
+- `isAllowed` is not for bots: during the bot's turn `isClientMoveAllowed` is
+  false by design, so bots enumerate legal moves via the raw `validate`/helpers.
+- `validate` is React-free, so a future authoritative/competition server could
+  run the exact same predicate.
+- Worked examples: `coins-in-3-piles` (two-phase turn), `cube-coloring` (reuses
+  its `isAllowedStep` helper).
+
+</details>
 
 ### BoardClient React component
 

--- a/README.md
+++ b/README.md
@@ -242,15 +242,19 @@ bugs loudly), and in production it warns, records an `illegal-move` analytics
 event, and no-ops (so a stray or tampered call cannot corrupt the board). A
 shorthand move (plain function) is always accepted, so this is fully opt-in.
 
-The validator is the **single source of truth** for legality. The framework also
-exposes it on the wrapped move with `ctx` already bound, so the `BoardClient`
-computes button `disabled` state as `moves.<name>.validate(board, ...args)`
-(AND-ed with `ctx.isClientMoveAllowed` for turn ownership); the bot can use it
-to enumerate legal moves, and because it is React-free the exact same function
+The validator is the **single source of truth** for legality: it drives the
+framework's enforcement, and because it is React-free the exact same function
 could run server-side in a future authoritative/competition mode. Keep the
 "whose turn is it" check out of the validator — that belongs to the framework,
-not to per-move legality. See `coins-in-3-piles` (two-phase turn) and
-`cube-coloring` (reuses its existing `isAllowedStep` helper) for worked
+not to per-move legality.
+
+For the UI, the framework exposes `moves.<name>.isAllowed(board, ...args)` on
+the wrapped move: `ctx.isClientMoveAllowed` (turn ownership) AND `validate`,
+with `ctx` already bound. A `BoardClient` computes button `disabled` state
+directly from it, with no gating boilerplate. It is not meant for bots — during
+the bot's turn `isClientMoveAllowed` is false by design, so bots enumerate legal
+moves via the raw `validate`/helpers. See `coins-in-3-piles` (two-phase turn)
+and `cube-coloring` (reuses its existing `isAllowedStep` helper) for worked
 examples.
 
 ### BoardClient React component

--- a/README.md
+++ b/README.md
@@ -218,6 +218,29 @@ You must always pass `board` as a first param to all moves (meaning you must
 pass the updated board to subsequent moves in case of multiple moves within a
 turn).
 
+Moves themselves do **not** validate their arguments — they apply them blindly.
+Legality is enforced separately (see below), so a move called with out-of-contract
+arguments would otherwise silently corrupt the board.
+
+### move validators (optional)
+
+`gameplay.moveValidators` is an optional map keyed by move name of pure,
+side-effect-free predicates `(board, { ctx }, ...args) => boolean`. When a move
+has a validator, the framework checks it before applying the move: in development
+it throws (surfacing bot/UI bugs loudly), and in production it warns, records an
+`illegal-move` analytics event, and no-ops (so a stray or tampered call cannot
+corrupt the board). A move with no validator is always accepted, so this is fully
+opt-in.
+
+Define the validator once and treat it as the **single source of truth** for
+legality: the `BoardClient` uses it to compute button `disabled` state (AND-ed
+with `ctx.isClientMoveAllowed` for turn ownership), the bot uses it to enumerate
+legal moves, and because it is React-free the exact same function could run
+server-side in a future authoritative/competition mode. Keep the "whose turn is
+it" check out of the validator — that belongs to the framework, not to per-move
+legality. See `coins-in-3-piles` (two-phase turn) and `cube-coloring` (reuses its
+existing `isAllowedStep` helper) for worked examples.
+
 ### BoardClient React component
 
 `BoardClient`: a React component which renders the board and calls appropriate

--- a/README.md
+++ b/README.md
@@ -205,11 +205,11 @@ Conceptually a `move` is a unit that captures a change in the board initiated by
 a player. Moves help ensure that the game is played according to rules by all
 players.
 
-Technically a move is a function whose first param is board, second param is `{
-ctx, events }` and may receive any number of additional params. The second param
-is provided by the framework, additional params will be provided by the client
-based on player interaction or by the bot strategy. Each move must return an
-object with `nextBoard`.
+Technically the apply function of a move takes board as first param, `{
+ctx, events }` as second param and may receive any number of additional params.
+The second param is provided by the framework, additional params will be
+provided by the client based on player interaction or by the bot strategy. Each
+move must return an object with `nextBoard`.
 
 A move may result in ending the turn of the current player or ending the game or
 allow further moves within the same turn.
@@ -218,28 +218,40 @@ You must always pass `board` as a first param to all moves (meaning you must
 pass the updated board to subsequent moves in case of multiple moves within a
 turn).
 
-Moves themselves do **not** validate their arguments — they apply them blindly.
-Legality is enforced separately (see below), so a move called with out-of-contract
-arguments would otherwise silently corrupt the board.
+In `gameplay.moves`, each entry is either the apply function itself (shorthand)
+or a long-form object `{ apply, validate? }`:
 
-### move validators (optional)
+```ts
+moves: {
+  removeCoin: {
+    validate: (board, { ctx }, value) => board[value - 1] > 0,
+    apply: (board, { events }, value) => { /* ... */ return { nextBoard }; }
+  }
+}
+```
 
-`gameplay.moveValidators` is an optional map keyed by move name of pure,
-side-effect-free predicates `(board, { ctx }, ...args) => boolean`. When a move
-has a validator, the framework checks it before applying the move: in development
-it throws (surfacing bot/UI bugs loudly), and in production it warns, records an
-`illegal-move` analytics event, and no-ops (so a stray or tampered call cannot
-corrupt the board). A move with no validator is always accepted, so this is fully
-opt-in.
+`apply` does **not** validate its arguments — it applies them blindly; legality
+lives in `validate`, right next to it.
 
-Define the validator once and treat it as the **single source of truth** for
-legality: the `BoardClient` uses it to compute button `disabled` state (AND-ed
-with `ctx.isClientMoveAllowed` for turn ownership), the bot uses it to enumerate
-legal moves, and because it is React-free the exact same function could run
-server-side in a future authoritative/competition mode. Keep the "whose turn is
-it" check out of the validator — that belongs to the framework, not to per-move
-legality. See `coins-in-3-piles` (two-phase turn) and `cube-coloring` (reuses its
-existing `isAllowedStep` helper) for worked examples.
+### validate (optional, per move)
+
+`validate` is a pure, side-effect-free predicate
+`(board, { ctx }, ...args) => boolean`. When a move has one, the framework
+checks it before applying the move: in development it throws (surfacing bot/UI
+bugs loudly), and in production it warns, records an `illegal-move` analytics
+event, and no-ops (so a stray or tampered call cannot corrupt the board). A
+shorthand move (plain function) is always accepted, so this is fully opt-in.
+
+The validator is the **single source of truth** for legality. The framework also
+exposes it on the wrapped move with `ctx` already bound, so the `BoardClient`
+computes button `disabled` state as `moves.<name>.validate(board, ...args)`
+(AND-ed with `ctx.isClientMoveAllowed` for turn ownership); the bot can use it
+to enumerate legal moves, and because it is React-free the exact same function
+could run server-side in a future authoritative/competition mode. Keep the
+"whose turn is it" check out of the validator — that belongs to the framework,
+not to per-move legality. See `coins-in-3-piles` (two-phase turn) and
+`cube-coloring` (reuses its existing `isAllowedStep` helper) for worked
+examples.
 
 ### BoardClient React component
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,11 @@ allow further moves within the same turn.
 
 You must always pass `board` as a first param to all moves (meaning you must
 pass the updated board to subsequent moves in case of multiple moves within a
-turn).
+turn). This threading is not incidental: the framework holds game state in
+React render state, which a bot's `setTimeout` closures see only as a stale
+snapshot — see [AGENTS.md § Known limitation: React state staleness in
+multi-move turns](AGENTS.md#known-limitation-react-state-staleness-in-multi-move-turns)
+for the root cause and how `ctx.turnState` is handled.
 
 In `gameplay.moves`, each entry is either the apply function itself (shorthand)
 or a long-form object `{ apply, validate? }`:

--- a/README.md
+++ b/README.md
@@ -250,7 +250,9 @@ bound) for the `BoardClient`'s `disabled` state. Full contract in
   tampered call cannot corrupt the board.
 - A shorthand move (plain function) is always accepted — fully opt-in.
 - Keep the "whose turn is it" check out of `validate` — `isAllowed` folds
-  `ctx.isClientMoveAllowed` in for you.
+  `ctx.isClientMoveAllowed` in for you. The engine consequently enforces
+  argument legality only (it cannot tell a bot dispatch from a client one);
+  out-of-turn protection stays with the `BoardClient`'s `disabled` gating.
 - `isAllowed` is not for bots: during the bot's turn `isClientMoveAllowed` is
   false by design, so bots enumerate legal moves via the raw `validate`/helpers.
 - `validate` is React-free, so a future authoritative/competition server could

--- a/src/components/games/coins-in-3-piles/board-client.tsx
+++ b/src/components/games/coins-in-3-piles/board-client.tsx
@@ -21,9 +21,6 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 
   const wasCoinAlreadyRemovedInTurn = valueOfRemovedCoin !== null;
 
-  // `isAllowed` is the engine-bound combination of turn ownership
-  // (ctx.isClientMoveAllowed) and the move's own `validate` — the single
-  // source of truth shared with the engine's illegal-move enforcement.
   const isRemovalAllowed = coinValue => moves.removeCoin.isAllowed!(board, coinValue);
   const isAddAllowed = coinValue => moves.addCoin.isAllowed!(board, coinValue);
 

--- a/src/components/games/coins-in-3-piles/board-client.tsx
+++ b/src/components/games/coins-in-3-piles/board-client.tsx
@@ -25,20 +25,9 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const isAddAllowed = coinValue => moves.addCoin.isAllowed!(board, coinValue);
   const isPassAllowed = () => moves.passAddition.isAllowed!(board);
 
-  const removeFromPile = coinValue => {
-    if (!isRemovalAllowed(coinValue)) return;
-    moves.removeCoin(board, coinValue);
-  };
-
-  const addToPile = coinValue => {
-    if (!isAddAllowed(coinValue)) return;
-    moves.addCoin(board, coinValue);
-  };
-
-  const passAddition = () => {
-    if (!isPassAllowed()) return;
-    moves.passAddition(board);
-  };
+  const removeFromPile = coinValue => moves.removeCoin(board, coinValue);
+  const addToPile = coinValue => moves.addCoin(board, coinValue);
+  const passAddition = () => moves.passAddition(board);
 
   const shouldShowCoinToBeRemoved = (coinValue) => {
     if (!ctx.isClientMoveAllowed) return false;

--- a/src/components/games/coins-in-3-piles/board-client.tsx
+++ b/src/components/games/coins-in-3-piles/board-client.tsx
@@ -21,14 +21,11 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 
   const wasCoinAlreadyRemovedInTurn = valueOfRemovedCoin !== null;
 
-  // Legality comes from the move's own validator (single source of truth with
-  // the engine, exposed here with ctx already bound); the board-client only
-  // adds the "is it my turn" gate on top.
-  const isRemovalAllowed = coinValue =>
-    ctx.isClientMoveAllowed && moves.removeCoin.validate!(board, coinValue);
-
-  const isAddAllowed = coinValue =>
-    ctx.isClientMoveAllowed && moves.addCoin.validate!(board, coinValue);
+  // `isAllowed` is the engine-bound combination of turn ownership
+  // (ctx.isClientMoveAllowed) and the move's own `validate` — the single
+  // source of truth shared with the engine's illegal-move enforcement.
+  const isRemovalAllowed = coinValue => moves.removeCoin.isAllowed!(board, coinValue);
+  const isAddAllowed = coinValue => moves.addCoin.isAllowed!(board, coinValue);
 
   const removeFromPile = coinValue => {
     if (!isRemovalAllowed(coinValue)) return;

--- a/src/components/games/coins-in-3-piles/board-client.tsx
+++ b/src/components/games/coins-in-3-piles/board-client.tsx
@@ -23,6 +23,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 
   const isRemovalAllowed = coinValue => moves.removeCoin.isAllowed!(board, coinValue);
   const isAddAllowed = coinValue => moves.addCoin.isAllowed!(board, coinValue);
+  const isPassAllowed = () => moves.passAddition.isAllowed!(board);
 
   const removeFromPile = coinValue => {
     if (!isRemovalAllowed(coinValue)) return;
@@ -35,8 +36,8 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   };
 
   const passAddition = () => {
-    if (!isAddAllowed(null)) return;
-    moves.addCoin(board, null);
+    if (!isPassAllowed()) return;
+    moves.passAddition(board);
   };
 
   const shouldShowCoinToBeRemoved = (coinValue) => {
@@ -64,7 +65,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
           </span>
           <div className="flex gap-2">
             <button
-              disabled={!isAddAllowed(1)}
+              disabled={!isPassAllowed()}
               className="secondary-button w-auto"
               onClick={passAddition}
             >

--- a/src/components/games/coins-in-3-piles/board-client.tsx
+++ b/src/components/games/coins-in-3-piles/board-client.tsx
@@ -1,6 +1,6 @@
 import { range } from 'lodash';
 import { useTranslation } from '../../../language';
-import { moveValidators, type Board } from './helpers';
+import type { Board } from './helpers';
 import { GameBoard, type BoardClientProps, useHoverPreview } from '../../strategy-game-factory';
 
 const getCoinBgColor = (coinValue) => {
@@ -21,13 +21,14 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 
   const wasCoinAlreadyRemovedInTurn = valueOfRemovedCoin !== null;
 
-  // Legality comes from the shared validator (single source of truth with the
-  // engine); the board-client only adds the "is it my turn" gate on top.
+  // Legality comes from the move's own validator (single source of truth with
+  // the engine, exposed here with ctx already bound); the board-client only
+  // adds the "is it my turn" gate on top.
   const isRemovalAllowed = coinValue =>
-    ctx.isClientMoveAllowed && moveValidators.removeCoin(board, { ctx }, coinValue);
+    ctx.isClientMoveAllowed && moves.removeCoin.validate!(board, coinValue);
 
   const isAddAllowed = coinValue =>
-    ctx.isClientMoveAllowed && moveValidators.addCoin(board, { ctx }, coinValue);
+    ctx.isClientMoveAllowed && moves.addCoin.validate!(board, coinValue);
 
   const removeFromPile = coinValue => {
     if (!isRemovalAllowed(coinValue)) return;

--- a/src/components/games/coins-in-3-piles/board-client.tsx
+++ b/src/components/games/coins-in-3-piles/board-client.tsx
@@ -35,6 +35,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   };
 
   const passAddition = () => {
+    if (!isAddAllowed(null)) return;
     moves.addCoin(board, null);
   };
 

--- a/src/components/games/coins-in-3-piles/board-client.tsx
+++ b/src/components/games/coins-in-3-piles/board-client.tsx
@@ -1,6 +1,6 @@
 import { range } from 'lodash';
 import { useTranslation } from '../../../language';
-import type { Board } from './helpers';
+import { moveValidators, type Board } from './helpers';
 import { GameBoard, type BoardClientProps, useHoverPreview } from '../../strategy-game-factory';
 
 const getCoinBgColor = (coinValue) => {
@@ -21,17 +21,13 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 
   const wasCoinAlreadyRemovedInTurn = valueOfRemovedCoin !== null;
 
-  const isRemovalAllowed = coinValue => {
-    if (!ctx.isClientMoveAllowed) return false;
-    if (wasCoinAlreadyRemovedInTurn) return false;
-    return board[coinValue - 1] !== 0;
-  };
+  // Legality comes from the shared validator (single source of truth with the
+  // engine); the board-client only adds the "is it my turn" gate on top.
+  const isRemovalAllowed = coinValue =>
+    ctx.isClientMoveAllowed && moveValidators.removeCoin(board, { ctx }, coinValue);
 
-  const isAddAllowed = coinValue => {
-    if (!ctx.isClientMoveAllowed) return false;
-    if (!wasCoinAlreadyRemovedInTurn) return false;
-    return coinValue < valueOfRemovedCoin!;
-  };
+  const isAddAllowed = coinValue =>
+    ctx.isClientMoveAllowed && moveValidators.addCoin(board, { ctx }, coinValue);
 
   const removeFromPile = coinValue => {
     if (!isRemovalAllowed(coinValue)) return;

--- a/src/components/games/coins-in-3-piles/board-client.tsx
+++ b/src/components/games/coins-in-3-piles/board-client.tsx
@@ -25,9 +25,6 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const isAddAllowed = coinValue => moves.addCoin.isAllowed!(board, coinValue);
   const isPassAllowed = () => moves.passAddition.isAllowed!(board);
 
-  const removeFromPile = coinValue => moves.removeCoin(board, coinValue);
-  const addToPile = coinValue => moves.addCoin(board, coinValue);
-  const passAddition = () => moves.passAddition(board);
 
   const shouldShowCoinToBeRemoved = (coinValue) => {
     if (!ctx.isClientMoveAllowed) return false;
@@ -56,7 +53,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
             <button
               disabled={!isPassAllowed()}
               className="secondary-button w-auto"
-              onClick={passAddition}
+              onClick={() => moves.passAddition(board)}
             >
               {t({ hu: 'Semmi ∅', en: 'Nothing ∅' })}
             </button>
@@ -68,7 +65,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
                   primary-button w-auto min-w-[4ch] rounded-2xl
                   ${getCoinBgColor(coinValue)} enabled:hocus:brightness-75
                 `}
-                onClick={() => addToPile(coinValue)}
+                onClick={() => moves.addCoin(board, coinValue)}
                 {...(isAddAllowed(coinValue) ? hoverProps(coinValue) : {})}
               >{coinValue}</button>
             ))}
@@ -101,7 +98,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
                     ? 'opacity-50' : ''}
                 `}
                 style={{ transform: 'scaleY(-1)' }}
-                onClick={() => removeFromPile(coinValue)}
+                onClick={() => moves.removeCoin(board, coinValue)}
                 {...(isRemovalAllowed(coinValue) ? hoverProps(coinValue) : {})}
               >{coinValue}</button>
             ))}

--- a/src/components/games/coins-in-3-piles/bot-strategy.ts
+++ b/src/components/games/coins-in-3-piles/bot-strategy.ts
@@ -8,8 +8,13 @@ export const randomBotStrategy = ({ board, moves }: StrategyArgs<Board>) => {
   const { nextBoard } = moves.removeCoin(board, remove);
   if (remove === 1) return;
   const addOptions = [null, ...range(1, remove)];
+  const add = sample(addOptions);
   setTimeout(() => {
-    moves.addCoin(nextBoard, sample(addOptions));
+    if (add === null) {
+      moves.passAddition(nextBoard);
+    } else {
+      moves.addCoin(nextBoard, add);
+    }
   }, 750);
 };
 
@@ -19,7 +24,7 @@ export const smartBotStrategy = ({ board, moves }: StrategyArgs<Board>) => {
   if (add === undefined) return;
   if (add === null) {
     setTimeout(() => {
-      moves.addCoin(nextBoard, null);
+      moves.passAddition(nextBoard);
     }, 0);
   } else {
     setTimeout(() => {

--- a/src/components/games/coins-in-3-piles/coins-in-3-piles.tsx
+++ b/src/components/games/coins-in-3-piles/coins-in-3-piles.tsx
@@ -2,7 +2,7 @@ import { random, sample, sum } from 'lodash';
 import { strategyGameFactory } from '../../strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { BoardClient } from './board-client';
-import { getPlayerStepDescription, canWin, moves, moveValidators, type Board } from './helpers';
+import { getPlayerStepDescription, canWin, moves, type Board } from './helpers';
 
 const generateWinningStartBoard = (): Board => {
   const board = [random(0, 5), random(0, 7), random(1, 8)];
@@ -64,7 +64,7 @@ export const CoinsIn3Piles = strategyGameFactory({
     getPlayerStepDescription
   },
   BoardClient,
-  gameplay: { moves, moveValidators },
+  gameplay: { moves },
   variants: [
     {
       botStrategy: randomBotStrategy,

--- a/src/components/games/coins-in-3-piles/coins-in-3-piles.tsx
+++ b/src/components/games/coins-in-3-piles/coins-in-3-piles.tsx
@@ -2,7 +2,7 @@ import { random, sample, sum } from 'lodash';
 import { strategyGameFactory } from '../../strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { BoardClient } from './board-client';
-import { getPlayerStepDescription, canWin, moves, type Board } from './helpers';
+import { getPlayerStepDescription, canWin, moves, moveValidators, type Board } from './helpers';
 
 const generateWinningStartBoard = (): Board => {
   const board = [random(0, 5), random(0, 7), random(1, 8)];
@@ -64,7 +64,7 @@ export const CoinsIn3Piles = strategyGameFactory({
     getPlayerStepDescription
   },
   BoardClient,
-  gameplay: { moves },
+  gameplay: { moves, moveValidators },
   variants: [
     {
       botStrategy: randomBotStrategy,

--- a/src/components/games/coins-in-3-piles/helpers.spec.ts
+++ b/src/components/games/coins-in-3-piles/helpers.spec.ts
@@ -1,16 +1,16 @@
-import { moveValidators, type Board } from './helpers';
+import { moves, type Board } from './helpers';
 import { makeCtx } from '../../../test-utils';
 
 // The board-client's `disabled` predicates and the engine's illegal-move
 // enforcement both flow through these validators, so they are the single legality
 // contract worth locking down. `ctx.isClientMoveAllowed` (whose turn) is out of
 // scope here on purpose — that gate lives in the board-client, not the validator.
-describe('coins-in-3-piles moveValidators', () => {
+describe('coins-in-3-piles move validators', () => {
   type TurnState = { removedCoinValue: number } | null;
   const removeCoin = (board: Board, turnState: TurnState, value: number) =>
-    moveValidators.removeCoin(board, { ctx: makeCtx({ turnState }) }, value);
+    moves.removeCoin.validate(board, { ctx: makeCtx({ turnState }) }, value);
   const addCoin = (board: Board, turnState: TurnState, value: number | null) =>
-    moveValidators.addCoin(board, { ctx: makeCtx({ turnState }) }, value);
+    moves.addCoin.validate(board, { ctx: makeCtx({ turnState }) }, value);
 
   describe('removeCoin', () => {
     it('allows removing from a non-empty pile at the start of a turn', () => {

--- a/src/components/games/coins-in-3-piles/helpers.spec.ts
+++ b/src/components/games/coins-in-3-piles/helpers.spec.ts
@@ -1,0 +1,55 @@
+import { moveValidators, type Board } from './helpers';
+import { makeCtx } from '../../../test-utils';
+
+// The board-client's `disabled` predicates and the engine's illegal-move
+// enforcement both flow through these validators, so they are the single legality
+// contract worth locking down. `ctx.isClientMoveAllowed` (whose turn) is out of
+// scope here on purpose — that gate lives in the board-client, not the validator.
+describe('coins-in-3-piles moveValidators', () => {
+  type TurnState = { removedCoinValue: number } | null;
+  const removeCoin = (board: Board, turnState: TurnState, value: number) =>
+    moveValidators.removeCoin(board, { ctx: makeCtx({ turnState }) }, value);
+  const addCoin = (board: Board, turnState: TurnState, value: number | null) =>
+    moveValidators.addCoin(board, { ctx: makeCtx({ turnState }) }, value);
+
+  describe('removeCoin', () => {
+    it('allows removing from a non-empty pile at the start of a turn', () => {
+      expect(removeCoin([3, 5, 7], null, 1)).toBe(true);
+      expect(removeCoin([3, 5, 7], null, 3)).toBe(true);
+    });
+
+    it('rejects removing from an empty pile', () => {
+      expect(removeCoin([0, 5, 7], null, 1)).toBe(false);
+    });
+
+    it('rejects a coin value out of the 1..3 range', () => {
+      expect(removeCoin([3, 5, 7], null, 0)).toBe(false);
+      expect(removeCoin([3, 5, 7], null, 4)).toBe(false);
+    });
+
+    it('rejects a second removal in the same turn', () => {
+      expect(removeCoin([3, 5, 7], { removedCoinValue: 3 }, 1)).toBe(false);
+    });
+  });
+
+  describe('addCoin', () => {
+    it('rejects placing back before any coin was removed', () => {
+      expect(addCoin([3, 5, 7], null, 1)).toBe(false);
+      expect(addCoin([3, 5, 7], null, null)).toBe(false);
+    });
+
+    it('allows placing back a strictly smaller coin', () => {
+      expect(addCoin([3, 5, 6], { removedCoinValue: 3 }, 1)).toBe(true);
+      expect(addCoin([3, 5, 6], { removedCoinValue: 3 }, 2)).toBe(true);
+    });
+
+    it('rejects placing back a coin greater than or equal to the removed value', () => {
+      expect(addCoin([3, 5, 6], { removedCoinValue: 2 }, 2)).toBe(false);
+      expect(addCoin([3, 5, 6], { removedCoinValue: 2 }, 3)).toBe(false);
+    });
+
+    it('allows placing back nothing', () => {
+      expect(addCoin([3, 5, 6], { removedCoinValue: 2 }, null)).toBe(true);
+    });
+  });
+});

--- a/src/components/games/coins-in-3-piles/helpers.spec.ts
+++ b/src/components/games/coins-in-3-piles/helpers.spec.ts
@@ -1,56 +1,51 @@
 import { moves, type Board } from './helpers';
 import { makeCtx } from '../../../test-utils';
 
-// The board-client's `disabled` predicates and the engine's illegal-move
-// enforcement both flow through these validators, so they are the single legality
-// contract worth locking down. `ctx.isClientMoveAllowed` (whose turn) is out of
-// scope here on purpose — the engine folds that into the wrapped `isAllowed`,
-// it is not part of per-move legality.
 describe('coins-in-3-piles move validators', () => {
   type TurnState = { removedCoinValue: number } | null;
-  const removeCoin = (board: Board, turnState: TurnState, value: number) =>
+  const isRemovalAllowed = (board: Board, turnState: TurnState, value: number) =>
     moves.removeCoin.validate(board, { ctx: makeCtx({ turnState }) }, value);
-  const addCoin = (board: Board, turnState: TurnState, value: number | null) =>
+  const isAddAllowed = (board: Board, turnState: TurnState, value: number | null) =>
     moves.addCoin.validate(board, { ctx: makeCtx({ turnState }) }, value);
 
   describe('removeCoin', () => {
     it('allows removing from a non-empty pile at the start of a turn', () => {
-      expect(removeCoin([3, 5, 7], null, 1)).toBe(true);
-      expect(removeCoin([3, 5, 7], null, 3)).toBe(true);
+      expect(isRemovalAllowed([3, 5, 7], null, 1)).toBe(true);
+      expect(isRemovalAllowed([3, 5, 7], null, 3)).toBe(true);
     });
 
     it('rejects removing from an empty pile', () => {
-      expect(removeCoin([0, 5, 7], null, 1)).toBe(false);
+      expect(isRemovalAllowed([0, 5, 7], null, 1)).toBe(false);
     });
 
     it('rejects a coin value out of the 1..3 range', () => {
-      expect(removeCoin([3, 5, 7], null, 0)).toBe(false);
-      expect(removeCoin([3, 5, 7], null, 4)).toBe(false);
+      expect(isRemovalAllowed([3, 5, 7], null, 0)).toBe(false);
+      expect(isRemovalAllowed([3, 5, 7], null, 4)).toBe(false);
     });
 
     it('rejects a second removal in the same turn', () => {
-      expect(removeCoin([3, 5, 7], { removedCoinValue: 3 }, 1)).toBe(false);
+      expect(isRemovalAllowed([3, 5, 7], { removedCoinValue: 3 }, 1)).toBe(false);
     });
   });
 
   describe('addCoin', () => {
     it('rejects placing back before any coin was removed', () => {
-      expect(addCoin([3, 5, 7], null, 1)).toBe(false);
-      expect(addCoin([3, 5, 7], null, null)).toBe(false);
+      expect(isAddAllowed([3, 5, 7], null, 1)).toBe(false);
+      expect(isAddAllowed([3, 5, 7], null, null)).toBe(false);
     });
 
     it('allows placing back a strictly smaller coin', () => {
-      expect(addCoin([3, 5, 6], { removedCoinValue: 3 }, 1)).toBe(true);
-      expect(addCoin([3, 5, 6], { removedCoinValue: 3 }, 2)).toBe(true);
+      expect(isAddAllowed([3, 5, 6], { removedCoinValue: 3 }, 1)).toBe(true);
+      expect(isAddAllowed([3, 5, 6], { removedCoinValue: 3 }, 2)).toBe(true);
     });
 
     it('rejects placing back a coin greater than or equal to the removed value', () => {
-      expect(addCoin([3, 5, 6], { removedCoinValue: 2 }, 2)).toBe(false);
-      expect(addCoin([3, 5, 6], { removedCoinValue: 2 }, 3)).toBe(false);
+      expect(isAddAllowed([3, 5, 6], { removedCoinValue: 2 }, 2)).toBe(false);
+      expect(isAddAllowed([3, 5, 6], { removedCoinValue: 2 }, 3)).toBe(false);
     });
 
     it('allows placing back nothing', () => {
-      expect(addCoin([3, 5, 6], { removedCoinValue: 2 }, null)).toBe(true);
+      expect(isAddAllowed([3, 5, 6], { removedCoinValue: 2 }, null)).toBe(true);
     });
   });
 });

--- a/src/components/games/coins-in-3-piles/helpers.spec.ts
+++ b/src/components/games/coins-in-3-piles/helpers.spec.ts
@@ -5,8 +5,10 @@ describe('coins-in-3-piles move validators', () => {
   type TurnState = { removedCoinValue: number } | null;
   const isRemovalAllowed = (board: Board, turnState: TurnState, value: number) =>
     moves.removeCoin.validate(board, { ctx: makeCtx({ turnState }) }, value);
-  const isAddAllowed = (board: Board, turnState: TurnState, value: number | null) =>
+  const isAddAllowed = (board: Board, turnState: TurnState, value: number) =>
     moves.addCoin.validate(board, { ctx: makeCtx({ turnState }) }, value);
+  const isPassAllowed = (board: Board, turnState: TurnState) =>
+    moves.passAddition.validate(board, { ctx: makeCtx({ turnState }) });
 
   describe('removeCoin', () => {
     it('allows removing from a non-empty pile at the start of a turn', () => {
@@ -31,7 +33,6 @@ describe('coins-in-3-piles move validators', () => {
   describe('addCoin', () => {
     it('rejects placing back before any coin was removed', () => {
       expect(isAddAllowed([3, 5, 7], null, 1)).toBe(false);
-      expect(isAddAllowed([3, 5, 7], null, null)).toBe(false);
     });
 
     it('allows placing back a strictly smaller coin', () => {
@@ -44,8 +45,15 @@ describe('coins-in-3-piles move validators', () => {
       expect(isAddAllowed([3, 5, 6], { removedCoinValue: 2 }, 3)).toBe(false);
     });
 
-    it('allows placing back nothing', () => {
-      expect(isAddAllowed([3, 5, 6], { removedCoinValue: 2 }, null)).toBe(true);
+  });
+
+  describe('passAddition', () => {
+    it('allows passing once a coin was removed', () => {
+      expect(isPassAllowed([3, 5, 6], { removedCoinValue: 2 })).toBe(true);
+    });
+
+    it('rejects passing before any coin was removed', () => {
+      expect(isPassAllowed([3, 5, 7], null)).toBe(false);
     });
   });
 });

--- a/src/components/games/coins-in-3-piles/helpers.spec.ts
+++ b/src/components/games/coins-in-3-piles/helpers.spec.ts
@@ -4,7 +4,8 @@ import { makeCtx } from '../../../test-utils';
 // The board-client's `disabled` predicates and the engine's illegal-move
 // enforcement both flow through these validators, so they are the single legality
 // contract worth locking down. `ctx.isClientMoveAllowed` (whose turn) is out of
-// scope here on purpose — that gate lives in the board-client, not the validator.
+// scope here on purpose — the engine folds that into the wrapped `isAllowed`,
+// it is not part of per-move legality.
 describe('coins-in-3-piles move validators', () => {
   type TurnState = { removedCoinValue: number } | null;
   const removeCoin = (board: Board, turnState: TurnState, value: number) =>

--- a/src/components/games/coins-in-3-piles/helpers.ts
+++ b/src/components/games/coins-in-3-piles/helpers.ts
@@ -1,5 +1,5 @@
 import { cloneDeep, isEqual } from "lodash";
-import type { Events } from '../../strategy-game-factory';
+import type { Ctx, Events } from '../../strategy-game-factory';
 
 export type Board = number[]
 
@@ -22,6 +22,20 @@ export const canWin = (board: Board) => {
 
   return (oddPiles.length === 3 || oddPiles.length === 0);
 }
+
+// Single source of legality for both the UI (button `disabled` in board-client)
+// and the engine's illegal-move enforcement. Deliberately excludes the "whose
+// turn is it" check (`ctx.isClientMoveAllowed`) — that is the engine's concern,
+// not per-move legality.
+export const moveValidators = {
+  removeCoin: (board: Board, { ctx }: { ctx: Ctx }, value: number) =>
+    ctx.turnState === null && value >= 1 && value <= 3 && board[value - 1] > 0,
+  addCoin: (board: Board, { ctx }: { ctx: Ctx }, value: number | null) => {
+    const removed = (ctx.turnState as { removedCoinValue: number } | null)?.removedCoinValue;
+    if (removed == null) return false;
+    return value === null || (value >= 1 && value < removed);
+  }
+};
 
 export const moves = {
   removeCoin: (board: Board, { events }: { events: Events }, value) => {

--- a/src/components/games/coins-in-3-piles/helpers.ts
+++ b/src/components/games/coins-in-3-piles/helpers.ts
@@ -23,44 +23,45 @@ export const canWin = (board: Board) => {
   return (oddPiles.length === 3 || oddPiles.length === 0);
 }
 
-// Single source of legality for both the UI (button `disabled` in board-client)
-// and the engine's illegal-move enforcement. Deliberately excludes the "whose
-// turn is it" check (`ctx.isClientMoveAllowed`) — that is the engine's concern,
-// not per-move legality.
-export const moveValidators = {
-  removeCoin: (board: Board, { ctx }: { ctx: Ctx }, value: number) =>
-    ctx.turnState === null && value >= 1 && value <= 3 && board[value - 1] > 0,
-  addCoin: (board: Board, { ctx }: { ctx: Ctx }, value: number | null) => {
-    const removed = (ctx.turnState as { removedCoinValue: number } | null)?.removedCoinValue;
-    if (removed == null) return false;
-    return value === null || (value >= 1 && value < removed);
-  }
-};
-
+// Each `validate` is the single source of legality for both the UI (button
+// `disabled` in board-client) and the engine's illegal-move enforcement. It
+// deliberately excludes the "whose turn is it" check (`ctx.isClientMoveAllowed`)
+// — that is the engine's concern, not per-move legality.
 export const moves = {
-  removeCoin: (board: Board, { events }: { events: Events }, value) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard[value - 1] -= 1;
-    if (value === 1) {
+  removeCoin: {
+    validate: (board: Board, { ctx }: { ctx: Ctx }, value: number) =>
+      ctx.turnState === null && value >= 1 && value <= 3 && board[value - 1] > 0,
+    apply: (board: Board, { events }: { events: Events }, value) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard[value - 1] -= 1;
+      if (value === 1) {
+        events.endTurn();
+        if (isEqual(nextBoard, [0, 0, 0])) {
+          events.endGame();
+        }
+      } else {
+        events.setTurnState({ removedCoinValue: value });
+      }
+      return { nextBoard };
+    }
+  },
+  addCoin: {
+    validate: (board: Board, { ctx }: { ctx: Ctx }, value: number | null) => {
+      const removed = (ctx.turnState as { removedCoinValue: number } | null)?.removedCoinValue;
+      if (removed == null) return false;
+      return value === null || (value >= 1 && value < removed);
+    },
+    apply: (board: Board, { events }: { events: Events }, value) => {
+      const nextBoard = cloneDeep(board);
+      if (value !== null) {
+        nextBoard[value - 1] += 1;
+      }
       events.endTurn();
+      events.setTurnState(null);
       if (isEqual(nextBoard, [0, 0, 0])) {
         events.endGame();
       }
-    } else {
-      events.setTurnState({ removedCoinValue: value });
+      return { nextBoard };
     }
-    return { nextBoard };
-  },
-  addCoin: (board: Board, { events }: { events: Events }, value) => {
-    const nextBoard = cloneDeep(board);
-    if (value !== null) {
-      nextBoard[value - 1] += 1;
-    }
-    events.endTurn();
-    events.setTurnState(null);
-    if (isEqual(nextBoard, [0, 0, 0])) {
-      events.endGame();
-    }
-    return { nextBoard };
   }
 }

--- a/src/components/games/coins-in-3-piles/helpers.ts
+++ b/src/components/games/coins-in-3-piles/helpers.ts
@@ -23,10 +23,6 @@ export const canWin = (board: Board) => {
   return (oddPiles.length === 3 || oddPiles.length === 0);
 }
 
-// Each `validate` is the single source of legality for both the UI (button
-// `disabled` in board-client) and the engine's illegal-move enforcement. It
-// deliberately excludes the "whose turn is it" check (`ctx.isClientMoveAllowed`)
-// — that is the engine's concern, not per-move legality.
 export const moves = {
   removeCoin: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, value: number) =>

--- a/src/components/games/coins-in-3-piles/helpers.ts
+++ b/src/components/games/coins-in-3-piles/helpers.ts
@@ -42,22 +42,29 @@ export const moves = {
     }
   },
   addCoin: {
-    validate: (board: Board, { ctx }: { ctx: Ctx }, value: number | null) => {
+    validate: (board: Board, { ctx }: { ctx: Ctx }, value: number) => {
       const removed = (ctx.turnState as { removedCoinValue: number } | null)?.removedCoinValue;
-      if (removed == null) return false;
-      return value === null || (value >= 1 && value < removed);
+      return removed != null && value >= 1 && value < removed;
     },
     apply: (board: Board, { events }: { events: Events }, value) => {
       const nextBoard = cloneDeep(board);
-      if (value !== null) {
-        nextBoard[value - 1] += 1;
-      }
-      events.endTurn();
-      events.setTurnState(null);
-      if (isEqual(nextBoard, [0, 0, 0])) {
-        events.endGame();
-      }
-      return { nextBoard };
+      nextBoard[value - 1] += 1;
+      return finishPlaceBack(nextBoard, events);
     }
+  },
+  passAddition: {
+    validate: (board: Board, { ctx }: { ctx: Ctx }) => ctx.turnState !== null,
+    apply: (board: Board, { events }: { events: Events }) => finishPlaceBack(board, events)
   }
+}
+
+// Shared second half of the place-back phase: whether a coin was added or the
+// player passed, the turn ends the same way.
+function finishPlaceBack(nextBoard: Board, events: Events) {
+  events.endTurn();
+  events.setTurnState(null);
+  if (isEqual(nextBoard, [0, 0, 0])) {
+    events.endGame();
+  }
+  return { nextBoard };
 }

--- a/src/components/games/cube-coloring/bot-strategy.ts
+++ b/src/components/games/cube-coloring/bot-strategy.ts
@@ -1,13 +1,12 @@
 import { difference, range, shuffle, sample } from 'lodash';
-import { isAllowedStep, isColored, neighbours, type Board } from './helpers';
-import { nodeColors } from './cube-coloring';
+import { isAllowedStep, isColored, neighbours, colors, type Board } from './helpers';
 import type { StrategyArgs } from '../../strategy-game-factory';
 
 export const randomBotStrategy = ({ board, moves }: StrategyArgs<Board>) => {
   const validMoves: { vertex: number, color: string }[] = [];
   for (const vertex of range(0, 8)) {
     if (isColored(board, vertex)) continue;
-    for (const color of Object.keys(nodeColors)) {
+    for (const color of colors) {
       if (isAllowedStep(board, vertex, color)) {
         validMoves.push({ vertex, color });
       }
@@ -27,8 +26,8 @@ const makeOptimalStepAsFirst = (board: Board) => {
   const mainDiagonal = shuffle([2, 4]);
   const otherVertices = shuffle([0, 1, 3, 5, 6, 7]);
   const vertexToColor = [...mainDiagonal, ...otherVertices].find(v => !isColored(board, v));
-  const colors = Object.keys(nodeColors).filter(c => isAllowedStep(board, vertexToColor, c));
-  return { vertex: vertexToColor, color: sample(colors) };
+  const allowedColors = colors.filter(c => isAllowedStep(board, vertexToColor, c));
+  return { vertex: vertexToColor, color: sample(allowedColors) };
 };
 
 const makeOptimalStepAsSecond = (board: Board) => {
@@ -67,7 +66,7 @@ const makeOptimalStepAsSecond = (board: Board) => {
   }
   // every vertex is either banned or has no colored neighbor
   for (const vertex of emptyVertices) {
-    for (const color of shuffle(Object.keys(nodeColors))) {
+    for (const color of shuffle(colors)) {
       if (isAllowedStep(board, vertex, color)) {
         return { vertex, color };
       }
@@ -79,7 +78,7 @@ const makeOptimalStepAsSecond = (board: Board) => {
 
 const getMissingColors = (board: Board, vertex) => {
   const nbColors = neighbours[vertex].map(v => board[v]);
-  return difference(Object.keys(nodeColors), nbColors);
+  return difference(colors, nbColors);
 };
 
 const getEmptyNeighbours = (board: Board, vertex) => {

--- a/src/components/games/cube-coloring/cube-coloring.tsx
+++ b/src/components/games/cube-coloring/cube-coloring.tsx
@@ -156,6 +156,14 @@ const moves = {
   }
 }
 
+// Reuses the same `isAllowedStep` legality helper the BoardClient and bot already
+// rely on, so the engine now enforces the colouring rule (no colouring an already
+// coloured vertex, no two adjacent equal colours) from a single source.
+const moveValidators = {
+  colorVertex: (board: Board, _, { vertex, color }: { vertex: number; color: string }) =>
+    isAllowedStep(board, vertex, color)
+}
+
 const rule = {
   hu: <>
     Adott egy téglatest rácsa, aminek be van húzva az egyik testátlója.
@@ -187,7 +195,7 @@ export const CubeColoring = strategyGameFactory({
     })
   },
   BoardClient,
-  gameplay: { moves },
+  gameplay: { moves, moveValidators },
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
     // smart bot: verified as optimal

--- a/src/components/games/cube-coloring/cube-coloring.tsx
+++ b/src/components/games/cube-coloring/cube-coloring.tsx
@@ -136,10 +136,7 @@ const isGameEnd = (board: Board) => {
 
 const moves = {
   colorVertex: {
-    // Reuses the same `isAllowedStep` legality helper the BoardClient and bot
-    // already rely on, so the engine enforces the colouring rule (no colouring
-    // an already coloured vertex, no two adjacent equal colours) from a single
-    // source. The colour must be a real palette colour — this also covers the
+    // The colour must be a real palette colour — this also covers the
     // BoardClient's "no colour picked yet" state (color === null).
     validate: (board: Board, _, { vertex, color }: { vertex: number; color: string | null }) =>
       color !== null && color in nodeColors && isAllowedStep(board, vertex, color),

--- a/src/components/games/cube-coloring/cube-coloring.tsx
+++ b/src/components/games/cube-coloring/cube-coloring.tsx
@@ -64,6 +64,8 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   });
 
   const setVertexColor = (vertex) => {
+    // the engine ignores disallowed dispatches, but the guard is still needed
+    // here: a rejected click must not clear the colour selection below
     if (!isColoringAllowed(vertex)) return;
     moves.colorVertex(board, { vertex, color });
     setColor(null);

--- a/src/components/games/cube-coloring/cube-coloring.tsx
+++ b/src/components/games/cube-coloring/cube-coloring.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { range, cloneDeep, every, some, map } from 'lodash';
 import { strategyGameFactory, type Events, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
-import { isAllowedStep, isColored, generateStartBoard, edges, type Board } from './helpers';
+import { isAllowedStep, isColored, generateStartBoard, edges, colors, type Board } from './helpers';
 import { useTranslation } from '../../../language';
 
 // Screen position of each node; the drawn skeleton (see `edges` in helpers)
@@ -43,7 +43,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const [x, setX] = useState(0);
   const [y, setY] = useState(0);
 
-  const isMoveAllowed = (vertex) => moves.colorVertex.isAllowed!(board, { vertex, color });
+  const isColoringAllowed = (vertex) => moves.colorVertex.isAllowed!(board, { vertex, color });
 
   const pick = (pickedColor) => {
     if (!ctx.isClientMoveAllowed) return;
@@ -57,14 +57,14 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   };
 
   const isNearAllowedNode = range(8).some(nodeId => {
-    if (!isMoveAllowed(nodeId)) return false;
+    if (!isColoringAllowed(nodeId)) return false;
     const cx = parseFloat(cubeCoords[nodeId].cx);
     const cy = parseFloat(cubeCoords[nodeId].cy);
     return Math.hypot(x - cx, y - cy) < 6;
   });
 
   const setVertexColor = (vertex) => {
-    if (!isMoveAllowed(vertex)) return;
+    if (!isColoringAllowed(vertex)) return;
     moves.colorVertex(board, { vertex, color });
     setColor(null);
   };
@@ -105,12 +105,12 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
           onKeyUp={(event) => {
             if (event.key === 'Enter') setVertexColor(nodeId);
           }}
-          tabIndex={isMoveAllowed(nodeId) ? 0 : undefined}
-          role={isMoveAllowed(nodeId) ? 'button' : undefined}
-          aria-label={isMoveAllowed(nodeId) ? `Node ${nodeId + 1}` : undefined}
+          tabIndex={isColoringAllowed(nodeId) ? 0 : undefined}
+          role={isColoringAllowed(nodeId) ? 'button' : undefined}
+          aria-label={isColoringAllowed(nodeId) ? `Node ${nodeId + 1}` : undefined}
           fill={nodeColors[board[nodeId]]?.svg}
           className={!nodeColors[board[nodeId]]
-            ? (isMoveAllowed(nodeId) || color === null
+            ? (isColoringAllowed(nodeId) || color === null
               ? 'fill-slate-50 dark:fill-slate-300'
               : 'fill-slate-400 dark:fill-slate-600')
             : undefined}
@@ -131,15 +131,13 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 
 const isGameEnd = (board: Board) => {
   const canUseColor = color => some(range(0, 8), v => isAllowedStep(board, v, color));
-  return every(Object.keys(nodeColors), color => !canUseColor(color));
+  return every(colors, color => !canUseColor(color));
 };
 
 const moves = {
   colorVertex: {
-    // The colour must be a real palette colour — this also covers the
-    // BoardClient's "no colour picked yet" state (color === null).
     validate: (board: Board, _, { vertex, color }: { vertex: number; color: string | null }) =>
-      color !== null && color in nodeColors && isAllowedStep(board, vertex, color),
+      isAllowedStep(board, vertex, color),
     apply: (board: Board, { events }: { events: Events }, { vertex, color }) => {
       const nextBoard = cloneDeep(board);
       nextBoard[vertex] = color;

--- a/src/components/games/cube-coloring/cube-coloring.tsx
+++ b/src/components/games/cube-coloring/cube-coloring.tsx
@@ -38,22 +38,16 @@ export const nodeColors = {
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
-  const [color, setColor] = useState('');
-  const [show, setShow] = useState(false);
+  // null = no colour picked; picking the selected colour again deselects it
+  const [color, setColor] = useState<string | null>(null);
   const [x, setX] = useState(0);
   const [y, setY] = useState(0);
 
-  const isMoveAllowed = (vertex) =>
-    show && moves.colorVertex.isAllowed!(board, { vertex, color });
+  const isMoveAllowed = (vertex) => moves.colorVertex.isAllowed!(board, { vertex, color });
 
   const pick = (pickedColor) => {
     if (!ctx.isClientMoveAllowed) return;
-    if (pickedColor === color) {
-      setShow(!show);
-    } else {
-      setShow(true);
-      setColor(pickedColor);
-    }
+    setColor(pickedColor === color ? null : pickedColor);
   };
 
   const drawPickedColor = (event) => {
@@ -62,7 +56,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     setY(event.nativeEvent.offsetY / svg.clientHeight * 100);
   };
 
-  const isNearAllowedNode = show && range(8).some(nodeId => {
+  const isNearAllowedNode = range(8).some(nodeId => {
     if (!isMoveAllowed(nodeId)) return false;
     const cx = parseFloat(cubeCoords[nodeId].cx);
     const cy = parseFloat(cubeCoords[nodeId].cy);
@@ -72,7 +66,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const setVertexColor = (vertex) => {
     if (!isMoveAllowed(vertex)) return;
     moves.colorVertex(board, { vertex, color });
-    setShow(false);
+    setColor(null);
   };
 
   return (
@@ -81,7 +75,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
       {map(nodeColors, ({ bg, name }, colorKey) =>
         <button
           key={colorKey}
-          disabled={!ctx.isClientMoveAllowed || (show && color !== colorKey)}
+          disabled={!ctx.isClientMoveAllowed || (color !== null && color !== colorKey)}
           className={`primary-button ${bg}`}
           onClick={() => pick(colorKey)}
         >
@@ -116,7 +110,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
           aria-label={isMoveAllowed(nodeId) ? `Node ${nodeId + 1}` : undefined}
           fill={nodeColors[board[nodeId]]?.svg}
           className={!nodeColors[board[nodeId]]
-            ? (isMoveAllowed(nodeId) || !show
+            ? (isMoveAllowed(nodeId) || color === null
               ? 'fill-slate-50 dark:fill-slate-300'
               : 'fill-slate-400 dark:fill-slate-600')
             : undefined}
@@ -126,7 +120,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
       {isNearAllowedNode && (
         <circle
           cx={x + '%'} cy={y + '%'} r="4%"
-          fill={nodeColors[color].svg}
+          fill={nodeColors[color!].svg}
           className="pointer-events-none opacity-50 stroke-0"
         />
       )}
@@ -145,9 +139,10 @@ const moves = {
     // Reuses the same `isAllowedStep` legality helper the BoardClient and bot
     // already rely on, so the engine enforces the colouring rule (no colouring
     // an already coloured vertex, no two adjacent equal colours) from a single
-    // source.
-    validate: (board: Board, _, { vertex, color }: { vertex: number; color: string }) =>
-      isAllowedStep(board, vertex, color),
+    // source. The colour must be a real palette colour — this also covers the
+    // BoardClient's "no colour picked yet" state (color === null).
+    validate: (board: Board, _, { vertex, color }: { vertex: number; color: string | null }) =>
+      color !== null && color in nodeColors && isAllowedStep(board, vertex, color),
     apply: (board: Board, { events }: { events: Events }, { vertex, color }) => {
       const nextBoard = cloneDeep(board);
       nextBoard[vertex] = color;

--- a/src/components/games/cube-coloring/cube-coloring.tsx
+++ b/src/components/games/cube-coloring/cube-coloring.tsx
@@ -43,11 +43,8 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const [x, setX] = useState(0);
   const [y, setY] = useState(0);
 
-  const isMoveAllowed = (vertex) => {
-    if (!ctx.isClientMoveAllowed) return false;
-    if (!show) return false;
-    return isAllowedStep(board, vertex, color);
-  };
+  const isMoveAllowed = (vertex) =>
+    show && moves.colorVertex.isAllowed!(board, { vertex, color });
 
   const pick = (pickedColor) => {
     if (!ctx.isClientMoveAllowed) return;

--- a/src/components/games/cube-coloring/cube-coloring.tsx
+++ b/src/components/games/cube-coloring/cube-coloring.tsx
@@ -144,24 +144,24 @@ const isGameEnd = (board: Board) => {
 };
 
 const moves = {
-  colorVertex: (board: Board, { events }: { events: Events }, { vertex, color }) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard[vertex] = color;
-    events.endTurn();
-    if (isGameEnd(nextBoard)) {
-      const winnerIndex = every(range(0, 8), v => isColored(nextBoard, v)) ? 0 : 1;
-      events.endGame(winnerIndex)
+  colorVertex: {
+    // Reuses the same `isAllowedStep` legality helper the BoardClient and bot
+    // already rely on, so the engine enforces the colouring rule (no colouring
+    // an already coloured vertex, no two adjacent equal colours) from a single
+    // source.
+    validate: (board: Board, _, { vertex, color }: { vertex: number; color: string }) =>
+      isAllowedStep(board, vertex, color),
+    apply: (board: Board, { events }: { events: Events }, { vertex, color }) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard[vertex] = color;
+      events.endTurn();
+      if (isGameEnd(nextBoard)) {
+        const winnerIndex = every(range(0, 8), v => isColored(nextBoard, v)) ? 0 : 1;
+        events.endGame(winnerIndex)
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
-}
-
-// Reuses the same `isAllowedStep` legality helper the BoardClient and bot already
-// rely on, so the engine now enforces the colouring rule (no colouring an already
-// coloured vertex, no two adjacent equal colours) from a single source.
-const moveValidators = {
-  colorVertex: (board: Board, _, { vertex, color }: { vertex: number; color: string }) =>
-    isAllowedStep(board, vertex, color)
 }
 
 const rule = {
@@ -195,7 +195,7 @@ export const CubeColoring = strategyGameFactory({
     })
   },
   BoardClient,
-  gameplay: { moves, moveValidators },
+  gameplay: { moves },
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
     // smart bot: verified as optimal

--- a/src/components/games/cube-coloring/helpers.spec.ts
+++ b/src/components/games/cube-coloring/helpers.spec.ts
@@ -7,6 +7,11 @@ describe('cube-coloring isAllowedStep', () => {
     expect(isAllowedStep(empty(), 0, 'red')).toBe(true);
   });
 
+  it('rejects a colour outside the palette', () => {
+    expect(isAllowedStep(empty(), 0, 'purple')).toBe(false);
+    expect(isAllowedStep(empty(), 0, null)).toBe(false);
+  });
+
   it('rejects colouring a vertex that is already coloured', () => {
     const board = empty();
     board[0] = 'red';

--- a/src/components/games/cube-coloring/helpers.spec.ts
+++ b/src/components/games/cube-coloring/helpers.spec.ts
@@ -1,4 +1,11 @@
-import { isAllowedStep, generateStartBoard, neighbours, type Board } from './helpers';
+import { isAllowedStep, generateStartBoard, neighbours, colors, type Board } from './helpers';
+import { nodeColors } from './cube-coloring';
+
+describe('cube-coloring palette', () => {
+  it('logic-side colors stay in sync with the styling palette nodeColors', () => {
+    expect(Object.keys(nodeColors)).toEqual(colors);
+  });
+});
 
 describe('cube-coloring isAllowedStep', () => {
   const empty = (): Board => generateStartBoard();

--- a/src/components/games/cube-coloring/helpers.spec.ts
+++ b/src/components/games/cube-coloring/helpers.spec.ts
@@ -1,8 +1,5 @@
 import { isAllowedStep, generateStartBoard, neighbours, type Board } from './helpers';
 
-// `isAllowedStep` is the single legality source shared by the board-client
-// (`disabled`), the bot, and — via the move's `validate` — the engine's
-// illegal-move enforcement for `colorVertex`. These tests lock that contract.
 describe('cube-coloring isAllowedStep', () => {
   const empty = (): Board => generateStartBoard();
 

--- a/src/components/games/cube-coloring/helpers.spec.ts
+++ b/src/components/games/cube-coloring/helpers.spec.ts
@@ -1,0 +1,32 @@
+import { isAllowedStep, generateStartBoard, neighbours, type Board } from './helpers';
+
+// `isAllowedStep` is the single legality source shared by the board-client
+// (`disabled`), the bot, and — since moveValidators was added — the engine's
+// illegal-move enforcement for `colorVertex`. These tests lock that contract.
+describe('cube-coloring isAllowedStep', () => {
+  const empty = (): Board => generateStartBoard();
+
+  it('allows colouring an uncoloured vertex on an empty board', () => {
+    expect(isAllowedStep(empty(), 0, 'red')).toBe(true);
+  });
+
+  it('rejects colouring a vertex that is already coloured', () => {
+    const board = empty();
+    board[0] = 'red';
+    expect(isAllowedStep(board, 0, 'blue')).toBe(false);
+  });
+
+  it('rejects a colour equal to an already-coloured neighbour', () => {
+    const board = empty();
+    const neighbour = neighbours[0][0];
+    board[neighbour] = 'red';
+    expect(isAllowedStep(board, 0, 'red')).toBe(false);
+  });
+
+  it('allows a colour that differs from every coloured neighbour', () => {
+    const board = empty();
+    const neighbour = neighbours[0][0];
+    board[neighbour] = 'red';
+    expect(isAllowedStep(board, 0, 'blue')).toBe(true);
+  });
+});

--- a/src/components/games/cube-coloring/helpers.spec.ts
+++ b/src/components/games/cube-coloring/helpers.spec.ts
@@ -1,7 +1,7 @@
 import { isAllowedStep, generateStartBoard, neighbours, type Board } from './helpers';
 
 // `isAllowedStep` is the single legality source shared by the board-client
-// (`disabled`), the bot, and — since moveValidators was added — the engine's
+// (`disabled`), the bot, and — via the move's `validate` — the engine's
 // illegal-move enforcement for `colorVertex`. These tests lock that contract.
 describe('cube-coloring isAllowedStep', () => {
   const empty = (): Board => generateStartBoard();

--- a/src/components/games/cube-coloring/helpers.ts
+++ b/src/components/games/cube-coloring/helpers.ts
@@ -5,7 +5,11 @@ export type Board = string[]
 export const generateStartBoard = (): Board => Array(8).fill('');
 export const isColored = (board: Board, i: number) => board[i] !== '';
 
+// The logic-side palette; `nodeColors` in cube-coloring.tsx adds the styling.
+export const colors = ['red', 'blue', 'yellow'];
+
 export const isAllowedStep = (board: Board, vertex, color) => {
+  if (!colors.includes(color)) return false;
   if (isColored(board, vertex)) return false;
   return every(neighbours[vertex], i => (!isColored(board, i)) || board[i] !== color);
 };

--- a/src/components/strategy-game-factory/index.ts
+++ b/src/components/strategy-game-factory/index.ts
@@ -2,7 +2,7 @@ export { strategyGameFactory, dummyEvents } from './strategy-game-factory';
 export type { Presentation, Gameplay, StrategyGameConfig } from './strategy-game-factory';
 export type {
   Phase, Mode, Ctx, Events,
-  MoveResult, MoveFunction, MoveValidator, GameMoves,
+  MoveResult, MoveFunction, MoveValidator, MoveDefinition, GameMoves,
   StrategyArgs, BoardClientProps,
   Variant, VariantInput
 } from './types';

--- a/src/components/strategy-game-factory/index.ts
+++ b/src/components/strategy-game-factory/index.ts
@@ -2,7 +2,7 @@ export { strategyGameFactory, dummyEvents } from './strategy-game-factory';
 export type { Presentation, Gameplay, StrategyGameConfig } from './strategy-game-factory';
 export type {
   Phase, Mode, Ctx, Events,
-  MoveResult, MoveFunction, GameMoves,
+  MoveResult, MoveFunction, MoveValidator, GameMoves,
   StrategyArgs, BoardClientProps,
   Variant, VariantInput
 } from './types';

--- a/src/components/strategy-game-factory/index.ts
+++ b/src/components/strategy-game-factory/index.ts
@@ -1,8 +1,8 @@
 export { strategyGameFactory, dummyEvents } from './strategy-game-factory';
-export type { Presentation, Gameplay, StrategyGameConfig } from './strategy-game-factory';
+export type { Presentation, StrategyGameConfig } from './strategy-game-factory';
 export type {
   Phase, Mode, Ctx, Events,
-  MoveResult, MoveFunction, MoveDefinition, GameMoves,
+  MoveResult, MoveFunction, MoveDefinition, Gameplay, GameMoves,
   StrategyArgs, BoardClientProps,
   Variant, VariantInput
 } from './types';

--- a/src/components/strategy-game-factory/index.ts
+++ b/src/components/strategy-game-factory/index.ts
@@ -2,7 +2,7 @@ export { strategyGameFactory, dummyEvents } from './strategy-game-factory';
 export type { Presentation, Gameplay, StrategyGameConfig } from './strategy-game-factory';
 export type {
   Phase, Mode, Ctx, Events,
-  MoveResult, MoveFunction, MoveValidator, MoveDefinition, GameMoves,
+  MoveResult, MoveFunction, MoveDefinition, GameMoves,
   StrategyArgs, BoardClientProps,
   Variant, VariantInput
 } from './types';

--- a/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
@@ -510,8 +510,8 @@ describe('move validate enforcement', () => {
         <button data-testid="legal-btn" onClick={() => moves.guarded(board, 'ok')}>legal</button>
         <button data-testid="illegal-btn" onClick={() => moves.guarded(board, 'bad')}>illegal</button>
         <span data-testid="board">{board.join(',')}</span>
-        <span data-testid="can-ok">{String(moves.guarded.validate!(board, 'ok'))}</span>
-        <span data-testid="can-bad">{String(moves.guarded.validate!(board, 'bad'))}</span>
+        <span data-testid="can-ok">{String(moves.guarded.isAllowed!(board, 'ok'))}</span>
+        <span data-testid="can-bad">{String(moves.guarded.isAllowed!(board, 'bad'))}</span>
       </>
     ),
     gameplay: {
@@ -552,8 +552,10 @@ describe('move validate enforcement', () => {
     }
   });
 
-  it('exposes the validator on the wrapped move with ctx bound, for BoardClient use', () => {
+  it('exposes isAllowed on the wrapped move: turn ownership AND the validator, ctx bound', () => {
     const { getByTestId } = renderGame(guardedConfig());
+    // outside the play phase nothing is dispatchable, even with legal args
+    expect(getByTestId('can-ok').textContent).toBe('false');
     fireEvent.click(getByTestId('role-btn-0'));
     expect(getByTestId('can-ok').textContent).toBe('true');
     expect(getByTestId('can-bad').textContent).toBe('false');

--- a/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
@@ -569,51 +569,61 @@ describe('move validate enforcement', () => {
     expect((getByTestId('move-btn') as HTMLButtonElement).disabled).toBe(true); // bot's turn now
   });
 
-  it('validates a bot-chained second move against current turnState, not a stale render', () => {
-    // Mirrors the coins-in-3-piles bots: a two-phase turn chained via setTimeout
-    // on the move wrappers captured when the bot's turn started. The phase-2
-    // validator reads ctx.turnState, which phase 1 just set — the engine must
-    // judge it against the current state, not the render the wrappers came from.
-    vi.useFakeTimers();
-    try {
-      const config = makeConfig({
-        BoardClient: ({ board }: BoardClientProps<Board>) => (
-          <span data-testid="board">{board.join(',')}</span>
-        ),
-        gameplay: {
-          moves: {
-            phase1: {
-              validate: (_board: Board, { ctx }: { ctx: Ctx }) => ctx.turnState === null,
-              apply: (board: Board, { events }: { events: Events }) => {
-                events.setTurnState({ removedCoinValue: 3 });
-                return { nextBoard: [...board, 'p1'] };
-              }
-            },
-            phase2: {
-              validate: (_board: Board, { ctx }: { ctx: Ctx }) => ctx.turnState !== null,
-              apply: (board: Board, { events }: { events: Events }) => {
-                events.endTurn();
-                events.setTurnState(null);
-                return { nextBoard: [...board, 'p2'] };
-              }
-            }
+  // Mirrors the coins-in-3-piles bots: a two-phase turn chained via setTimeout
+  // on the move wrappers captured when the bot's turn started. The phase-2
+  // validator reads ctx.turnState, which phase 1 just set — the engine must
+  // judge it against the current game state, not the render the wrappers came
+  // from. The 0-delay variant (smartBotStrategy's "place back nothing" branch)
+  // is the harshest case: phase 2 dispatches before React re-renders at all.
+  const twoPhaseBotConfig = (chainDelayMs: number) => makeConfig({
+    BoardClient: ({ board }: BoardClientProps<Board>) => (
+      <span data-testid="board">{board.join(',')}</span>
+    ),
+    gameplay: {
+      moves: {
+        phase1: {
+          validate: (_board: Board, { ctx }: { ctx: Ctx }) => ctx.turnState === null,
+          apply: (board: Board, { events }: { events: Events }) => {
+            events.setTurnState({ removedCoinValue: 3 });
+            return { nextBoard: [...board, 'p1'] };
           }
         },
-        botStrategy: ({ board, moves }) => {
-          const { nextBoard } = moves.phase1(board);
-          setTimeout(() => { moves.phase2(nextBoard); }, 750);
+        phase2: {
+          validate: (_board: Board, { ctx }: { ctx: Ctx }) => ctx.turnState !== null,
+          apply: (board: Board, { events }: { events: Events }) => {
+            events.endTurn();
+            events.setTurnState(null);
+            return { nextBoard: [...board, 'p2'] };
+          }
         }
-      });
-      const { getByTestId } = renderGame(config);
+      }
+    },
+    botStrategy: ({ board, moves }) => {
+      const { nextBoard } = moves.phase1(board);
+      setTimeout(() => { moves.phase2(nextBoard); }, chainDelayMs);
+    }
+  });
+
+  const playTwoPhaseBotTurn = (chainDelayMs: number) => {
+    vi.useFakeTimers();
+    try {
+      const { getByTestId } = renderGame(twoPhaseBotConfig(chainDelayMs));
       fireEvent.click(getByTestId('role-btn-1')); // human is 2nd player → bot moves first
       act(() => { vi.advanceTimersByTime(1500); }); // bot "thinking" delay → phase1
-      expect(getByTestId('board').textContent).toBe('initial,p1');
-      act(() => { vi.advanceTimersByTime(750); }); // bot's chained phase2 — must not be rejected
-      expect(getByTestId('board').textContent).toBe('initial,p1,p2');
+      act(() => { vi.advanceTimersByTime(750); }); // the chained phase2 — must not be rejected
+      return getByTestId('board').textContent;
     } finally {
       vi.clearAllTimers();
       vi.useRealTimers();
     }
+  };
+
+  it('validates a bot-chained second move against current turnState, not a stale render', () => {
+    expect(playTwoPhaseBotTurn(750)).toBe('initial,p1,p2');
+  });
+
+  it('validates a 0-delay chained second move dispatched before React re-renders', () => {
+    expect(playTwoPhaseBotTurn(0)).toBe('initial,p1,p2');
   });
 
   describe('in production (import.meta.env.DEV = false)', () => {

--- a/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
@@ -503,21 +503,23 @@ describe('umami game-finished event', () => {
   });
 });
 
-describe('moveValidators enforcement', () => {
+describe('move validate enforcement', () => {
   const guardedConfig = () => makeConfig({
     BoardClient: ({ board, moves }: BoardClientProps<Board>) => (
       <>
         <button data-testid="legal-btn" onClick={() => moves.guarded(board, 'ok')}>legal</button>
         <button data-testid="illegal-btn" onClick={() => moves.guarded(board, 'bad')}>illegal</button>
         <span data-testid="board">{board.join(',')}</span>
+        <span data-testid="can-ok">{String(moves.guarded.validate!(board, 'ok'))}</span>
+        <span data-testid="can-bad">{String(moves.guarded.validate!(board, 'bad'))}</span>
       </>
     ),
     gameplay: {
       moves: {
-        guarded: (board: Board, _meta: { events: Events }, arg: string) => ({ nextBoard: [...board, arg] })
-      },
-      moveValidators: {
-        guarded: (_board: Board, _meta: { ctx: Ctx }, arg: string) => arg === 'ok'
+        guarded: {
+          apply: (board: Board, _meta: { events: Events }, arg: string) => ({ nextBoard: [...board, arg] }),
+          validate: (_board: Board, _meta: { ctx: Ctx }, arg: string) => arg === 'ok'
+        }
       }
     }
   });
@@ -550,8 +552,15 @@ describe('moveValidators enforcement', () => {
     }
   });
 
-  it('runs a move unchanged when no validator is registered for it', () => {
-    // defaultGameplay registers no validators, so mainMove applies + endTurn as before
+  it('exposes the validator on the wrapped move with ctx bound, for BoardClient use', () => {
+    const { getByTestId } = renderGame(guardedConfig());
+    fireEvent.click(getByTestId('role-btn-0'));
+    expect(getByTestId('can-ok').textContent).toBe('true');
+    expect(getByTestId('can-bad').textContent).toBe('false');
+  });
+
+  it('runs a plain-function (shorthand) move unchanged — no validator', () => {
+    // defaultGameplay uses the function shorthand, so mainMove applies + endTurn as before
     const { getByTestId } = renderGame(ctxAwareConfig());
     fireEvent.click(getByTestId('role-btn-0'));
     fireEvent.click(getByTestId('move-btn'));

--- a/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 import { render, fireEvent, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
-import { strategyGameFactory, type StrategyGameConfig, type Gameplay } from './strategy-game-factory';
-import type { BoardClientProps, Ctx, Events, GameMoves } from './types';
+import { strategyGameFactory, type StrategyGameConfig } from './strategy-game-factory';
+import type { BoardClientProps, Ctx, Events, Gameplay, GameMoves } from './types';
 
 type Board = string[];
 

--- a/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
@@ -2,7 +2,7 @@
 import { render, fireEvent, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { strategyGameFactory, type StrategyGameConfig } from './strategy-game-factory';
-import type { BoardClientProps, Ctx, Events, Gameplay, GameMoves } from './types';
+import type { BoardClientProps, Ctx, Events, Gameplay, GameMoves, StrategyArgs } from './types';
 
 type Board = string[];
 
@@ -40,7 +40,7 @@ const makeConfig = ({
 }: {
   BoardClient?: StrategyGameConfig<Board>['BoardClient']
   gameplay?: Gameplay<Board>
-  botStrategy?: () => void
+  botStrategy?: (args: StrategyArgs<Board>) => void
 } = {}): StrategyGameConfig<Board> => ({
   presentation: { rule: <></>, getPlayerStepDescription: () => '' },
   BoardClient,
@@ -567,6 +567,53 @@ describe('move validate enforcement', () => {
     fireEvent.click(getByTestId('role-btn-0'));
     fireEvent.click(getByTestId('move-btn'));
     expect((getByTestId('move-btn') as HTMLButtonElement).disabled).toBe(true); // bot's turn now
+  });
+
+  it('validates a bot-chained second move against current turnState, not a stale render', () => {
+    // Mirrors the coins-in-3-piles bots: a two-phase turn chained via setTimeout
+    // on the move wrappers captured when the bot's turn started. The phase-2
+    // validator reads ctx.turnState, which phase 1 just set — the engine must
+    // judge it against the current state, not the render the wrappers came from.
+    vi.useFakeTimers();
+    try {
+      const config = makeConfig({
+        BoardClient: ({ board }: BoardClientProps<Board>) => (
+          <span data-testid="board">{board.join(',')}</span>
+        ),
+        gameplay: {
+          moves: {
+            phase1: {
+              validate: (_board: Board, { ctx }: { ctx: Ctx }) => ctx.turnState === null,
+              apply: (board: Board, { events }: { events: Events }) => {
+                events.setTurnState({ removedCoinValue: 3 });
+                return { nextBoard: [...board, 'p1'] };
+              }
+            },
+            phase2: {
+              validate: (_board: Board, { ctx }: { ctx: Ctx }) => ctx.turnState !== null,
+              apply: (board: Board, { events }: { events: Events }) => {
+                events.endTurn();
+                events.setTurnState(null);
+                return { nextBoard: [...board, 'p2'] };
+              }
+            }
+          }
+        },
+        botStrategy: ({ board, moves }) => {
+          const { nextBoard } = moves.phase1(board);
+          setTimeout(() => { moves.phase2(nextBoard); }, 750);
+        }
+      });
+      const { getByTestId } = renderGame(config);
+      fireEvent.click(getByTestId('role-btn-1')); // human is 2nd player → bot moves first
+      act(() => { vi.advanceTimersByTime(1500); }); // bot "thinking" delay → phase1
+      expect(getByTestId('board').textContent).toBe('initial,p1');
+      act(() => { vi.advanceTimersByTime(750); }); // bot's chained phase2 — must not be rejected
+      expect(getByTestId('board').textContent).toBe('initial,p1,p2');
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
   });
 
   describe('in production (import.meta.env.DEV = false)', () => {

--- a/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
@@ -502,3 +502,86 @@ describe('umami game-finished event', () => {
     expect(lastEvent()[1]).not.toHaveProperty('result');
   });
 });
+
+describe('moveValidators enforcement', () => {
+  const guardedConfig = () => makeConfig({
+    BoardClient: ({ board, moves }: BoardClientProps<Board>) => (
+      <>
+        <button data-testid="legal-btn" onClick={() => moves.guarded(board, 'ok')}>legal</button>
+        <button data-testid="illegal-btn" onClick={() => moves.guarded(board, 'bad')}>illegal</button>
+        <span data-testid="board">{board.join(',')}</span>
+      </>
+    ),
+    gameplay: {
+      moves: {
+        guarded: (board: Board, _meta: { events: Events }, arg: string) => ({ nextBoard: [...board, arg] })
+      },
+      moveValidators: {
+        guarded: (_board: Board, _meta: { ctx: Ctx }, arg: string) => arg === 'ok'
+      }
+    }
+  });
+
+  it('applies a move whose args pass its validator', () => {
+    const { getByTestId } = renderGame(guardedConfig());
+    fireEvent.click(getByTestId('role-btn-0'));
+    fireEvent.click(getByTestId('legal-btn'));
+    expect(getByTestId('board').textContent).toBe('initial,ok');
+  });
+
+  it('throws a loud error in dev when a move fails its validator', () => {
+    // React 19 does not propagate an event-handler throw back to fireEvent; it
+    // reports it on the global `error` event. Capture that (and preventDefault so
+    // vitest does not flag it as an unhandled error).
+    const caught: string[] = [];
+    const onError = (event: ErrorEvent) => {
+      caught.push(event.error?.message ?? event.message);
+      event.preventDefault();
+    };
+    window.addEventListener('error', onError);
+    try {
+      const { getByTestId } = renderGame(guardedConfig());
+      fireEvent.click(getByTestId('role-btn-0'));
+      fireEvent.click(getByTestId('illegal-btn'));
+      expect(caught.some(message => /illegal move/.test(message))).toBe(true);
+      expect(getByTestId('board').textContent).toBe('initial'); // threw before touching the board
+    } finally {
+      window.removeEventListener('error', onError);
+    }
+  });
+
+  it('runs a move unchanged when no validator is registered for it', () => {
+    // defaultGameplay registers no validators, so mainMove applies + endTurn as before
+    const { getByTestId } = renderGame(ctxAwareConfig());
+    fireEvent.click(getByTestId('role-btn-0'));
+    fireEvent.click(getByTestId('move-btn'));
+    expect((getByTestId('move-btn') as HTMLButtonElement).disabled).toBe(true); // bot's turn now
+  });
+
+  describe('in production (import.meta.env.DEV = false)', () => {
+    beforeEach(() => { vi.stubEnv('DEV', false); });
+    afterEach(() => { vi.unstubAllEnvs(); });
+
+    it('does not throw and leaves the board unchanged on an illegal move', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { getByTestId } = renderGame(guardedConfig());
+      fireEvent.click(getByTestId('role-btn-0'));
+      fireEvent.click(getByTestId('illegal-btn'));
+      expect(getByTestId('board').textContent).toBe('initial'); // no-op, not corrupted
+      expect(warn).toHaveBeenCalled();
+      warn.mockRestore();
+    });
+
+    it('reports an illegal-move umami event', () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const track = vi.fn();
+      window.umami = { track: track as NonNullable<Window['umami']>['track'] };
+      const { getByTestId } = renderGame(guardedConfig());
+      fireEvent.click(getByTestId('role-btn-0'));
+      fireEvent.click(getByTestId('illegal-btn'));
+      expect(track).toHaveBeenCalledWith('illegal-move', expect.objectContaining({ move: 'guarded' }));
+      delete window.umami;
+      vi.restoreAllMocks();
+    });
+  });
+});

--- a/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
@@ -137,6 +137,7 @@ describe('strategyGameFactory endOfTurnMove', () => {
     };
 
     const { getByTestId } = renderGame(minimalConfig({ moves, endOfTurnMove: 'autoMove' }));
+    fireEvent.click(getByTestId('role-btn-0'));
     fireEvent.click(getByTestId('move-btn'));
 
     expect(autoMove).not.toHaveBeenCalled();
@@ -157,6 +158,7 @@ describe('strategyGameFactory endOfTurnMove', () => {
     };
 
     const { getByTestId } = renderGame(minimalConfig({ moves, endOfTurnMove: 'autoMove' }));
+    fireEvent.click(getByTestId('role-btn-0'));
     fireEvent.click(getByTestId('move-btn'));
     act(() => { vi.advanceTimersByTime(750); });
 
@@ -504,11 +506,12 @@ describe('umami game-finished event', () => {
 });
 
 describe('move validate enforcement', () => {
-  const guardedConfig = () => makeConfig({
+  const guardedConfig = (botStrategy: () => void = () => {}) => makeConfig({
     BoardClient: ({ board, moves }: BoardClientProps<Board>) => (
       <>
         <button data-testid="legal-btn" onClick={() => moves.guarded(board, 'ok')}>legal</button>
         <button data-testid="illegal-btn" onClick={() => moves.guarded(board, 'bad')}>illegal</button>
+        <button data-testid="hand-over-btn" onClick={() => moves.handOver(board)}>hand over</button>
         <span data-testid="board">{board.join(',')}</span>
         <span data-testid="can-ok">{String(moves.guarded.isAllowed!(board, 'ok'))}</span>
         <span data-testid="can-bad">{String(moves.guarded.isAllowed!(board, 'bad'))}</span>
@@ -519,36 +522,56 @@ describe('move validate enforcement', () => {
         guarded: {
           apply: (board: Board, _meta: { events: Events }, arg: string) => ({ nextBoard: [...board, arg] }),
           validate: (_board: Board, _meta: { ctx: Ctx }, arg: string) => arg === 'ok'
+        },
+        handOver: (board: Board, { events }: { events: Events }) => {
+          events.endTurn();
+          return { nextBoard: board };
         }
       }
-    }
+    },
+    botStrategy
   });
 
-  it('applies a move whose args pass its validator', () => {
+  it('applies a client dispatch whose args pass its validator', () => {
     const { getByTestId } = renderGame(guardedConfig());
     fireEvent.click(getByTestId('role-btn-0'));
     fireEvent.click(getByTestId('legal-btn'));
     expect(getByTestId('board').textContent).toBe('initial,ok');
   });
 
-  it('throws a loud error in dev when a move fails its validator', () => {
-    // React 19 does not propagate an event-handler throw back to fireEvent; it
-    // reports it on the global `error` event. Capture that (and preventDefault so
-    // vitest does not flag it as an unhandled error).
-    const caught: string[] = [];
-    const onError = (event: ErrorEvent) => {
-      caught.push(event.error?.message ?? event.message);
-      event.preventDefault();
-    };
-    window.addEventListener('error', onError);
+  it('silently ignores a client dispatch whose args fail the validator', () => {
+    const { getByTestId } = renderGame(guardedConfig());
+    fireEvent.click(getByTestId('role-btn-0'));
+    fireEvent.click(getByTestId('illegal-btn')); // must not throw
+    expect(getByTestId('board').textContent).toBe('initial');
+  });
+
+  it('silently ignores a client dispatch when it is not the client turn', () => {
+    const { getByTestId } = renderGame(guardedConfig());
+    fireEvent.click(getByTestId('role-btn-0'));
+    fireEvent.click(getByTestId('hand-over-btn')); // endTurn → bot's turn
+    fireEvent.click(getByTestId('legal-btn')); // legal args, wrong turn
+    expect(getByTestId('board').textContent).toBe('initial');
+  });
+
+  it('silently ignores a client dispatch before the game starts', () => {
+    const { getByTestId } = renderGame(guardedConfig());
+    fireEvent.click(getByTestId('legal-btn'));
+    expect(getByTestId('board').textContent).toBe('initial');
+  });
+
+  it('throws a loud error in dev when a bot dispatches a move that fails its validator', () => {
+    vi.useFakeTimers();
     try {
-      const { getByTestId } = renderGame(guardedConfig());
+      const botStrategy = vi.fn().mockImplementation((args: any) => { args.moves.guarded(args.board, 'bad'); });
+      const { getByTestId } = renderGame(guardedConfig(botStrategy));
       fireEvent.click(getByTestId('role-btn-0'));
-      fireEvent.click(getByTestId('illegal-btn'));
-      expect(caught.some(message => /illegal move/.test(message))).toBe(true);
+      fireEvent.click(getByTestId('hand-over-btn')); // → bot's turn
+      expect(() => act(() => { vi.advanceTimersByTime(1500); })).toThrow(/illegal move/);
       expect(getByTestId('board').textContent).toBe('initial'); // threw before touching the board
     } finally {
-      window.removeEventListener('error', onError);
+      vi.clearAllTimers();
+      vi.useRealTimers();
     }
   });
 
@@ -627,14 +650,18 @@ describe('move validate enforcement', () => {
   });
 
   describe('in production (import.meta.env.DEV = false)', () => {
-    beforeEach(() => { vi.stubEnv('DEV', false); });
-    afterEach(() => { vi.unstubAllEnvs(); });
+    beforeEach(() => { vi.stubEnv('DEV', false); vi.useFakeTimers(); });
+    afterEach(() => { vi.clearAllTimers(); vi.useRealTimers(); vi.unstubAllEnvs(); });
 
-    it('does not throw and leaves the board unchanged on an illegal move', () => {
+    const illegalBotStrategy = () =>
+      vi.fn().mockImplementation((args: any) => { args.moves.guarded(args.board, 'bad'); });
+
+    it('does not throw and leaves the board unchanged on an illegal bot move', () => {
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-      const { getByTestId } = renderGame(guardedConfig());
+      const { getByTestId } = renderGame(guardedConfig(illegalBotStrategy()));
       fireEvent.click(getByTestId('role-btn-0'));
-      fireEvent.click(getByTestId('illegal-btn'));
+      fireEvent.click(getByTestId('hand-over-btn')); // → bot's turn
+      act(() => { vi.advanceTimersByTime(1500); }); // bot dispatches 'bad' — must not throw
       expect(getByTestId('board').textContent).toBe('initial'); // no-op, not corrupted
       expect(warn).toHaveBeenCalled();
       warn.mockRestore();
@@ -644,9 +671,10 @@ describe('move validate enforcement', () => {
       vi.spyOn(console, 'warn').mockImplementation(() => {});
       const track = vi.fn();
       window.umami = { track: track as NonNullable<Window['umami']>['track'] };
-      const { getByTestId } = renderGame(guardedConfig());
+      const { getByTestId } = renderGame(guardedConfig(illegalBotStrategy()));
       fireEvent.click(getByTestId('role-btn-0'));
-      fireEvent.click(getByTestId('illegal-btn'));
+      fireEvent.click(getByTestId('hand-over-btn'));
+      act(() => { vi.advanceTimersByTime(1500); });
       expect(track).toHaveBeenCalledWith('illegal-move', expect.objectContaining({ move: 'guarded' }));
       delete window.umami;
       vi.restoreAllMocks();

--- a/src/components/strategy-game-factory/strategy-game-factory.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.tsx
@@ -243,7 +243,13 @@ export const strategyGameFactory = <TBoard,>({
     const events: Events = {
       endTurn,
       endGame,
-      setTurnState
+      // Also patch turnState onto ctxRef synchronously: a chained dispatch can
+      // validate before React re-renders (e.g. a bot's 0-delay setTimeout),
+      // when the render-synced ref would still hold the previous turnState.
+      setTurnState: (state) => {
+        setTurnState(state);
+        ctxRef.current = { ...ctxRef.current, turnState: state };
+      }
     };
 
     wrappedGameMoves = mapValues(normalizedMoves, ({ apply, validate }, name) => {

--- a/src/components/strategy-game-factory/strategy-game-factory.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.tsx
@@ -113,7 +113,7 @@ export const strategyGameFactory = <TBoard,>({
       doMove: () => MoveResult<TBoard>
     ): MoveResult<TBoard> => {
       const validator = normalizedMoves[name]!.validate;
-      if (validator && !validator(moveBoard, { ctx }, ...args)) {
+      if (validator && !validator(moveBoard, { ctx: ctxRef.current }, ...args)) {
         reportIllegalMove(name, moveBoard, args);
         return { nextBoard: moveBoard };
       }
@@ -231,6 +231,14 @@ export const strategyGameFactory = <TBoard,>({
       winnerIndex,
       moveCount
     };
+
+    // Bots chain the moves of a multi-move turn through setTimeout on the
+    // wrappers captured when their turn started, so by the time the second
+    // move dispatches, the render-scoped `ctx` those wrappers close over is
+    // stale (e.g. `turnState` still null). Validators must judge the move
+    // against the *current* game state, so they read `ctx` through this ref.
+    const ctxRef = useRef(ctx);
+    ctxRef.current = ctx;
 
     const events: Events = {
       endTurn,

--- a/src/components/strategy-game-factory/strategy-game-factory.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.tsx
@@ -252,9 +252,13 @@ export const strategyGameFactory = <TBoard,>({
       const wrapped: GameMoves<TBoard>[string] = (board: TBoard, ...args: unknown[]) =>
         moveWrapper(name, board, args, () => apply(board, { ctx, events }, ...args));
       if (validate) {
-        // Expose the validator with `ctx` bound, so the BoardClient can check
-        // legality as `moves.x.validate(board, ...args)`.
-        wrapped.validate = (board: TBoard, ...args: unknown[]) => validate(board, { ctx }, ...args);
+        // "May the client dispatch this move right now?" — turn ownership plus
+        // the move's own legality, with `ctx` bound, so the BoardClient drives
+        // `disabled` as `moves.x.isAllowed(board, ...args)` with no boilerplate.
+        // (Bots enumerate legal moves via the raw `validate`/helpers instead:
+        // during the bot's turn `isClientMoveAllowed` is false by design.)
+        wrapped.isAllowed = (board: TBoard, ...args: unknown[]) =>
+          isClientMoveAllowed && validate(board, { ctx }, ...args);
       }
       return wrapped;
     });

--- a/src/components/strategy-game-factory/strategy-game-factory.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.tsx
@@ -10,7 +10,7 @@ import { useLocation } from 'react-router';
 import { useGameStats } from './hooks/use-game-stats';
 import { trackEvent } from '../../tracking';
 import type {
-  Phase, Mode, Ctx, Events, MoveResult, MoveDefinition, GameMoves,
+  Phase, Mode, Ctx, Events, MoveResult, Gameplay, GameMoves,
   BoardClientProps, Variant as DisplayVariant, VariantInput
 } from './types';
 import { resolveVariants } from './helpers/resolve-variants';
@@ -24,16 +24,6 @@ export interface Presentation<TBoard> {
   rule: TranslatableNode
   roleLabels?: [I18nString, I18nString]
   getPlayerStepDescription: (args: { board: TBoard; ctx: Ctx }) => TranslatableNode
-}
-
-export interface Gameplay<TBoard> {
-  // Each move is either a plain apply function (shorthand — always accepted),
-  // or `{ apply, validate? }`. When `validate` is present, the engine rejects
-  // any dispatch whose args fail it (see `moveWrapper`), and exposes it on the
-  // wrapped move (with `ctx` bound) so the BoardClient can drive `disabled`
-  // state from the same predicate.
-  moves: Record<string, MoveDefinition<TBoard>>
-  endOfTurnMove?: string
 }
 
 export type StrategyGameConfig<TBoard> = {

--- a/src/components/strategy-game-factory/strategy-game-factory.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.tsx
@@ -10,7 +10,7 @@ import { useLocation } from 'react-router';
 import { useGameStats } from './hooks/use-game-stats';
 import { trackEvent } from '../../tracking';
 import type {
-  Phase, Mode, Ctx, Events, MoveResult, MoveFunction, MoveValidator, GameMoves,
+  Phase, Mode, Ctx, Events, MoveResult, MoveDefinition, GameMoves,
   BoardClientProps, Variant as DisplayVariant, VariantInput
 } from './types';
 import { resolveVariants } from './helpers/resolve-variants';
@@ -27,11 +27,12 @@ export interface Presentation<TBoard> {
 }
 
 export interface Gameplay<TBoard> {
-  moves: Record<string, MoveFunction<TBoard>>
-  // Optional, keyed by move name. When present for a move, the engine rejects
-  // any dispatch whose args fail the predicate (see `moveWrapper`). Missing key
-  // = always legal, so games that predate this field keep working unchanged.
-  moveValidators?: Record<string, MoveValidator<TBoard>>
+  // Each move is either a plain apply function (shorthand — always accepted),
+  // or `{ apply, validate? }`. When `validate` is present, the engine rejects
+  // any dispatch whose args fail it (see `moveWrapper`), and exposes it on the
+  // wrapped move (with `ctx` bound) so the BoardClient can drive `disabled`
+  // state from the same predicate.
+  moves: Record<string, MoveDefinition<TBoard>>
   endOfTurnMove?: string
 }
 
@@ -49,8 +50,11 @@ export const strategyGameFactory = <TBoard,>({
   variants
 }: StrategyGameConfig<TBoard>) => {
   const { rule, roleLabels, getPlayerStepDescription } = presentation;
-  const { moves, moveValidators, endOfTurnMove } = gameplay;
+  const { moves, endOfTurnMove } = gameplay;
   const { defaultVariantIndex, defaultVariant, resolvedVariants } = resolveVariants(variants);
+  // Normalize the shorthand (plain function = apply with no validator) so the
+  // rest of the engine deals with a single long-form shape.
+  const normalizedMoves = mapValues(moves, (m) => typeof m === 'function' ? { apply: m } : m);
 
   return () => {
     const { t } = useTranslation();
@@ -118,7 +122,7 @@ export const strategyGameFactory = <TBoard,>({
       args: unknown[],
       doMove: () => MoveResult<TBoard>
     ): MoveResult<TBoard> => {
-      const validator = moveValidators?.[name];
+      const validator = normalizedMoves[name]!.validate;
       if (validator && !validator(moveBoard, { ctx }, ...args)) {
         reportIllegalMove(name, moveBoard, args);
         return { nextBoard: moveBoard };
@@ -244,11 +248,16 @@ export const strategyGameFactory = <TBoard,>({
       setTurnState
     };
 
-    wrappedGameMoves = mapValues(
-      moves,
-      (f, name) => (board: TBoard, ...args: unknown[]) =>
-        moveWrapper(name, board, args, () => f(board, { ctx, events }, ...args))
-    ) as GameMoves<TBoard>;
+    wrappedGameMoves = mapValues(normalizedMoves, ({ apply, validate }, name) => {
+      const wrapped: GameMoves<TBoard>[string] = (board: TBoard, ...args: unknown[]) =>
+        moveWrapper(name, board, args, () => apply(board, { ctx, events }, ...args));
+      if (validate) {
+        // Expose the validator with `ctx` bound, so the BoardClient can check
+        // legality as `moves.x.validate(board, ...args)`.
+        wrapped.validate = (board: TBoard, ...args: unknown[]) => validate(board, { ctx }, ...args);
+      }
+      return wrapped;
+    });
 
     const doBotTurn = () => {
       const { botStrategy } = activeVariant;

--- a/src/components/strategy-game-factory/strategy-game-factory.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.tsx
@@ -252,19 +252,27 @@ export const strategyGameFactory = <TBoard,>({
       }
     };
 
-    wrappedGameMoves = mapValues(normalizedMoves, ({ apply, validate }, name) => {
+    wrappedGameMoves = mapValues(normalizedMoves, ({ apply }, name) => {
       const wrapped: GameMoves<TBoard>[string] = (board: TBoard, ...args: unknown[]) =>
         moveWrapper(name, board, args, () => apply(board, { ctx, events }, ...args));
-      if (validate) {
-        // "May the client dispatch this move right now?" — turn ownership plus
-        // the move's own legality, with `ctx` bound, so the BoardClient drives
-        // `disabled` as `moves.x.isAllowed(board, ...args)` with no boilerplate.
-        // (Bots enumerate legal moves via the raw `validate`/helpers instead:
-        // during the bot's turn `isClientMoveAllowed` is false by design.)
-        wrapped.isAllowed = (board: TBoard, ...args: unknown[]) =>
-          isClientMoveAllowed && validate(board, { ctx }, ...args);
-      }
       return wrapped;
+    });
+
+    // What the BoardClient receives: the same moves, but a dispatch is silently
+    // ignored unless `isAllowed` holds — turn ownership (ctx.isClientMoveAllowed)
+    // AND the move's validator. This engine-side gate replaces per-handler
+    // `if (!allowed) return` guards, and also covers browsers that fire pointer
+    // events on disabled buttons. Bots and the auto `endOfTurnMove` dispatch use
+    // `wrappedGameMoves` instead: there an illegal move is a bug, and the
+    // validator fails loudly (see `reportIllegalMove`).
+    const clientGameMoves: GameMoves<TBoard> = mapValues(normalizedMoves, ({ validate }, name) => {
+      const isAllowed = (board: TBoard, ...args: unknown[]) =>
+        ctxRef.current.isClientMoveAllowed
+          && (!validate || validate(board, { ctx: ctxRef.current }, ...args));
+      const clientWrapped: GameMoves<TBoard>[string] = (board: TBoard, ...args: unknown[]) =>
+        isAllowed(board, ...args) ? wrappedGameMoves[name]!(board, ...args) : { nextBoard: board };
+      clientWrapped.isAllowed = isAllowed;
+      return clientWrapped;
     });
 
     const doBotTurn = () => {
@@ -291,7 +299,7 @@ export const strategyGameFactory = <TBoard,>({
               board={board}
               ctx={ctx}
               events={events}
-              moves={wrappedGameMoves}
+              moves={clientGameMoves}
             />
             <GameSidebar
               roleLabels={roleLabels}

--- a/src/components/strategy-game-factory/strategy-game-factory.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.tsx
@@ -10,7 +10,7 @@ import { useLocation } from 'react-router';
 import { useGameStats } from './hooks/use-game-stats';
 import { trackEvent } from '../../tracking';
 import type {
-  Phase, Mode, Ctx, Events, MoveResult, MoveFunction, GameMoves,
+  Phase, Mode, Ctx, Events, MoveResult, MoveFunction, MoveValidator, GameMoves,
   BoardClientProps, Variant as DisplayVariant, VariantInput
 } from './types';
 import { resolveVariants } from './helpers/resolve-variants';
@@ -28,6 +28,10 @@ export interface Presentation<TBoard> {
 
 export interface Gameplay<TBoard> {
   moves: Record<string, MoveFunction<TBoard>>
+  // Optional, keyed by move name. When present for a move, the engine rejects
+  // any dispatch whose args fail the predicate (see `moveWrapper`). Missing key
+  // = always legal, so games that predate this field keep working unchanged.
+  moveValidators?: Record<string, MoveValidator<TBoard>>
   endOfTurnMove?: string
 }
 
@@ -45,7 +49,7 @@ export const strategyGameFactory = <TBoard,>({
   variants
 }: StrategyGameConfig<TBoard>) => {
   const { rule, roleLabels, getPlayerStepDescription } = presentation;
-  const { moves, endOfTurnMove } = gameplay;
+  const { moves, moveValidators, endOfTurnMove } = gameplay;
   const { defaultVariantIndex, defaultVariant, resolvedVariants } = resolveVariants(variants);
 
   return () => {
@@ -94,7 +98,31 @@ export const strategyGameFactory = <TBoard,>({
 
     let wrappedGameMoves: GameMoves<TBoard> = {} as GameMoves<TBoard>;
 
-    const moveWrapper = (doMove: () => MoveResult<TBoard>): MoveResult<TBoard> => {
+    // An illegal move should never happen through the UI (buttons are disabled)
+    // or a correct bot, so reaching here means a bug or tampering. In dev we
+    // throw loudly to surface the bug; in prod we fail safe: warn, record it,
+    // and no-op so a stray call can't corrupt the board or white-screen a player.
+    const reportIllegalMove = (name: string, moveBoard: TBoard, args: unknown[]) => {
+      const message = `strategyGameFactory: illegal move ${name}(${JSON.stringify(args)}) `
+        + `rejected on board ${JSON.stringify(moveBoard)}`;
+      if (import.meta.env.DEV) {
+        throw new Error(message);
+      }
+      console.warn(message);
+      trackEvent('illegal-move', { game: gameId, move: name });
+    };
+
+    const moveWrapper = (
+      name: string,
+      moveBoard: TBoard,
+      args: unknown[],
+      doMove: () => MoveResult<TBoard>
+    ): MoveResult<TBoard> => {
+      const validator = moveValidators?.[name];
+      if (validator && !validator(moveBoard, { ctx }, ...args)) {
+        reportIllegalMove(name, moveBoard, args);
+        return { nextBoard: moveBoard };
+      }
       if (!currentTurnHasMovesRef.current) {
         setUndoSnapshot({ board: cloneDeep(board), currentPlayer: currentPlayer!, moveCount });
         currentTurnHasMovesRef.current = true;
@@ -218,7 +246,8 @@ export const strategyGameFactory = <TBoard,>({
 
     wrappedGameMoves = mapValues(
       moves,
-      (f) => (board: TBoard, ...args: unknown[]) => moveWrapper(() => f(board, { ctx, events }, ...args))
+      (f, name) => (board: TBoard, ...args: unknown[]) =>
+        moveWrapper(name, board, args, () => f(board, { ctx, events }, ...args))
     ) as GameMoves<TBoard>;
 
     const doBotTurn = () => {

--- a/src/components/strategy-game-factory/types.ts
+++ b/src/components/strategy-game-factory/types.ts
@@ -38,6 +38,11 @@ type MoveValidator<TBoard> = (
 export type MoveDefinition<TBoard> =
   | MoveFunction<TBoard>
   | { apply: MoveFunction<TBoard>; validate?: MoveValidator<TBoard> }
+export interface Gameplay<TBoard> {
+  moves: Record<string, MoveDefinition<TBoard>>
+  // move name auto-executed (after a delay) following moves returning autoEndOfTurn: true
+  endOfTurnMove?: string
+}
 // Engine-wrapped moves as seen by BoardClient and bots: callable to dispatch.
 // When the move defines `validate`, the wrapped move also exposes
 // `isAllowed(board, ...args)` — `ctx.isClientMoveAllowed` (turn ownership)

--- a/src/components/strategy-game-factory/types.ts
+++ b/src/components/strategy-game-factory/types.ts
@@ -44,11 +44,13 @@ export interface Gameplay<TBoard> {
   endOfTurnMove?: string
 }
 // Engine-wrapped moves as seen by BoardClient and bots: callable to dispatch.
-// When the move defines `validate`, the wrapped move also exposes
-// `isAllowed(board, ...args)` — `ctx.isClientMoveAllowed` (turn ownership)
-// AND the move's `validate`, with `ctx` already bound — which is what the
-// BoardClient's `disabled` state should ask. Not for bots: during the bot's
-// turn `isClientMoveAllowed` is false, so bots use the raw `validate`/helpers.
+// The BoardClient's copy exposes `isAllowed(board, ...args)` on every move —
+// `ctx.isClientMoveAllowed` (turn ownership) AND the move's `validate`, with
+// `ctx` already bound — which is what its `disabled` state should ask; the
+// same check silently gates every client dispatch, so handlers need no
+// `if (!allowed) return` guards. Not for bots: their copy carries no
+// `isAllowed` (during the bot's turn `isClientMoveAllowed` is false), so bots
+// use the raw `validate`/helpers to enumerate legal moves.
 export type GameMoves<TBoard> = Record<
   string,
   ((board: TBoard, ...args: any[]) => MoveResult<TBoard>)

--- a/src/components/strategy-game-factory/types.ts
+++ b/src/components/strategy-game-factory/types.ts
@@ -38,13 +38,16 @@ export type MoveValidator<TBoard> = (
 export type MoveDefinition<TBoard> =
   | MoveFunction<TBoard>
   | { apply: MoveFunction<TBoard>; validate?: MoveValidator<TBoard> }
-// Engine-wrapped moves as seen by BoardClient and bots: callable to dispatch,
-// with `validate` (when defined) exposed with `ctx` already bound, so clients
-// can check legality as `moves.x.validate(board, ...args)`.
+// Engine-wrapped moves as seen by BoardClient and bots: callable to dispatch.
+// When the move defines `validate`, the wrapped move also exposes
+// `isAllowed(board, ...args)` — `ctx.isClientMoveAllowed` (turn ownership)
+// AND the move's `validate`, with `ctx` already bound — which is what the
+// BoardClient's `disabled` state should ask. Not for bots: during the bot's
+// turn `isClientMoveAllowed` is false, so bots use the raw `validate`/helpers.
 export type GameMoves<TBoard> = Record<
   string,
   ((board: TBoard, ...args: any[]) => MoveResult<TBoard>)
-    & { validate?: (board: TBoard, ...args: any[]) => boolean }
+    & { isAllowed?: (board: TBoard, ...args: any[]) => boolean }
 >
 export type StrategyArgs<TBoard> = { board: TBoard; ctx: Ctx; moves: GameMoves<TBoard> }
 export type BoardClientProps<TBoard> = StrategyArgs<TBoard> & { events: Events }

--- a/src/components/strategy-game-factory/types.ts
+++ b/src/components/strategy-game-factory/types.ts
@@ -30,7 +30,7 @@ export type MoveFunction<TBoard> = (
 // `board` + `ctx` (no React, no `events`), the same function drives the UI
 // (button `disabled`), the engine (illegal-move enforcement) and, in the
 // future, an authoritative server-side check.
-export type MoveValidator<TBoard> = (
+type MoveValidator<TBoard> = (
   board: TBoard, meta: { ctx: Ctx }, ...args: any[]
 ) => boolean
 // A move is either a plain apply function (shorthand — always accepted by the

--- a/src/components/strategy-game-factory/types.ts
+++ b/src/components/strategy-game-factory/types.ts
@@ -25,15 +25,27 @@ export type MoveResult<TBoard> = { nextBoard: TBoard; autoEndOfTurn?: boolean }
 export type MoveFunction<TBoard> = (
   board: TBoard, meta: { ctx: Ctx; events: Events }, ...args: any[]
 ) => MoveResult<TBoard>
-// Pure, side-effect-free legality predicate for a single move. Keyed by move
-// name in `gameplay.moveValidators`. Because it depends only on `board` + `ctx`
-// (no React, no `events`), the same function drives the UI (button `disabled`),
-// the engine (illegal-move enforcement) and, in the future, an authoritative
-// server-side check.
+// Pure, side-effect-free legality predicate for a single move, colocated with
+// its `apply` in the long-form move definition. Because it depends only on
+// `board` + `ctx` (no React, no `events`), the same function drives the UI
+// (button `disabled`), the engine (illegal-move enforcement) and, in the
+// future, an authoritative server-side check.
 export type MoveValidator<TBoard> = (
   board: TBoard, meta: { ctx: Ctx }, ...args: any[]
 ) => boolean
-export type GameMoves<TBoard> = Record<string, (board: TBoard, ...args: any[]) => MoveResult<TBoard>>
+// A move is either a plain apply function (shorthand — always accepted by the
+// engine) or a long-form object pairing it with an optional legality validator.
+export type MoveDefinition<TBoard> =
+  | MoveFunction<TBoard>
+  | { apply: MoveFunction<TBoard>; validate?: MoveValidator<TBoard> }
+// Engine-wrapped moves as seen by BoardClient and bots: callable to dispatch,
+// with `validate` (when defined) exposed with `ctx` already bound, so clients
+// can check legality as `moves.x.validate(board, ...args)`.
+export type GameMoves<TBoard> = Record<
+  string,
+  ((board: TBoard, ...args: any[]) => MoveResult<TBoard>)
+    & { validate?: (board: TBoard, ...args: any[]) => boolean }
+>
 export type StrategyArgs<TBoard> = { board: TBoard; ctx: Ctx; moves: GameMoves<TBoard> }
 export type BoardClientProps<TBoard> = StrategyArgs<TBoard> & { events: Events }
 

--- a/src/components/strategy-game-factory/types.ts
+++ b/src/components/strategy-game-factory/types.ts
@@ -25,6 +25,14 @@ export type MoveResult<TBoard> = { nextBoard: TBoard; autoEndOfTurn?: boolean }
 export type MoveFunction<TBoard> = (
   board: TBoard, meta: { ctx: Ctx; events: Events }, ...args: any[]
 ) => MoveResult<TBoard>
+// Pure, side-effect-free legality predicate for a single move. Keyed by move
+// name in `gameplay.moveValidators`. Because it depends only on `board` + `ctx`
+// (no React, no `events`), the same function drives the UI (button `disabled`),
+// the engine (illegal-move enforcement) and, in the future, an authoritative
+// server-side check.
+export type MoveValidator<TBoard> = (
+  board: TBoard, meta: { ctx: Ctx }, ...args: any[]
+) => boolean
 export type GameMoves<TBoard> = Record<string, (board: TBoard, ...args: any[]) => MoveResult<TBoard>>
 export type StrategyArgs<TBoard> = { board: TBoard; ctx: Ctx; moves: GameMoves<TBoard> }
 export type BoardClientProps<TBoard> = StrategyArgs<TBoard> & { events: Events }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "checkJs": false,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals", "vite/client"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
Move functions and the engine previously applied any dispatched move blindly; legality was enforced only in each BoardClient (disabled buttons + early-return guards), duplicated per game. This introduces a dedicated, uniformly applied legality check so the same predicate can drive the UI, the engine, and a future server-side authoritative validation.

- Each entry in `gameplay.moves` is now either the plain apply function (shorthand — always accepted, all pre-existing games unchanged) or a boardgame.io-style long-form `{ apply, validate? }`, colocating the legality predicate with the code it constrains.
- `validate` is a pure `(board, { ctx }, ...args) => boolean` — React-free, so a future server-side authoritative check can run the exact same function.
- The engine enforces it on every dispatch: in dev an illegal move throws loudly; in prod it warns, fires an `illegal-move` analytics event, and no-ops so a stray/tampered call cannot corrupt the board.
- For the UI, the engine exposes `moves.<name>.isAllowed(board, ...args)` on the wrapped move — `ctx.isClientMoveAllowed` (turn ownership) AND `validate`, with `ctx` bound — so BoardClients drive `disabled` state with no gating boilerplate. (Not for bots: during the bot's turn `isClientMoveAllowed` is false by design; bots enumerate legal moves via the raw `validate`/helpers.)
- Migrate two sample games as the pattern: coins-in-3-piles (two-phase turn) and cube-coloring (reuses the existing `isAllowedStep` helper).
- Add engine-enforcement tests and validator unit tests.
- Add `vite/client` to tsconfig types for `import.meta.env` typing.
- Document the long-form move, `validate` and `isAllowed` in AGENTS.md and README.md.

Claude-Session: https://claude.ai/code/session_01BTg7qNQXfvYgYCAbZjFJGV