### PR TITLE
Move legality layer: the 3 pebble-pile take-away games

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -116,6 +116,7 @@
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
@@ -131,6 +132,7 @@
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -246,7 +248,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -295,9 +296,29 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1481,6 +1502,7 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.2.0.tgz",
       "integrity": "sha512-CytIvb6tVOADRngTHGWNxH8LPgO/3hi/BdCEHOf7Qd2GvZVClhVP0Wo/QHzWhpki49Bk0b4VT6xpt3fx8HTSIw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -1500,6 +1522,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -1512,6 +1535,7 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -1525,7 +1549,8 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@testing-library/react": {
       "version": "16.3.2",
@@ -1569,7 +1594,8 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1623,7 +1649,6 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1634,7 +1659,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1684,7 +1708,6 @@
       "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.65.0",
         "@typescript-eslint/types": "8.65.0",
@@ -2028,7 +2051,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2068,6 +2090,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2077,6 +2100,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2092,6 +2116,7 @@
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2161,6 +2186,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2186,6 +2212,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2197,7 +2224,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/compare-versions": {
       "version": "6.1.1",
@@ -2305,6 +2333,7 @@
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2322,7 +2351,8 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/enhanced-resolve": {
       "version": "5.24.3",
@@ -2375,7 +2405,6 @@
       "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -2824,6 +2853,7 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2907,7 +2937,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/jsdom": {
       "version": "29.1.1",
@@ -2915,7 +2946,6 @@
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -3277,6 +3307,7 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3452,7 +3483,6 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3559,7 +3589,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
       "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3569,7 +3598,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
       "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3736,6 +3764,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -3927,7 +3956,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3971,7 +3999,6 @@
       "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",

--- a/src/components/games/single-pile-removal/doubling-reduction/doubling-reduction.tsx
+++ b/src/components/games/single-pile-removal/doubling-reduction/doubling-reduction.tsx
@@ -1,6 +1,6 @@
 import { strategyGameFactory, type Events, type StrategyArgs } from '../../../strategy-game-factory';
 import { range, random, sample, minBy } from 'lodash';
-import { type Board, cap, BoardClient, getPlayerStepDescription } from '../pebble-pile';
+import { type Board, cap, validateTake, BoardClient, getPlayerStepDescription } from '../pebble-pile';
 
 export { cap };
 
@@ -47,12 +47,15 @@ export const chooseSmartTake = (board: Board): number => {
 };
 
 const moves = {
-  take: (board: Board, { events }: { events: Events }, count: number) => {
-    // Next player may take strictly less than twice this take, i.e. up to 2·count − 1.
-    const nextBoard: Board = { stones: board.stones - count, maxTake: 2 * count - 1 };
-    events.endTurn();
-    if (nextBoard.stones === 0) events.endGame(); // mover took the last stone(s) → wins
-    return { nextBoard };
+  take: {
+    validate: validateTake,
+    apply: (board: Board, { events }: { events: Events }, count: number) => {
+      // Next player may take strictly less than twice this take, i.e. up to 2·count − 1.
+      const nextBoard: Board = { stones: board.stones - count, maxTake: 2 * count - 1 };
+      events.endTurn();
+      if (nextBoard.stones === 0) events.endGame(); // mover took the last stone(s) → wins
+      return { nextBoard };
+    }
   }
 };
 

--- a/src/components/games/single-pile-removal/pebble-pile.spec.ts
+++ b/src/components/games/single-pile-removal/pebble-pile.spec.ts
@@ -1,0 +1,45 @@
+import { cap, validateTake, type Board } from './pebble-pile';
+
+const isTakeAllowed = (board: Board, count: number) => validateTake(board, undefined, count);
+
+describe('pebble-pile shared take legality', () => {
+  describe('cap', () => {
+    it('is the per-turn maximum while the pile is larger', () => {
+      expect(cap({ stones: 10, maxTake: 4 })).toBe(4);
+    });
+
+    it('is the pile size once fewer pebbles remain than the maximum', () => {
+      expect(cap({ stones: 3, maxTake: 7 })).toBe(3);
+    });
+  });
+
+  describe('validateTake', () => {
+    it('allows any count between one and the cap', () => {
+      const board: Board = { stones: 10, maxTake: 4 };
+      expect([1, 2, 3, 4].every(count => isTakeAllowed(board, count))).toBe(true);
+    });
+
+    it('rejects taking more than the cap', () => {
+      expect(isTakeAllowed({ stones: 10, maxTake: 4 }, 5)).toBe(false);
+    });
+
+    it('rejects taking more pebbles than the pile holds', () => {
+      expect(isTakeAllowed({ stones: 3, maxTake: 7 }, 4)).toBe(false);
+    });
+
+    it('allows clearing a pile smaller than the cap', () => {
+      expect(isTakeAllowed({ stones: 3, maxTake: 7 }, 3)).toBe(true);
+    });
+
+    it('rejects taking nothing or a negative amount', () => {
+      const board: Board = { stones: 10, maxTake: 4 };
+      expect(isTakeAllowed(board, 0)).toBe(false);
+      expect(isTakeAllowed(board, -1)).toBe(false);
+    });
+
+    it('rejects non-integer counts', () => {
+      expect(isTakeAllowed({ stones: 10, maxTake: 4 }, 1.5)).toBe(false);
+      expect(isTakeAllowed({ stones: 10, maxTake: 4 }, NaN)).toBe(false);
+    });
+  });
+});

--- a/src/components/games/single-pile-removal/pebble-pile.tsx
+++ b/src/components/games/single-pile-removal/pebble-pile.tsx
@@ -12,8 +12,14 @@ export type Board = { stones: number; maxTake: number }
 // The most a player may legally take this turn.
 export const cap = (board: Board): number => Math.min(board.maxTake, board.stones);
 
-const StonePile = ({ board, disabled, onTake, moveCount }: {
-  board: Board; disabled: boolean; onTake: (count: number) => void; moveCount: number
+// A take is legal when it removes a whole number of pebbles, at least one and at
+// most this turn's cap. The three games differ only in how the *next* cap is
+// derived, so they share this one validator.
+export const validateTake = (board: Board, _, count: number): boolean =>
+  Number.isInteger(count) && count >= 1 && count <= cap(board);
+
+const StonePile = ({ board, isTakeAllowed, onTake, moveCount }: {
+  board: Board; isTakeAllowed: (count: number) => boolean; onTake: (count: number) => void; moveCount: number
 }) => {
   const { value, hoverProps } = useHoverPreview<number>(moveCount);
   const previewCount = value ?? 0;
@@ -30,7 +36,7 @@ const StonePile = ({ board, disabled, onTake, moveCount }: {
         // Only selectable pebbles drive the hover preview. Don't rely on the
         // `disabled` attribute to suppress this — some browsers (e.g. Safari)
         // still fire pointer events on disabled buttons.
-        const canSelect = !disabled && (takeCount <= cap(board));
+        const canSelect = isTakeAllowed(takeCount);
         return (
           <button
             key={i}
@@ -61,7 +67,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
       </p>
       <StonePile
         board={board}
-        disabled={!ctx.isClientMoveAllowed}
+        isTakeAllowed={count => moves.take.isAllowed!(board, count)}
         onTake={count => moves.take(board, count)}
         moveCount={ctx.moveCount}
       />

--- a/src/components/games/single-pile-removal/three-more/three-more.tsx
+++ b/src/components/games/single-pile-removal/three-more/three-more.tsx
@@ -1,6 +1,6 @@
 import { strategyGameFactory, type Events, type StrategyArgs } from '../../../strategy-game-factory';
 import { range, random, sample, minBy } from 'lodash';
-import { type Board, cap, BoardClient, getPlayerStepDescription } from '../pebble-pile';
+import { type Board, cap, validateTake, BoardClient, getPlayerStepDescription } from '../pebble-pile';
 
 export { cap };
 
@@ -56,11 +56,14 @@ export const chooseSmartTake = (board: Board): number => {
 };
 
 const moves = {
-  take: (board: Board, { events }: { events: Events }, count: number) => {
-    const nextBoard: Board = { stones: board.stones - count, maxTake: count + INCREMENT };
-    events.endTurn();
-    if (nextBoard.stones === 0) events.endGame(); // mover took the last stone(s) → wins
-    return { nextBoard };
+  take: {
+    validate: validateTake,
+    apply: (board: Board, { events }: { events: Events }, count: number) => {
+      const nextBoard: Board = { stones: board.stones - count, maxTake: count + INCREMENT };
+      events.endTurn();
+      if (nextBoard.stones === 0) events.endGame(); // mover took the last stone(s) → wins
+      return { nextBoard };
+    }
   }
 };
 

--- a/src/components/games/single-pile-removal/waning-stones/waning-stones.tsx
+++ b/src/components/games/single-pile-removal/waning-stones/waning-stones.tsx
@@ -1,6 +1,6 @@
 import { strategyGameFactory, type Events, type StrategyArgs } from '../../../strategy-game-factory';
 import { range, random, sample, minBy } from 'lodash';
-import { type Board, cap, BoardClient, getPlayerStepDescription } from '../pebble-pile';
+import { type Board, cap, validateTake, BoardClient, getPlayerStepDescription } from '../pebble-pile';
 
 export { cap };
 
@@ -33,11 +33,14 @@ export const chooseSmartTake = (board: Board): number => {
 };
 
 const moves = {
-  take: (board: Board, { events }: { events: Events }, count: number) => {
-    const nextBoard: Board = { stones: board.stones - count, maxTake: count };
-    events.endTurn();
-    if (nextBoard.stones === 0) events.endGame(); // mover took the last stone(s) → wins
-    return { nextBoard };
+  take: {
+    validate: validateTake,
+    apply: (board: Board, { events }: { events: Events }, count: number) => {
+      const nextBoard: Board = { stones: board.stones - count, maxTake: count };
+      events.endTurn();
+      if (nextBoard.stones === 0) events.endGame(); // mover took the last stone(s) → wins
+      return { nextBoard };
+    }
   }
 };
 


### PR DESCRIPTION
Batch 1 of the follow-up to #333, which added the per-move `validate` legality layer and migrated two sample games. Each batch is a small group of similar games on its own branch off `main`, reviewable and mergeable independently.

## Games covered

`three-more`, `waning-stones`, `doubling-reduction` — the three single-pile take-away games that share `pebble-pile.tsx`. They differ only in how the *next* turn's cap is derived, so one validator covers all three.

## Changes

- **`pebble-pile.tsx`**: add `validateTake` next to the `cap` helper it already shares — a take is legal when it removes a whole number of pebbles, at least one and at most `cap(board)`.
- **`StonePile`** now takes an `isTakeAllowed` predicate instead of a `disabled` flag, so both the button's `disabled` state and the hover-preview gating come from the engine's `moves.take.isAllowed` (turn ownership AND the validator) rather than a locally repeated cap check.
- The three games switch `take` to the long-form `{ validate, apply }`.
- Add `pebble-pile.spec.ts` covering `cap` and `validateTake`.

No change to the bots: they already choose from `1..cap(board)`.

## Verification

`npm run test` passes (lint, typecheck, 96 files / 634 tests — baseline is 95 / 626, plus the 8 new cases here).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSxP4EAjGt4vDBxsQt32c)_