### PR TITLE
Move legality layer: the 3 tic-tac-toe alike games

### DIFF
--- a/src/components/games/tictactoe-alikes/anti-tictactoe/anti-tictactoe.tsx
+++ b/src/components/games/tictactoe-alikes/anti-tictactoe/anti-tictactoe.tsx
@@ -2,20 +2,12 @@ import { range, cloneDeep } from 'lodash';
 import {
   strategyGameFactory, type Events, type BoardClientProps, type Ctx, GameBoard
 } from '../../../strategy-game-factory';
-import { generateEmptyTicTacToeBoard } from '../helpers';
+import { generateEmptyTicTacToeBoard, validatePlacement } from '../helpers';
 import { isGameEnd, hasFirstPlayerWon, type Board } from './helpers';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 
-const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
-  const isMoveAllowed = (id) => {
-    if (!ctx.isClientMoveAllowed) return false;
-    return board[id] === null;
-  };
-  const clickField = (id) => {
-    if (!isMoveAllowed(id)) return;
-
-    moves.placePiece(board, id);
-  };
+const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
+  const isMoveAllowed = (id) => moves.placePiece.isAllowed!(board, id);
   const pieceColor = (id) => {
     const colorCode = board[id];
     if (colorCode === 'red') return 'bg-red-800';
@@ -33,7 +25,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
         <button
           key={id}
           disabled={!isMoveAllowed(id)}
-          onClick={() => clickField(id)}
+          onClick={() => moves.placePiece(board, id)}
           className="aspect-square p-[25%] bg-surface-elevated"
         >
           {board[id] && (
@@ -49,14 +41,17 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 };
 
 const moves = {
-  placePiece: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, id) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard[id] = ctx.currentPlayer === 0 ? 'red' : 'blue';
-    events.endTurn();
-    if (isGameEnd(nextBoard)) {
-      events.endGame(hasFirstPlayerWon(nextBoard) ? 0 : 1);
+  placePiece: {
+    validate: validatePlacement,
+    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, id) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard[id] = ctx.currentPlayer === 0 ? 'red' : 'blue';
+      events.endTurn();
+      if (isGameEnd(nextBoard)) {
+        events.endGame(hasFirstPlayerWon(nextBoard) ? 0 : 1);
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 }
 

--- a/src/components/games/tictactoe-alikes/anti-tictactoe/anti-tictactoe.tsx
+++ b/src/components/games/tictactoe-alikes/anti-tictactoe/anti-tictactoe.tsx
@@ -7,7 +7,6 @@ import { isGameEnd, hasFirstPlayerWon, type Board } from './helpers';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 
 const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
-  const isMoveAllowed = (id) => moves.placePiece.isAllowed!(board, id);
   const pieceColor = (id) => {
     const colorCode = board[id];
     if (colorCode === 'red') return 'bg-red-800';
@@ -24,7 +23,7 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
       {range(9).map(id => (
         <button
           key={id}
-          disabled={!isMoveAllowed(id)}
+          disabled={!moves.placePiece.isAllowed!(board, id)}
           onClick={() => moves.placePiece(board, id)}
           className="aspect-square p-[25%] bg-surface-elevated"
         >

--- a/src/components/games/tictactoe-alikes/helpers.spec.ts
+++ b/src/components/games/tictactoe-alikes/helpers.spec.ts
@@ -1,0 +1,29 @@
+import { validatePlacement, generateEmptyTicTacToeBoard, type Board } from './helpers';
+
+const isPlacementAllowed = (board: Board, id: number) => validatePlacement(board, undefined, id);
+
+describe('tictactoe-alikes shared placement legality', () => {
+  it('allows placing on any cell of an empty board', () => {
+    const board = generateEmptyTicTacToeBoard();
+    expect([0, 1, 2, 3, 4, 5, 6, 7, 8].every(id => isPlacementAllowed(board, id))).toBe(true);
+  });
+
+  it('rejects placing on an occupied cell', () => {
+    const board: Board = [null, 'red', null, null, 'blue', null, null, null, null];
+    expect(isPlacementAllowed(board, 1)).toBe(false);
+    expect(isPlacementAllowed(board, 4)).toBe(false);
+  });
+
+  it('still allows the empty cells of a partly filled board', () => {
+    const board: Board = [null, 'red', null, null, 'blue', null, null, null, null];
+    expect(isPlacementAllowed(board, 0)).toBe(true);
+    expect(isPlacementAllowed(board, 8)).toBe(true);
+  });
+
+  it('rejects cells outside the board', () => {
+    const board = generateEmptyTicTacToeBoard();
+    expect(isPlacementAllowed(board, -1)).toBe(false);
+    expect(isPlacementAllowed(board, 9)).toBe(false);
+    expect(isPlacementAllowed(board, 1.5)).toBe(false);
+  });
+});

--- a/src/components/games/tictactoe-alikes/helpers.ts
+++ b/src/components/games/tictactoe-alikes/helpers.ts
@@ -11,6 +11,11 @@ board indices topography
 
 export const generateEmptyTicTacToeBoard = () => Array(9).fill(null);
 
+// All three variants place a piece the same way: on a cell of the board that is
+// still empty.
+export const validatePlacement = (board: Board, _, id: number): boolean =>
+  Number.isInteger(id) && id >= 0 && id < board.length && board[id] === null;
+
 export const hasWinningSubset = (indices) => {
   const winningIndexSets = [
     [0, 1, 2],

--- a/src/components/games/tictactoe-alikes/tictactoe-doublestart/tictactoe-doublestart.tsx
+++ b/src/components/games/tictactoe-alikes/tictactoe-doublestart/tictactoe-doublestart.tsx
@@ -3,18 +3,11 @@ import {
   strategyGameFactory, type Events, type BoardClientProps, type Ctx, GameBoard
 } from '../../../strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
-import { generateEmptyTicTacToeBoard } from '../helpers';
+import { generateEmptyTicTacToeBoard, validatePlacement } from '../helpers';
 import { isGameEnd, hasFirstPlayerWon, type Board } from './helpers';
 
-const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
-  const isMoveAllowed = (id) => {
-    if (!ctx.isClientMoveAllowed) return false;
-    return board[id] === null;
-  };
-  const clickField = (id) => {
-    if (!isMoveAllowed(id)) return;
-    moves.placePiece(board, id);
-  };
+const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
+  const isMoveAllowed = (id) => moves.placePiece.isAllowed!(board, id);
   const pieceColor = (id) => {
     const colorCode = board[id];
     if (colorCode === 'red') return 'bg-red-800';
@@ -32,7 +25,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
         <button
         key={id}
         disabled={!isMoveAllowed(id)}
-        onClick={() => clickField(id)}
+        onClick={() => moves.placePiece(board, id)}
         className="aspect-square p-[25%] bg-surface-elevated"
         >
           {board[id] && (
@@ -50,18 +43,21 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 const isDuringFirstMove = (board: Board) => board.filter(c => c).length <= 1;
 
 const moves = {
-  placePiece: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, id) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard[id] = ctx.currentPlayer === 0 ? 'red' : 'blue';
+  placePiece: {
+    validate: validatePlacement,
+    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, id) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard[id] = ctx.currentPlayer === 0 ? 'red' : 'blue';
 
-    if (!isDuringFirstMove(nextBoard)) {
-      events.endTurn();
-      if (isGameEnd(nextBoard)) {
-        events.endGame(hasFirstPlayerWon(nextBoard) ? 0 : 1);
+      if (!isDuringFirstMove(nextBoard)) {
+        events.endTurn();
+        if (isGameEnd(nextBoard)) {
+          events.endGame(hasFirstPlayerWon(nextBoard) ? 0 : 1);
+        }
       }
-    }
 
-    return { nextBoard };
+      return { nextBoard };
+    }
   }
 };
 

--- a/src/components/games/tictactoe-alikes/tictactoe-doublestart/tictactoe-doublestart.tsx
+++ b/src/components/games/tictactoe-alikes/tictactoe-doublestart/tictactoe-doublestart.tsx
@@ -7,7 +7,6 @@ import { generateEmptyTicTacToeBoard, validatePlacement } from '../helpers';
 import { isGameEnd, hasFirstPlayerWon, type Board } from './helpers';
 
 const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
-  const isMoveAllowed = (id) => moves.placePiece.isAllowed!(board, id);
   const pieceColor = (id) => {
     const colorCode = board[id];
     if (colorCode === 'red') return 'bg-red-800';
@@ -24,7 +23,7 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
       {range(9).map(id => (
         <button
         key={id}
-        disabled={!isMoveAllowed(id)}
+        disabled={!moves.placePiece.isAllowed!(board, id)}
         onClick={() => moves.placePiece(board, id)}
         className="aspect-square p-[25%] bg-surface-elevated"
         >

--- a/src/components/games/tictactoe-alikes/tictactoe/helpers.spec.ts
+++ b/src/components/games/tictactoe-alikes/tictactoe/helpers.spec.ts
@@ -1,9 +1,10 @@
+import { makeCtx } from '../../../../test-utils';
 import { inPlacingPhase, isWhiteningAllowed, type Board } from "./helpers";
 
 // vsHuman keeps the colours independent of role choice: player 0 is blue, so the
 // other player's colour is red.
-const ctxForFirstPlayer = { isHumanVsHumanGame: true, currentPlayer: 0 };
-const ctxForSecondPlayer = { isHumanVsHumanGame: true, currentPlayer: 1 };
+const ctxForFirstPlayer = makeCtx({ isHumanVsHumanGame: true, currentPlayer: 0 });
+const ctxForSecondPlayer = makeCtx({ isHumanVsHumanGame: true, currentPlayer: 1 });
 
 const fullBoard: Board = [
   'blue', 'red', 'blue',

--- a/src/components/games/tictactoe-alikes/tictactoe/helpers.spec.ts
+++ b/src/components/games/tictactoe-alikes/tictactoe/helpers.spec.ts
@@ -1,4 +1,15 @@
-import { inPlacingPhase } from "./helpers";
+import { inPlacingPhase, isWhiteningAllowed, type Board } from "./helpers";
+
+// vsHuman keeps the colours independent of role choice: player 0 is blue, so the
+// other player's colour is red.
+const ctxForFirstPlayer = { isHumanVsHumanGame: true, currentPlayer: 0 };
+const ctxForSecondPlayer = { isHumanVsHumanGame: true, currentPlayer: 1 };
+
+const fullBoard: Board = [
+  'blue', 'red', 'blue',
+  'red', 'blue', 'red',
+  'red', 'blue', 'red'
+];
 
 describe('helpers', () => {
   describe('inPlacingPhase', () => {
@@ -8,6 +19,29 @@ describe('helpers', () => {
 
     it('should return false if board does not have empty place', () => {
       expect(inPlacingPhase(['blue', 'red', 'red', 'white', 'red', 'white', 'blue', 'blue', 'white'])).toBe(false);
+    });
+  });
+
+  describe('isWhiteningAllowed', () => {
+    it('rejects any whitening while empty cells remain', () => {
+      const partialBoard: Board = [...fullBoard.slice(0, 8), null];
+      expect(isWhiteningAllowed(partialBoard, ctxForFirstPlayer, 1)).toBe(false);
+    });
+
+    it("allows whitening the other player's piece on a full board", () => {
+      expect(isWhiteningAllowed(fullBoard, ctxForFirstPlayer, 1)).toBe(true);
+      expect(isWhiteningAllowed(fullBoard, ctxForSecondPlayer, 0)).toBe(true);
+    });
+
+    it('rejects whitening an own piece', () => {
+      expect(isWhiteningAllowed(fullBoard, ctxForFirstPlayer, 0)).toBe(false);
+      expect(isWhiteningAllowed(fullBoard, ctxForSecondPlayer, 1)).toBe(false);
+    });
+
+    it('rejects whitening an already whitened piece', () => {
+      const board: Board = [...fullBoard];
+      board[1] = 'white';
+      expect(isWhiteningAllowed(board, ctxForFirstPlayer, 1)).toBe(false);
     });
   });
 });

--- a/src/components/games/tictactoe-alikes/tictactoe/helpers.ts
+++ b/src/components/games/tictactoe-alikes/tictactoe/helpers.ts
@@ -23,3 +23,11 @@ export const otherPlayerColor = (ctx) =>
   ctx.isHumanVsHumanGame
     ? (ctx.currentPlayer === 0 ? 'red' : 'blue')
     : (ctx.currentPlayer === ctx.chosenRoleIndex ? botColor : pColor);
+
+// Whitening only starts once the board is full, and a player may only whiten one
+// of the *other* player's pieces — never an own or an already whitened one. The
+// phase check is what stops a player from whitening mid-placement; for placing,
+// "the cell is empty" already implies the placing phase, so that move needs no
+// phase check of its own.
+export const isWhiteningAllowed = (board: Board, ctx, id: number) =>
+  !inPlacingPhase(board) && board[id] === otherPlayerColor(ctx);

--- a/src/components/games/tictactoe-alikes/tictactoe/tictactoe.tsx
+++ b/src/components/games/tictactoe-alikes/tictactoe/tictactoe.tsx
@@ -2,29 +2,24 @@ import { range, cloneDeep } from 'lodash';
 import {
   strategyGameFactory, type Events, type BoardClientProps, type Ctx, GameBoard
 } from '../../../strategy-game-factory';
-import { generateEmptyTicTacToeBoard } from '../helpers';
+import { generateEmptyTicTacToeBoard, validatePlacement } from '../helpers';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
-import { inPlacingPhase, isGameEnd, currentPlayerColor, otherPlayerColor, type Board } from './helpers';
+import {
+  inPlacingPhase, isGameEnd, currentPlayerColor, otherPlayerColor, isWhiteningAllowed, type Board
+} from './helpers';
 
-const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
+const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
   const gameIsInPlacingPhase = inPlacingPhase(board);
   const clickField = (id) => {
-    if (!isMoveAllowed(id)) return;
-
     if (gameIsInPlacingPhase) {
       moves.placePiece(board, id);
     } else {
       moves.whitenPiece(board, id);
     }
   };
-  const isMoveAllowed = (id) => {
-    if (!ctx.isClientMoveAllowed) return false;
-    if (gameIsInPlacingPhase) {
-      return board[id] === null;
-    } else {
-      return board[id] === otherPlayerColor(ctx);
-    }
-  };
+  const isMoveAllowed = (id) => gameIsInPlacingPhase
+    ? moves.placePiece.isAllowed!(board, id)
+    : moves.whitenPiece.isAllowed!(board, id);
   const pieceColor = (id) => {
     const colorCode = board[id];
     if (colorCode === 'red') return 'bg-red-800';
@@ -64,23 +59,29 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 };
 
 const moves = {
-  placePiece: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, id) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard[id] = currentPlayerColor(ctx);
-    events.endTurn();
-    if (isGameEnd(nextBoard)) {
-      events.endGame();
+  placePiece: {
+    validate: validatePlacement,
+    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, id) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard[id] = currentPlayerColor(ctx);
+      events.endTurn();
+      if (isGameEnd(nextBoard)) {
+        events.endGame();
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   },
-  whitenPiece: (board: Board, { events }: { events: Events }, id) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard[id] = 'white';
-    events.endTurn();
-    if (isGameEnd(nextBoard)) {
-      events.endGame();
+  whitenPiece: {
+    validate: (board: Board, { ctx }: { ctx: Ctx }, id: number) => isWhiteningAllowed(board, ctx, id),
+    apply: (board: Board, { events }: { events: Events }, id) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard[id] = 'white';
+      events.endTurn();
+      if (isGameEnd(nextBoard)) {
+        events.endGame();
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 }
 


### PR DESCRIPTION
Batch 2 of the follow-up to #333. Independent of the other batches — branched off `main`, mergeable in any order.

## Games covered

`tictactoe`, `anti-tictactoe`, `tictactoe-doublestart`.

## Changes

- **`tictactoe-alikes/helpers.ts`**: add `validatePlacement` alongside the board shape the three games already share — all three place a piece under the same rule, the target cell must be empty.
- All three `placePiece` moves switch to the long-form `{ validate, apply }` with that shared validator.
- **`tictactoe`'s second phase** gets its own predicate, `isWhiteningAllowed`, in its own helpers: the board must be full and the target must hold the *other* player's colour (never an own or an already whitened piece). The phase check is what stops a player whitening mid-placement — `placePiece` needs no phase check of its own, since an empty cell already implies the placing phase.
- The three board clients drop their local `isMoveAllowed` predicates and their `if (!isMoveAllowed) return` click guards, driving `disabled` from `moves.<name>.isAllowed` instead. Two of them no longer read `ctx` at all.
- Add specs for `validatePlacement` and `isWhiteningAllowed`.

No change to the bots: they already enumerate empty cells / the opponent's pieces, and `tictactoe-doublestart`'s two-placement opening already threads `nextBoard` into its second dispatch.

## Verification

`npm run test` passes (lint, typecheck, 96 files / 634 tests — baseline is 95 / 626, plus the 8 new cases here).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSxP4EAjGt4vDBxsQt32c)_