### PR TITLE
Move legality layer: the 2 connected-fields games

### DIFF
--- a/src/components/games/five-connected-fields/board-client.tsx
+++ b/src/components/games/five-connected-fields/board-client.tsx
@@ -19,7 +19,6 @@ const edges = side1.flatMap((a) => side2.map((b) => [a, b] as const));
 export const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
   const isClickable = (node: number) => moves.placeCoin.isAllowed!(board, node);
 
-
   return (
     <GameBoard>
       <svg className="aspect-square stroke-slate-900 dark:stroke-slate-300 stroke-2">

--- a/src/components/games/five-connected-fields/board-client.tsx
+++ b/src/components/games/five-connected-fields/board-client.tsx
@@ -19,7 +19,6 @@ const edges = side1.flatMap((a) => side2.map((b) => [a, b] as const));
 export const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
   const isClickable = (node: number) => moves.placeCoin.isAllowed!(board, node);
 
-  const handleClick = (node: number) => moves.placeCoin(board, node);
 
   return (
     <GameBoard>
@@ -37,9 +36,9 @@ export const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
         {range(5).map((node) => (
           <g
             key={node}
-            onClick={() => handleClick(node)}
+            onClick={() => moves.placeCoin(board, node)}
             onKeyUp={(event) => {
-              if (event.key === "Enter") handleClick(node);
+              if (event.key === "Enter") moves.placeCoin(board, node);
             }}
             tabIndex={isClickable(node) ? 0 : undefined}
             role={isClickable(node) ? "button" : undefined}

--- a/src/components/games/five-connected-fields/board-client.tsx
+++ b/src/components/games/five-connected-fields/board-client.tsx
@@ -1,6 +1,6 @@
 import { range } from "lodash";
 import { GameBoard, type BoardClientProps } from "../../strategy-game-factory";
-import { type Board, side1, side2, isNodePlayable } from "./helpers";
+import { type Board, side1, side2 } from "./helpers";
 
 // A deliberately non-obvious drawing of the K(2,3) graph: the two hub fields
 // (side 1) sit at the diagonal corners, the three side-2 fields at top-right,
@@ -16,14 +16,10 @@ const coords: Record<number, { cx: string; cy: string }> = {
 
 const edges = side1.flatMap((a) => side2.map((b) => [a, b] as const));
 
-export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
-  const isClickable = (node: number) =>
-    ctx.isClientMoveAllowed && isNodePlayable(board, node);
+export const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
+  const isClickable = (node: number) => moves.placeCoin.isAllowed!(board, node);
 
-  const handleClick = (node: number) => {
-    if (!isClickable(node)) return;
-    moves.placeCoin(board, node);
-  };
+  const handleClick = (node: number) => moves.placeCoin(board, node);
 
   return (
     <GameBoard>

--- a/src/components/games/five-connected-fields/five-connected-fields.tsx
+++ b/src/components/games/five-connected-fields/five-connected-fields.tsx
@@ -1,21 +1,24 @@
 import { strategyGameFactory, type Ctx, type Events } from "../../strategy-game-factory";
-import { type Board, hasAnyMove } from "./helpers";
+import { type Board, hasAnyMove, isNodePlayable } from "./helpers";
 import { smartBotStrategy } from "./bot-strategy";
 import { BoardClient } from "./board-client";
 
 export type { Board };
 
 const moves = {
-  placeCoin: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, node: number) => {
-    const nextBoard = board.slice();
-    nextBoard[node] += 1;
-    events.endTurn();
-    // The player who places the last coin wins: the game ends when no line has
-    // equal endpoints, i.e. when the mover just made all further moves impossible.
-    if (!hasAnyMove(nextBoard)) {
-      events.endGame(ctx.currentPlayer);
+  placeCoin: {
+    validate: (board: Board, _, node: number) => isNodePlayable(board, node),
+    apply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, node: number) => {
+      const nextBoard = board.slice();
+      nextBoard[node] += 1;
+      events.endTurn();
+      // The player who places the last coin wins: the game ends when no line has
+      // equal endpoints, i.e. when the mover just made all further moves impossible.
+      if (!hasAnyMove(nextBoard)) {
+        events.endGame(ctx.currentPlayer);
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 };
 

--- a/src/components/games/five-connected-fields/helpers.spec.ts
+++ b/src/components/games/five-connected-fields/helpers.spec.ts
@@ -1,0 +1,33 @@
+import { isNodePlayable, type Board } from "./helpers";
+
+// K(2,3): 0=A and 1=B are the hubs, each joined to 2=C, 3=D and 4=E. Neither
+// hub is joined to the other, and C, D, E are not joined to each other.
+describe("isNodePlayable", () => {
+  it("allows every field of the empty board", () => {
+    expect([0, 1, 2, 3, 4].every((node) => isNodePlayable([0, 0, 0, 0, 0], node))).toBe(true);
+  });
+
+  it("allows a field whose neighbour holds the same number of coins", () => {
+    const board: Board = [1, 3, 1, 2, 4];
+    expect(isNodePlayable(board, 0)).toBe(true); // A-C line, both 1
+    expect(isNodePlayable(board, 2)).toBe(true);
+  });
+
+  it("rejects a field with no equal-valued neighbour", () => {
+    expect(isNodePlayable([1, 3, 2, 4, 5], 0)).toBe(false);
+  });
+
+  it("rejects a field equal only to one on its own side", () => {
+    // the two hubs both hold 1, but they are not joined
+    expect(isNodePlayable([1, 1, 2, 3, 4], 0)).toBe(false);
+    // C and D both hold 2, but they are not joined either
+    expect(isNodePlayable([1, 3, 2, 2, 4], 2)).toBe(false);
+  });
+
+  it("rejects anything that is not a field of the graph", () => {
+    const board: Board = [0, 0, 0, 0, 0];
+    expect(isNodePlayable(board, 5)).toBe(false);
+    expect(isNodePlayable(board, -1)).toBe(false);
+    expect(isNodePlayable(board, 1.5)).toBe(false);
+  });
+});

--- a/src/components/games/five-connected-fields/helpers.ts
+++ b/src/components/games/five-connected-fields/helpers.ts
@@ -18,9 +18,11 @@ export const neighbours: Record<number, number[]> = {
 };
 
 // A field can receive a coin iff it is joined by a line to a field holding the
-// same number of coins.
+// same number of coins. Anything that is not a field of the graph is rejected
+// rather than looked up.
 export const isNodePlayable = (board: Board, node: number): boolean =>
-  neighbours[node].some((other) => board[other] === board[node]);
+  neighbours[node] !== undefined
+    && neighbours[node].some((other) => board[other] === board[node]);
 
 export const legalNodes = (board: Board): number[] =>
   range(5).filter((node) => isNodePlayable(board, node));

--- a/src/components/games/four-connected-fields/board-client.tsx
+++ b/src/components/games/four-connected-fields/board-client.tsx
@@ -23,7 +23,6 @@ const edges = [
 export const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
   const isClickable = (node: number) => moves.placeCoin.isAllowed!(board, node);
 
-
   return (
     <GameBoard>
       <svg className="aspect-square stroke-slate-900 dark:stroke-slate-300 stroke-2">

--- a/src/components/games/four-connected-fields/board-client.tsx
+++ b/src/components/games/four-connected-fields/board-client.tsx
@@ -1,6 +1,6 @@
 import { range } from "lodash";
 import { GameBoard, type BoardClientProps } from "../../strategy-game-factory";
-import { type Board, hubs, others, isNodePlayable } from "./helpers";
+import { type Board, hubs, others } from "./helpers";
 
 // Drawing of the graph (K4 minus the C-D edge) as a rhomboid: the two hub fields
 // sit at left and right (joined by the horizontal diagonal, and each joined to
@@ -20,14 +20,10 @@ const edges = [
   [hubs[0], hubs[1]] as const
 ];
 
-export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
-  const isClickable = (node: number) =>
-    ctx.isClientMoveAllowed && isNodePlayable(board, node);
+export const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
+  const isClickable = (node: number) => moves.placeCoin.isAllowed!(board, node);
 
-  const handleClick = (node: number) => {
-    if (!isClickable(node)) return;
-    moves.placeCoin(board, node);
-  };
+  const handleClick = (node: number) => moves.placeCoin(board, node);
 
   return (
     <GameBoard>

--- a/src/components/games/four-connected-fields/board-client.tsx
+++ b/src/components/games/four-connected-fields/board-client.tsx
@@ -23,7 +23,6 @@ const edges = [
 export const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
   const isClickable = (node: number) => moves.placeCoin.isAllowed!(board, node);
 
-  const handleClick = (node: number) => moves.placeCoin(board, node);
 
   return (
     <GameBoard>
@@ -41,9 +40,9 @@ export const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
         {range(4).map((node) => (
           <g
             key={node}
-            onClick={() => handleClick(node)}
+            onClick={() => moves.placeCoin(board, node)}
             onKeyUp={(event) => {
-              if (event.key === "Enter") handleClick(node);
+              if (event.key === "Enter") moves.placeCoin(board, node);
             }}
             tabIndex={isClickable(node) ? 0 : undefined}
             role={isClickable(node) ? "button" : undefined}

--- a/src/components/games/four-connected-fields/four-connected-fields.tsx
+++ b/src/components/games/four-connected-fields/four-connected-fields.tsx
@@ -1,22 +1,25 @@
 import { strategyGameFactory, type Ctx, type Events } from "../../strategy-game-factory";
-import { type Board, hasAnyMove } from "./helpers";
+import { type Board, hasAnyMove, isNodePlayable } from "./helpers";
 import { randomBotStrategy, smartBotStrategy } from "./bot-strategy";
 import { BoardClient } from "./board-client";
 
 export type { Board };
 
 const moves = {
-  placeCoin: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, node: number) => {
-    const nextBoard = board.slice();
-    nextBoard[node] += 1;
-    events.endTurn();
-    // The player who places the last coin wins: the game ends when no field is
-    // empty and no line has equal endpoints, i.e. when the mover just made all
-    // further moves impossible.
-    if (!hasAnyMove(nextBoard)) {
-      events.endGame(ctx.currentPlayer);
+  placeCoin: {
+    validate: (board: Board, _, node: number) => isNodePlayable(board, node),
+    apply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, node: number) => {
+      const nextBoard = board.slice();
+      nextBoard[node] += 1;
+      events.endTurn();
+      // The player who places the last coin wins: the game ends when no field is
+      // empty and no line has equal endpoints, i.e. when the mover just made all
+      // further moves impossible.
+      if (!hasAnyMove(nextBoard)) {
+        events.endGame(ctx.currentPlayer);
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 };
 

--- a/src/components/games/four-connected-fields/helpers.spec.ts
+++ b/src/components/games/four-connected-fields/helpers.spec.ts
@@ -1,0 +1,32 @@
+import { isNodePlayable, type Board } from "./helpers";
+
+// 0=A and 1=B are the hubs, joined to each other and to both 2=C and 3=D;
+// C and D are not joined.
+describe("isNodePlayable", () => {
+  it("allows any empty field", () => {
+    expect([0, 1, 2, 3].every((node) => isNodePlayable([0, 0, 0, 0], node))).toBe(true);
+  });
+
+  it("allows a field whose neighbour holds the same number of coins", () => {
+    const board: Board = [2, 2, 1, 3];
+    expect(isNodePlayable(board, 0)).toBe(true); // A-B line, both 2
+    expect(isNodePlayable(board, 1)).toBe(true);
+  });
+
+  it("rejects a non-empty field with no equal-valued neighbour", () => {
+    expect(isNodePlayable([2, 3, 1, 4], 2)).toBe(false);
+  });
+
+  it("rejects a field equal only to the one it is not joined to", () => {
+    // C and D both hold 1, but there is no C-D line
+    expect(isNodePlayable([2, 3, 1, 1], 2)).toBe(false);
+    expect(isNodePlayable([2, 3, 1, 1], 3)).toBe(false);
+  });
+
+  it("rejects anything that is not a field of the graph", () => {
+    const board: Board = [0, 0, 0, 0];
+    expect(isNodePlayable(board, 4)).toBe(false);
+    expect(isNodePlayable(board, -1)).toBe(false);
+    expect(isNodePlayable(board, 1.5)).toBe(false);
+  });
+});

--- a/src/components/games/four-connected-fields/helpers.ts
+++ b/src/components/games/four-connected-fields/helpers.ts
@@ -18,9 +18,11 @@ export const neighbours: Record<number, number[]> = {
 
 // A field can receive a coin in two ways: it is empty (place a coin on any empty
 // field), or it is joined by a line to a field holding the same number of coins
-// (add a coin to one end of an equal-valued line).
+// (add a coin to one end of an equal-valued line). Anything that is not a field
+// of the graph is rejected rather than looked up.
 export const isNodePlayable = (board: Board, node: number): boolean =>
-  board[node] === 0 || neighbours[node].some((other) => board[other] === board[node]);
+  neighbours[node] !== undefined
+    && (board[node] === 0 || neighbours[node].some((other) => board[other] === board[node]));
 
 export const legalNodes = (board: Board): number[] =>
   range(4).filter((node) => isNodePlayable(board, node));


### PR DESCRIPTION
Batch 6 of the follow-up to #333. Branched off `main`, mergeable in any order.

## Games covered

`four-connected-fields`, `five-connected-fields`.

## Changes

Each already owns an `isNodePlayable` predicate describing its own graph, so neither needs anything from the other — this is mostly wiring an existing predicate into the engine.

- `placeCoin` switches to the long-form `{ validate, apply }`, delegating to the game's own `isNodePlayable`.
- **Both `isNodePlayable` implementations now reject anything that is not a field of the graph** instead of looking it up. This is a real (if small) fix that the legality layer forces: as the engine's tamper check, a validator must answer `false` for a stray argument rather than throw on `neighbours[node]` being `undefined`.
- The board clients drop their `isClientMoveAllowed` conjunction and their click guard, reading `isClickable` from `moves.placeCoin.isAllowed`; neither reads `ctx` any more.
- Add a `helpers.spec.ts` per game covering `isNodePlayable`, including the cases where two fields hold equal coins but are *not* joined by a line (C–D in the 4-field graph, two same-side fields in K(2,3)).

No change to the bots: both already choose from `legalNodes`.

## Verification

`npm run test` passes (97 files / 636 tests — baseline 95 / 626, plus the 10 new cases).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSxP4EAjGt4vDBxsQt32c)_