### PR TITLE
Move legality layer: the 4 number-subtraction sibling games

### DIFF
--- a/src/components/games/single-pile-removal/prime-exponentials/prime-exponentials.spec.ts
+++ b/src/components/games/single-pile-removal/prime-exponentials/prime-exponentials.spec.ts
@@ -1,0 +1,32 @@
+import { isSubtractionAllowed } from './prime-exponentials';
+
+describe('isSubtractionAllowed', () => {
+  it('allows a prime power no larger than the number', () => {
+    expect(isSubtractionAllowed(100, { prime: 7, exponent: 2 })).toBe(true); // 49
+    expect(isSubtractionAllowed(100, { prime: 97, exponent: 1 })).toBe(true);
+  });
+
+  it('allows subtracting exactly the number itself', () => {
+    expect(isSubtractionAllowed(49, { prime: 7, exponent: 2 })).toBe(true);
+  });
+
+  it('rejects a prime power larger than the number', () => {
+    expect(isSubtractionAllowed(48, { prime: 7, exponent: 2 })).toBe(false);
+  });
+
+  it('allows 1, the single exponent-0 entry', () => {
+    expect(isSubtractionAllowed(5, { prime: 2, exponent: 0 })).toBe(true);
+    // 3^0 is also 1, but it is not one of the enumerated entries
+    expect(isSubtractionAllowed(5, { prime: 3, exponent: 0 })).toBe(false);
+  });
+
+  it('rejects a composite base, which plain arithmetic would accept', () => {
+    expect(isSubtractionAllowed(100, { prime: 6, exponent: 2 })).toBe(false); // 36
+    expect(isSubtractionAllowed(100, { prime: 4, exponent: 1 })).toBe(false);
+  });
+
+  it('rejects a negative or non-integer exponent', () => {
+    expect(isSubtractionAllowed(100, { prime: 7, exponent: -1 })).toBe(false);
+    expect(isSubtractionAllowed(100, { prime: 7, exponent: 1.5 })).toBe(false);
+  });
+});

--- a/src/components/games/single-pile-removal/prime-exponentials/prime-exponentials.tsx
+++ b/src/components/games/single-pile-removal/prime-exponentials/prime-exponentials.tsx
@@ -33,6 +33,12 @@ const allPrimePowers = (() => {
   return entries.sort((a, b) => a.value - b.value);
 })();
 
