### PR TITLE
Move legality layer: the 4 single-piece grid games

### DIFF
--- a/src/components/games/chess-bishops/chess-bishops.tsx
+++ b/src/components/games/chess-bishops/chess-bishops.tsx
@@ -1,4 +1,4 @@
-import { range, isEqual, some, cloneDeep } from 'lodash';
+import { range, some, isEqual, cloneDeep } from 'lodash';
 import {
   strategyGameFactory, type BoardClientProps, type Events, GameBoard, useHoverPreview
 } from '../../strategy-game-factory';
@@ -11,21 +11,13 @@ import {
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { value: validHoveredField, hoverProps } = useHoverPreview<Field>(ctx.moveCount);
-  const clickField = (field: Field) => {
-    if (!isMoveAllowed(field)) return;
-
-    moves.placeBishop(board, field);
-  };
 
   const isPotentialNextStep = (field: Field) => {
     if (!isMoveAllowed(field)) return false;
     if (!validHoveredField) return false;
     return isEqual(validHoveredField, field);
   };
-  const isMoveAllowed = (targetField: Field) => {
-    if (!ctx.isClientMoveAllowed) return false;
-    return some(getAllowedMoves(board), field => isEqual(field, targetField));
-  };
+  const isMoveAllowed = (targetField: Field) => moves.placeBishop.isAllowed!(board, targetField);
   const isForbidden = ({ row, col }: Field) => {
     return board[row][col] === FORBIDDEN;
   };
@@ -59,7 +51,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
                 <button
                   className="w-full aspect-square p-[5%]"
                   disabled={!isMoveAllowed({ row, col })}
-                  onClick={() => clickField({ row, col })}
+                  onClick={() => moves.placeBishop(board, { row, col })}
                   {...hoverProps({ row, col })}
                 >
                   {isBishop({ row, col }) && (
@@ -84,15 +76,19 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 };
 
 const moves = {
-  placeBishop: (board: Board, { events }: { events: Events }, { row, col }: Field) => {
-    const nextBoard = cloneDeep(board);
-    markForbiddenFields(nextBoard, { row, col });
-    nextBoard[row][col] = BISHOP;
-    events.endTurn();
-    if (getAllowedMoves(nextBoard).length === 0) {
-      events.endGame();
+  placeBishop: {
+    validate: (board: Board, _, target: Field) =>
+      some(getAllowedMoves(board), field => isEqual(field, target)),
+    apply: (board: Board, { events }: { events: Events }, { row, col }: Field) => {
+      const nextBoard = cloneDeep(board);
+      markForbiddenFields(nextBoard, { row, col });
+      nextBoard[row][col] = BISHOP;
+      events.endTurn();
+      if (getAllowedMoves(nextBoard).length === 0) {
+        events.endGame();
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 };
 

--- a/src/components/games/chess-knight/chess-knight.tsx
+++ b/src/components/games/chess-knight/chess-knight.tsx
@@ -4,16 +4,8 @@ import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { getAllowedMoves, generateStartBoard, markVisitedFields, type Board, type Field } from './helpers';
 import { ChessKnightSvg } from './chess-knight-svg';
 
-const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
-  const clickField = (field: Field) => {
-    if (!isMoveAllowed(field)) return;
-
-    moves.moveKnight(board, field);
-  };
-  const isMoveAllowed = (targetField: Field) => {
-    if (!ctx.isClientMoveAllowed) return false;
-    return some(getAllowedMoves(board), field => isEqual(field, targetField));
-  };
+const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
+  const isMoveAllowed = (targetField: Field) => moves.moveKnight.isAllowed!(board, targetField);
 
   return (
   <GameBoard>
@@ -32,7 +24,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
                 <button
                   className="w-full aspect-square p-[5%]"
                   disabled={!isMoveAllowed({ row, col })}
-                  onClick={() => clickField({ row, col })}
+                  onClick={() => moves.moveKnight(board, { row, col })}
                 >
                   {isMoveAllowed({ row, col }) && (
                     <svg className="w-full aspect-square opacity-20">
@@ -56,18 +48,22 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 };
 
 const moves = {
-  moveKnight: (board: Board, { events }: { events: Events }, { row, col }: Field) => {
-    const nextBoard = cloneDeep(board);
-    markVisitedFields(nextBoard, nextBoard.knightPosition);
+  moveKnight: {
+    validate: (board: Board, _, target: Field) =>
+      some(getAllowedMoves(board), field => isEqual(field, target)),
+    apply: (board: Board, { events }: { events: Events }, { row, col }: Field) => {
+      const nextBoard = cloneDeep(board);
+      markVisitedFields(nextBoard, nextBoard.knightPosition);
 
-    nextBoard.chessBoard[row][col] = 'knight';
-    nextBoard.knightPosition = { row, col };
+      nextBoard.chessBoard[row][col] = 'knight';
+      nextBoard.knightPosition = { row, col };
 
-    events.endTurn();
-    if (getAllowedMoves(nextBoard).length === 0) {
-      events.endGame();
+      events.endTurn();
+      if (getAllowedMoves(nextBoard).length === 0) {
+        events.endGame();
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 };
 

--- a/src/components/games/chess-rook/chess-rook.tsx
+++ b/src/components/games/chess-rook/chess-rook.tsx
@@ -4,16 +4,8 @@ import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { getAllowedMoves, generateStartBoard, markVisitedFields, type Board, type Field } from './helpers';
 import { RookSvg } from '../shared/rook-svg';
 
-const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
-  const clickField = (field: Field) => {
-    if (!isMoveAllowed(field)) return;
-
-    moves.moveRook(board, field);
-  };
-  const isMoveAllowed = (targetField: Field) => {
-    if (!ctx.isClientMoveAllowed) return false;
-    return some(getAllowedMoves(board), field => isEqual(field, targetField));
-  };
+const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
+  const isMoveAllowed = (targetField: Field) => moves.moveRook.isAllowed!(board, targetField);
 
   return (
   <GameBoard>
@@ -32,7 +24,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
                 <button
                   className="w-full aspect-square p-[5%]"
                   disabled={!isMoveAllowed({ row, col })}
-                  onClick={() => clickField({ row, col })}
+                  onClick={() => moves.moveRook(board, { row, col })}
                 >
                   {isMoveAllowed({ row, col }) && (
                     <svg className="w-full aspect-square opacity-20">
@@ -56,18 +48,22 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 };
 
 const moves = {
-  moveRook: (board: Board, { events }: { events: Events }, { row, col }: Field) => {
-    const nextBoard = cloneDeep(board);
-    markVisitedFields(nextBoard, nextBoard.rookPosition, { row, col });
+  moveRook: {
+    validate: (board: Board, _, target: Field) =>
+      some(getAllowedMoves(board), field => isEqual(field, target)),
+    apply: (board: Board, { events }: { events: Events }, { row, col }: Field) => {
+      const nextBoard = cloneDeep(board);
+      markVisitedFields(nextBoard, nextBoard.rookPosition, { row, col });
 
-    nextBoard.chessBoard[row][col] = 'rook';
-    nextBoard.rookPosition = { row, col };
+      nextBoard.chessBoard[row][col] = 'rook';
+      nextBoard.rookPosition = { row, col };
 
-    events.endTurn();
-    if (getAllowedMoves(nextBoard).length === 0) {
-      events.endGame();
+      events.endTurn();
+      if (getAllowedMoves(nextBoard).length === 0) {
+        events.endGame();
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 };
 

--- a/src/components/games/rook-to-corner/rook-to-corner.tsx
+++ b/src/components/games/rook-to-corner/rook-to-corner.tsx
@@ -4,16 +4,8 @@ import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { getAllowedMoves, generateStartBoard, isTarget, boardSize, type Board, type Field } from './helpers';
 import { RookSvg } from '../shared/rook-svg';
 
-const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
-  const clickField = (field: Field) => {
-    if (!isMoveAllowed(field)) return;
-
-    moves.moveRook(board, field);
-  };
-  const isMoveAllowed = (targetField: Field) => {
-    if (!ctx.isClientMoveAllowed) return false;
-    return some(getAllowedMoves(board), field => isEqual(field, targetField));
-  };
+const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
+  const isMoveAllowed = (targetField: Field) => moves.moveRook.isAllowed!(board, targetField);
 
   return (
   <GameBoard>
@@ -30,7 +22,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
                   <button
                     className="w-full aspect-square p-[5%]"
                     disabled={!isMoveAllowed({ row, col })}
-                    onClick={() => clickField({ row, col })}
+                    onClick={() => moves.moveRook(board, { row, col })}
                   >
                     {isGoal && !hasRook && (
                       <span className="flex items-center justify-center w-full aspect-square text-3xl sm:text-4xl">
@@ -60,16 +52,20 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 };
 
 const moves = {
-  moveRook: (board: Board, { events }: { events: Events }, { row, col }: Field) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard.rookPosition = { row, col };
+  moveRook: {
+    validate: (board: Board, _, target: Field) =>
+      some(getAllowedMoves(board), field => isEqual(field, target)),
+    apply: (board: Board, { events }: { events: Events }, { row, col }: Field) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard.rookPosition = { row, col };
 
-    if (isTarget({ row, col })) {
-      events.endGame();
-    } else {
-      events.endTurn();
+      if (isTarget({ row, col })) {
+        events.endGame();
+      } else {
+        events.endTurn();
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 };
 


### PR DESCRIPTION
Batch 3 of the follow-up to #333. Independent of the other batches — branched off `main`, mergeable in any order.

## Games covered

`chess-rook`, `chess-knight`, `chess-bishops`, `rook-to-corner` — four games that move or place a single piece on a grid.

## Changes

Each of the four already owns a `getAllowedMoves(board)` move generator, and each board client repeated the same "is the clicked square in that list" check. That check becomes the move's `validate`, so the generator is now the single place each game's geometry is written down — for the UI, the engine and the bot alike.

- The four moves switch to the long-form `{ validate, apply }`. `validate` is a one-line delegate to the game's own `getAllowedMoves`; comparing by value also rejects a target that is not a field at all.
- The board clients drop their local predicates and click guards, driving `disabled` — and `chess-bishops`' hover preview — from `moves.<name>.isAllowed`. Three of them no longer read `ctx`.

No change to the bots: all of them already sample from `getAllowedMoves`.

No new tests here: unlike the other batches, these validators carry no logic of their own — each is a one-line delegate to a `getAllowedMoves` that the game's existing `helpers.spec.ts` already covers.

## Verification

`npm run test` passes (lint, typecheck, 95 files / 626 tests — unchanged from baseline).