+// Only a genuine prime power that fits within the number may be subtracted, so
+// legality is membership in the enumeration above rather than an arithmetic
+// check, which would also accept a composite base.
+export const isSubtractionAllowed = (board: Board, { prime, exponent }: { prime: number; exponent: number }) =>
+  allPrimePowers.some(e => e.prime === prime && e.exponent === exponent && e.value <= board);
+
 const generateStartBoard = () => {
   if (random(0, 1)) {
     return random(3, 166) * 6;
@@ -43,10 +49,10 @@ const generateStartBoard = () => {
 
 const generateSmallStartBoard = () => random(12, 72);
 
-const PrimePowerButton = ({ entry, board, isClientMoveAllowed, chooseEntry, hoverProps }) => {
+const PrimePowerButton = ({ entry, board, isEntryAllowed, chooseEntry, hoverProps }) => {
   const { prime, exponent, value } = entry;
   const isAboveBoard = value > board;
-  const isActive = !isAboveBoard && isClientMoveAllowed;
+  const isActive = isEntryAllowed(entry);
   return (
     <button
       disabled={!isActive}
@@ -55,7 +61,7 @@ const PrimePowerButton = ({ entry, board, isClientMoveAllowed, chooseEntry, hove
         ${isAboveBoard ? 'opacity-25' : ''}
         enabled:hocus:bg-blue-100 dark:enabled:hocus:bg-blue-900 enabled:hocus:border-blue-300
       `}
-      onClick={() => isActive && chooseEntry(entry)}
+      onClick={() => chooseEntry(entry)}
       {...(isActive ? hoverProps(entry) : {})}
     >
       <span className="block text-xs text-slate-500" aria-hidden={exponent <= 1}>
@@ -66,7 +72,7 @@ const PrimePowerButton = ({ entry, board, isClientMoveAllowed, chooseEntry, hove
   );
 };
 
-const PrimePowerGrid = ({ board, visiblePowers, isClientMoveAllowed, chooseEntry, hoverProps }) => {
+const PrimePowerGrid = ({ board, visiblePowers, isEntryAllowed, chooseEntry, hoverProps }) => {
   return (
     <div className="flex flex-wrap gap-1 items-end">
       {visiblePowers.map(entry => (
@@ -74,7 +80,7 @@ const PrimePowerGrid = ({ board, visiblePowers, isClientMoveAllowed, chooseEntry
           key={`${entry.prime}-${entry.exponent}`}
           entry={entry}
           board={board}
-          isClientMoveAllowed={isClientMoveAllowed}
+          isEntryAllowed={isEntryAllowed}
           chooseEntry={chooseEntry}
           hoverProps={hoverProps}
         />
@@ -83,11 +89,11 @@ const PrimePowerGrid = ({ board, visiblePowers, isClientMoveAllowed, chooseEntry
   );
 };
 
-const HoverPreview = ({ hovered, board, isClientMoveAllowed }) => {
+const HoverPreview = ({ hovered, board, isEntryAllowed }) => {
   const { t } = useTranslation();
   return (
     <div className="min-h-6 mb-2">
-      {hovered !== null && hovered.value <= board && isClientMoveAllowed && <p>
+      {hovered !== null && isEntryAllowed(hovered) && <p>
         {t({ hu: 'Kivonandó prímhatvány:', en: 'Prime power to subtract:' })}{' '}
         <strong>{hovered.prime}<sup>{hovered.exponent}</sup> = {hovered.value}</strong>.{' '}
         {t({ hu: 'Eredmény:', en: 'Result:' })}{' '}
@@ -100,6 +106,8 @@ const HoverPreview = ({ hovered, board, isClientMoveAllowed }) => {
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { value: hovered, hoverProps } = useHoverPreview<typeof allPrimePowers[0]>(ctx.moveCount);
   const [visiblePowers] = useState(() => allPrimePowers.filter(e => e.value <= board));
+  const isEntryAllowed = (entry: typeof allPrimePowers[0]) =>
+    moves.subtractPrimeExponent.isAllowed!(board, entry);
 
   const chooseEntry = ({ prime, exponent }) => {
     moves.subtractPrimeExponent(board, { prime, exponent });
@@ -108,11 +116,11 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   return (
     <GameBoard>
       <p className='w-full text-8xl font-bold text-center mb-4'>{board}</p>
-      <HoverPreview hovered={hovered} board={board} isClientMoveAllowed={ctx.isClientMoveAllowed} />
+      <HoverPreview hovered={hovered} board={board} isEntryAllowed={isEntryAllowed} />
       <PrimePowerGrid
         board={board}
         visiblePowers={visiblePowers}
-        isClientMoveAllowed={ctx.isClientMoveAllowed}
+        isEntryAllowed={isEntryAllowed}
         chooseEntry={chooseEntry}
         hoverProps={hoverProps}
       />
@@ -153,13 +161,17 @@ const getPlayerStepDescription = () => ({
 });
 
 const moves = {
-  subtractPrimeExponent: (board: Board, { events }: { events: Events }, { prime, exponent }) => {
-    const nextBoard = board - prime ** exponent;
-    events.endTurn();
-    if (nextBoard === 0) {
-      events.endGame();
+  subtractPrimeExponent: {
+    validate: (board: Board, _, entry: { prime: number; exponent: number }) =>
+      isSubtractionAllowed(board, entry),
+    apply: (board: Board, { events }: { events: Events }, { prime, exponent }) => {
+      const nextBoard = board - prime ** exponent;
+      events.endTurn();
+      if (nextBoard === 0) {
+        events.endGame();
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 };
 

--- a/src/components/games/single-pile-removal/primely-to-zero/primely-to-zero.spec.ts
+++ b/src/components/games/single-pile-removal/primely-to-zero/primely-to-zero.spec.ts
@@ -1,0 +1,30 @@
+import { isMoveValid } from './primely-to-zero';
+
+describe('isMoveValid', () => {
+  it('allows a target reached by subtracting 1, 2 or a prime', () => {
+    expect(isMoveValid(50, 49)).toBe(true); // −1
+    expect(isMoveValid(50, 48)).toBe(true); // −2
+    expect(isMoveValid(50, 47)).toBe(true); // −3
+    expect(isMoveValid(50, 3)).toBe(true); // −47
+  });
+
+  it('rejects a target reached by subtracting a composite', () => {
+    expect(isMoveValid(50, 46)).toBe(false); // −4
+    expect(isMoveValid(50, 44)).toBe(false); // −6
+  });
+
+  it('allows landing exactly on zero when the number itself is a valid step', () => {
+    expect(isMoveValid(47, 0)).toBe(true);
+    expect(isMoveValid(50, 0)).toBe(false); // 50 is not a valid step
+  });
+
+  it('rejects staying put or moving upwards', () => {
+    expect(isMoveValid(50, 50)).toBe(false);
+    expect(isMoveValid(50, 51)).toBe(false);
+  });
+
+  it('rejects a negative or non-integer target', () => {
+    expect(isMoveValid(50, -1)).toBe(false);
+    expect(isMoveValid(50, 47.5)).toBe(false);
+  });
+});

--- a/src/components/games/single-pile-removal/primely-to-zero/primely-to-zero.tsx
+++ b/src/components/games/single-pile-removal/primely-to-zero/primely-to-zero.tsx
@@ -20,15 +20,13 @@ export const isMoveValid = (board: Board, target: number): boolean => {
 };
 
 const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
-  const isTargetAllowed = (target: number) => moves.moveTo.isAllowed!(board, target);
-
   return (
     <GameBoard>
       <div className="flex flex-wrap gap-2">
         {range(maxStart + 1).map(i =>
           <button
             key={i}
-            disabled={!isTargetAllowed(i)}
+            disabled={!moves.moveTo.isAllowed!(board, i)}
             onClick={() => moves.moveTo(board, i)}
             className={`
               border-2 rounded-sm text-2xl min-w-[4ch] p-1 my-1 font-bold

--- a/src/components/games/single-pile-removal/primely-to-zero/primely-to-zero.tsx
+++ b/src/components/games/single-pile-removal/primely-to-zero/primely-to-zero.tsx
@@ -14,16 +14,13 @@ const validSteps = new Set([1, 2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 4
 
 const isValidStep = (d: number): boolean => validSteps.has(d);
 
-const isMoveValid = (board: Board, target: number): boolean => {
+export const isMoveValid = (board: Board, target: number): boolean => {
   if (target < 0 || target >= board) return false;
   return isValidStep(board - target);
 };
 
-const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
-  const clickTarget = (target: number) => {
-    if (!ctx.isClientMoveAllowed || !isMoveValid(board, target)) return;
-    moves.moveTo(board, target);
-  };
+const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
+  const isTargetAllowed = (target: number) => moves.moveTo.isAllowed!(board, target);
 
   return (
     <GameBoard>
@@ -31,8 +28,8 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
         {range(maxStart + 1).map(i =>
           <button
             key={i}
-            disabled={!ctx.isClientMoveAllowed || !isMoveValid(board, i)}
-            onClick={() => clickTarget(i)}
+            disabled={!isTargetAllowed(i)}
+            onClick={() => moves.moveTo(board, i)}
             className={`
               border-2 rounded-sm text-2xl min-w-[4ch] p-1 my-1 font-bold
               enabled:bg-green-200 dark:enabled:bg-green-700 enabled:hocus:bg-green-400 dark:enabled:hocus:bg-green-600
@@ -49,13 +46,16 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 };
 
 const moves = {
-  moveTo: (_board: Board, { ctx, events }: { ctx: Ctx, events: Events }, target: number) => {
-    const winner = ctx.currentPlayer!;
-    events.endTurn();
-    if (target === 0) {
-      events.endGame(winner);
+  moveTo: {
+    validate: (board: Board, _, target: number) => isMoveValid(board, target),
+    apply: (_board: Board, { ctx, events }: { ctx: Ctx, events: Events }, target: number) => {
+      const winner = ctx.currentPlayer!;
+      events.endTurn();
+      if (target === 0) {
+        events.endGame(winner);
+      }
+      return { nextBoard: target };
     }
-    return { nextBoard: target };
   }
 };
 

--- a/src/components/games/single-pile-removal/take-1-or-halve/take-1-or-halve.tsx
+++ b/src/components/games/single-pile-removal/take-1-or-halve/take-1-or-halve.tsx
@@ -28,8 +28,8 @@ const CoinPile = ({ count, hoveredAction }: { count: number, hoveredAction: Hove
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
   const { value: hoveredAction, hoverProps } = useHoverPreview<'take1' | 'halve'>(ctx.moveCount);
-  const canTake1 = ctx.isClientMoveAllowed;
-  const canHalve = ctx.isClientMoveAllowed && board % 2 === 0;
+  const canTake1 = moves.take1.isAllowed!(board);
+  const canHalve = moves.halve.isAllowed!(board);
   return(
     <GameBoard>
       <h2 className="text-center">{board}</h2>
@@ -60,9 +60,13 @@ const moves = {
     }
     return { nextBoard: board - 1 }
   },
-  halve: (board: Board, { events }: { events: Events }) => {
-    events.endTurn();
-    return { nextBoard: board / 2 };
+  halve: {
+    // Half may only be taken when the pile is even; taking one is always legal.
+    validate: (board: Board) => board >= 2 && board % 2 === 0,
+    apply: (board: Board, { events }: { events: Events }) => {
+      events.endTurn();
+      return { nextBoard: board / 2 };
+    }
   }
 };
 

--- a/src/components/games/single-pile-removal/take-power-of-two/take-power-of-two.tsx
+++ b/src/components/games/single-pile-removal/take-power-of-two/take-power-of-two.tsx
@@ -14,7 +14,7 @@ const generateStartBoard = () => {
 
 type Board = number
 
-const ExponentsTable = ({ disabled, board, choosePower, hovered, hoverProps }) => {
+const ExponentsTable = ({ isPowerAllowed, board, choosePower, hovered, hoverProps }) => {
   const { t } = useTranslation();
   const availableExponents = getAvailableExponents(board);
 
@@ -26,14 +26,14 @@ const ExponentsTable = ({ disabled, board, choosePower, hovered, hoverProps }) =
       {availableExponents.map(e =>
         <button
           key={e}
-          disabled={disabled}
+          disabled={!isPowerAllowed(e)}
           className="secondary-button w-auto min-w-12"
           onClick={() => choosePower(e)}
-          {...(disabled ? {} : hoverProps(e))}
+          {...(isPowerAllowed(e) ? hoverProps(e) : {})}
         >{2 ** e}</button>
       )}
     </div>
-    {hovered !== null && !disabled && <p className="mt-2">
+    {hovered !== null && isPowerAllowed(hovered) && <p className="mt-2">
       {t({
         hu: `Kivonandó 2-hatvány: 2^${hovered} = ${2**hovered}. Eredmény: ${board-2**hovered}.`,
         en: `Power to subtract: 2^${hovered} = ${2**hovered}. Result: ${board-2**hovered}.`
@@ -50,7 +50,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     <GameBoard>
       <p className='w-full text-8xl font-bold text-center mb-4'>{board}</p>
       <ExponentsTable
-        disabled={!ctx.isClientMoveAllowed}
+        isPowerAllowed={(e: number) => moves.subtractPowerOfTwo.isAllowed!(board, e)}
         board={board}
         choosePower={(e: number) => moves.subtractPowerOfTwo(board, e)}
         hovered={hoveredPower}
@@ -99,13 +99,18 @@ const getPlayerStepDescription = () => ({
 });
 
 const moves = {
-  subtractPowerOfTwo: (board: Board, { events }: { events: Events }, exponent: number) => {
-    const nextBoard = board - 2 ** exponent;
-    events.endTurn();
-    if (nextBoard === 0) {
-      events.endGame();
+  subtractPowerOfTwo: {
+    // A power of 2 may be subtracted only if it does not exceed the number —
+    // exactly the exponents the board already offers.
+    validate: (board: Board, _, exponent: number) => getAvailableExponents(board).includes(exponent),
+    apply: (board: Board, { events }: { events: Events }, exponent: number) => {
+      const nextBoard = board - 2 ** exponent;
+      events.endTurn();
+      if (nextBoard === 0) {
+        events.endGame();
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 }
 


### PR DESCRIPTION
Batch 5 of the follow-up to #333. Branched off `main`, mergeable in any order.

## Games covered

`take-power-of-two`, `prime-exponentials`, `primely-to-zero`, `take-1-or-halve` — the `single-pile-removal` siblings that count a single number down to zero.

Each has its own rule for what may be subtracted, so **nothing is shared between them** — each keeps its own validator.

## Changes

- **`primely-to-zero`** already had `isMoveValid`; it becomes `moveTo`'s `validate` and the board client's `disabled`, replacing the duplicated check and the click guard. Now exported and covered by a spec.
- **`prime-exponentials`**: extract `isSubtractionAllowed` — membership in the game's own prime-power enumeration, which (unlike an arithmetic `prime ** exponent <= board` check) also rejects a composite base. Threaded through the button, grid and hover preview in place of the raw `isClientMoveAllowed` + size check. Covered by a spec.
- **`take-power-of-two`**: `validate` delegates to the existing `getAvailableExponents`; the exponents table takes an `isPowerAllowed` predicate instead of a `disabled` flag.
- **`take-1-or-halve`**: only `halve` has a precondition (an even, non-empty pile). Taking one is legal whenever it is your turn, so it stays in the shorthand form — per the agreed rule of validating only non-trivial legality. Both buttons still read `disabled` from `moves.<name>.isAllowed`, which the engine defines for shorthand moves too, so the pair stays symmetric in the UI without a no-op validator.

No change to the bots: each already picks from its game's own set of legal subtractions.

## Verification

`npm run test` passes (97 files / 637 tests — baseline 95 / 626, plus the 11 new cases).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSxP4EAjGt4vDBxsQt32c)_