### PR TITLE
Move legality layer: the 2 domino-placing games

### DIFF
--- a/src/components/games/dominoes-4x4/dominoes-4x4.tsx
+++ b/src/components/games/dominoes-4x4/dominoes-4x4.tsx
@@ -30,6 +30,14 @@ export const getPossibleMoves = (board: Board, player: number): Board => {
   return possibleMoves;
 };
 
+// A domino is legal when it covers two uncovered fields along the current
+// player's own axis, which is what `getPossibleMoves` enumerates for them. The
+// player picks the two fields in either order, so the pair is matched unordered.
+export const isDominoAllowed = (board: Board, player: number, domino: Domino): boolean =>
+  Array.isArray(domino) && domino.length === 2
+    && getPossibleMoves(board, player)
+      .some(m => isEqual(m, domino) || isEqual(m, [domino[1], domino[0]]));
+
 const getDominoDirection = (field: Field, board: Board) => {
   const domino = board.find(d => d.some(c => isEqual(c, field)))!;
   const neighbor = isEqual(domino[0], field) ? domino[1] : domino[0];
@@ -53,14 +61,9 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   // horizontal for Félix (player 1).
   const step = ctx.currentPlayer === 0 ? { dRow: 1, dCol: 0 } : { dRow: 0, dCol: 1 };
 
-  const isValidPartner = ({ row, col }: Field) => {
-    if (selectedField === null) return false;
-    const dRow = Math.abs(row - selectedField.row);
-    const dCol = Math.abs(col - selectedField.col);
-    if (dRow + dCol !== 1) return false;
-    const alongPlayerAxis = ctx.currentPlayer === 0 ? dRow === 1 : dCol === 1;
-    return alongPlayerAxis && !isCovered({ row, col }, board);
-  };
+  // The field would complete a legal domino with the one already selected.
+  const isValidPartner = (field: Field) =>
+    selectedField !== null && moves.placeDomino.isAllowed!(board, [selectedField, field]);
 
   const hasPlaceablePartner = ({ row, col }: Field) => {
     return [[step.dRow, step.dCol], [-step.dRow, -step.dCol]].some(([dRow, dCol]) => {
@@ -70,7 +73,10 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     });
   };
 
+  // A rejected click must leave the local selection alone, so this keeps a guard
+  // rather than relying on the engine silently ignoring the dispatch.
   const clickField = (field: Field) => {
+    if (!isClickAllowed(field)) return;
     if (selectedField === null) { setSelectedField(field); return; }
     if (isEqual(field, selectedField)) { setSelectedField(null); return; }
     moves.placeDomino(board, [selectedField, field]);
@@ -104,7 +110,9 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const isClickAllowed = (field: Field) => {
     if (!ctx.isClientMoveAllowed) return false;
     if (isCovered(field, board)) return false;
+    // clicking the selected field again deselects it
     if (selectedField !== null && isEqual(field, selectedField)) return true;
+    // the second click has to complete a domino the engine would accept
     if (selectedField !== null) return isValidPartner(field);
     return hasPlaceablePartner(field);
   };
@@ -153,17 +161,21 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 };
 
 const moves = {
-  placeDomino: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, domino: Domino) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard.push(domino);
-    const nextPlayer = 1 - ctx.currentPlayer!;
-    events.endTurn();
-    // Normal play: if the next player has no legal placement, they lose and the player
-    // who just moved wins (endGame with no argument credits the mover).
-    if (getPossibleMoves(nextBoard, nextPlayer).length === 0) {
-      events.endGame();
+  placeDomino: {
+    validate: (board: Board, { ctx }: { ctx: Ctx }, domino: Domino) =>
+      isDominoAllowed(board, ctx.currentPlayer!, domino),
+    apply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, domino: Domino) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard.push(domino);
+      const nextPlayer = 1 - ctx.currentPlayer!;
+      events.endTurn();
+      // Normal play: if the next player has no legal placement, they lose and the player
+      // who just moved wins (endGame with no argument credits the mover).
+      if (getPossibleMoves(nextBoard, nextPlayer).length === 0) {
+        events.endGame();
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 };
 

--- a/src/components/games/dominoes-4x4/legality.spec.ts
+++ b/src/components/games/dominoes-4x4/legality.spec.ts
@@ -1,0 +1,36 @@
+import { isDominoAllowed, type Board, type Domino } from './dominoes-4x4';
+
+const emptyBoard: Board = [];
+// Player 0 (Árgyélus) places vertical dominoes, player 1 (Félix) horizontal ones.
+const VERTICAL = 0;
+const HORIZONTAL = 1;
+
+describe('isDominoAllowed', () => {
+  it('allows a domino along the current player’s own axis', () => {
+    expect(isDominoAllowed(emptyBoard, VERTICAL, [{ row: 0, col: 0 }, { row: 1, col: 0 }])).toBe(true);
+    expect(isDominoAllowed(emptyBoard, HORIZONTAL, [{ row: 0, col: 0 }, { row: 0, col: 1 }])).toBe(true);
+  });
+
+  it('rejects a domino along the other player’s axis', () => {
+    expect(isDominoAllowed(emptyBoard, VERTICAL, [{ row: 0, col: 0 }, { row: 0, col: 1 }])).toBe(false);
+    expect(isDominoAllowed(emptyBoard, HORIZONTAL, [{ row: 0, col: 0 }, { row: 1, col: 0 }])).toBe(false);
+  });
+
+  it('allows the two fields in either order', () => {
+    expect(isDominoAllowed(emptyBoard, VERTICAL, [{ row: 1, col: 0 }, { row: 0, col: 0 }])).toBe(true);
+  });
+
+  it('rejects a domino overlapping one already placed', () => {
+    const board: Board = [[{ row: 0, col: 0 }, { row: 1, col: 0 }]];
+    expect(isDominoAllowed(board, VERTICAL, [{ row: 1, col: 0 }, { row: 2, col: 0 }])).toBe(false);
+    expect(isDominoAllowed(board, VERTICAL, [{ row: 2, col: 0 }, { row: 3, col: 0 }])).toBe(true);
+  });
+
+  it('rejects fields off the board', () => {
+    expect(isDominoAllowed(emptyBoard, VERTICAL, [{ row: 3, col: 0 }, { row: 4, col: 0 }])).toBe(false);
+  });
+
+  it('rejects anything that is not a pair of fields', () => {
+    expect(isDominoAllowed(emptyBoard, VERTICAL, undefined as unknown as Domino)).toBe(false);
+  });
+});

--- a/src/components/games/dominoes-on-chessboard/dominoes-on-chessboard.tsx
+++ b/src/components/games/dominoes-on-chessboard/dominoes-on-chessboard.tsx
@@ -42,21 +42,23 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     });
   };
 
+  // A rejected click must leave the local selection alone, so this keeps a guard
+  // rather than relying on the engine silently ignoring the dispatch.
   const clickField = (field: Field) => {
+    if (!isClickAllowed(field)) return;
     if (selectedField === null) { setSelectedField(field); return; }
     if (isEqual(field, selectedField)) { setSelectedField(null); return; }
     moves.placeDomino(board, [selectedField, field]);
     setSelectedField(null);
   };
 
-  const isNeighborOfSelected = ({ row, col }) => {
-    if (selectedField === null) return false;
-    return Math.abs(row - selectedField.row) + Math.abs(col - selectedField.col) === 1;
-  }
+  // The field would complete a legal domino with the one already selected.
+  const isValidPartner = (field: Field) =>
+    selectedField !== null && moves.placeDomino.isAllowed!(board, [selectedField, field]);
 
   const isPartOfPreview = (field: Field) => {
     if (selectedField === null || validHoveredField === null) return false;
-    if (!isNeighborOfSelected(validHoveredField) || isCovered(validHoveredField, board)) return false;
+    if (!isValidPartner(validHoveredField)) return false;
     return isEqual(field, selectedField) || isEqual(field, validHoveredField);
   };
 
@@ -64,7 +66,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     if (isCovered(field, board)) return 'bg-slate-600 border-slate-900 dark:border-slate-400';
     if (!ctx.isClientMoveAllowed) return 'bg-surface-elevated';
     if (isPartOfPreview(field) || isEqual(selectedField, field)) return 'bg-blue-400';
-    if (isNeighborOfSelected(field)) return 'bg-blue-100 dark:bg-blue-900';
+    if (isValidPartner(field)) return 'bg-blue-100 dark:bg-blue-900';
     return 'bg-surface-elevated';
   };
 
@@ -72,8 +74,10 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     if (!ctx.isClientMoveAllowed) return false;
     if (isCovered(field, board)) return false;
     if (!hasEmptyNeighbor(field)) return false;
+    // clicking the selected field again deselects it
     if (selectedField !== null && isEqual(field, selectedField)) return true;
-    if (selectedField !== null && !isNeighborOfSelected(field)) return false;
+    // the second click has to complete a domino the engine would accept
+    if (selectedField !== null) return isValidPartner(field);
     return true;
   }
 
@@ -148,15 +152,25 @@ export const getPossibleMoves = (board: Board) => {
   return possibleMoves;
 }
 
+// A domino is legal when it covers two uncovered neighbouring fields, which is
+// what `getPossibleMoves` enumerates. The player picks the two fields in either
+// order, so the pair is matched unordered.
+export const isDominoAllowed = (board: Board, domino: Domino): boolean =>
+  Array.isArray(domino) && domino.length === 2
+    && getPossibleMoves(board).some(m => isEqual(m, domino) || isEqual(m, [domino[1], domino[0]]));
+
 const moves = {
-  placeDomino: (board: Board, { events }: { events: Events }, domino: Domino) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard.push(domino);
-    events.endTurn();
-    if (getPossibleMoves(nextBoard).length === 0) {
-      events.endGame();
+  placeDomino: {
+    validate: (board: Board, _, domino: Domino) => isDominoAllowed(board, domino),
+    apply: (board: Board, { events }: { events: Events }, domino: Domino) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard.push(domino);
+      events.endTurn();
+      if (getPossibleMoves(nextBoard).length === 0) {
+        events.endGame();
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 }
 

--- a/src/components/games/dominoes-on-chessboard/legality.spec.ts
+++ b/src/components/games/dominoes-on-chessboard/legality.spec.ts
@@ -1,0 +1,38 @@
+import { isDominoAllowed, type Board, type Domino } from './dominoes-on-chessboard';
+
+const emptyBoard: Board = [];
+
+describe('isDominoAllowed', () => {
+  it('allows a domino covering two uncovered neighbours', () => {
+    expect(isDominoAllowed(emptyBoard, [{ row: 0, col: 0 }, { row: 0, col: 1 }])).toBe(true);
+    expect(isDominoAllowed(emptyBoard, [{ row: 0, col: 0 }, { row: 1, col: 0 }])).toBe(true);
+  });
+
+  it('allows the two fields in either order', () => {
+    // the smart bot mirrors the opponent's domino through the board's centre,
+    // which reverses the pair relative to how the move generator lists it
+    expect(isDominoAllowed(emptyBoard, [{ row: 0, col: 1 }, { row: 0, col: 0 }])).toBe(true);
+    expect(isDominoAllowed(emptyBoard, [{ row: 1, col: 0 }, { row: 0, col: 0 }])).toBe(true);
+  });
+
+  it('rejects fields that are not neighbours', () => {
+    expect(isDominoAllowed(emptyBoard, [{ row: 0, col: 0 }, { row: 0, col: 2 }])).toBe(false);
+    expect(isDominoAllowed(emptyBoard, [{ row: 0, col: 0 }, { row: 1, col: 1 }])).toBe(false);
+  });
+
+  it('rejects a domino overlapping one already placed', () => {
+    const board: Board = [[{ row: 0, col: 0 }, { row: 0, col: 1 }]];
+    expect(isDominoAllowed(board, [{ row: 0, col: 1 }, { row: 0, col: 2 }])).toBe(false);
+    expect(isDominoAllowed(board, [{ row: 0, col: 2 }, { row: 0, col: 3 }])).toBe(true);
+  });
+
+  it('rejects fields off the board', () => {
+    expect(isDominoAllowed(emptyBoard, [{ row: 0, col: 5 }, { row: 0, col: 6 }])).toBe(false);
+    expect(isDominoAllowed(emptyBoard, [{ row: -1, col: 0 }, { row: 0, col: 0 }])).toBe(false);
+  });
+
+  it('rejects anything that is not a pair of fields', () => {
+    expect(isDominoAllowed(emptyBoard, undefined as unknown as Domino)).toBe(false);
+    expect(isDominoAllowed(emptyBoard, [{ row: 0, col: 0 }] as unknown as Domino)).toBe(false);
+  });
+});


### PR DESCRIPTION
Batch 8 of the follow-up to #333. Branched off `main`, mergeable in any order.

## Games covered

`dominoes-4x4`, `dominoes-on-chessboard`. Separate games, so each keeps its own predicate.

## Changes

Both already enumerate their legal placements in `getPossibleMoves`; `placeDomino`'s legality becomes membership in that enumeration.

- **`isDominoAllowed` per game, matching the pair *unordered*.** This is not cosmetic — see below.
- `dominoes-4x4`'s legal set depends on whose turn it is (player 0 places vertical dominoes, player 1 horizontal), so its `validate` reads `ctx.currentPlayer`. That field is stable within a turn, so it needs none of the mid-turn `ctx` handling AGENTS.md warns about.
- Both board clients' `isValidPartner` now delegates to `moves.placeDomino.isAllowed`, replacing hand-written adjacency and axis checks. It drives the second click's `disabled`, the preview tint and the hover preview alike.
- `clickField` gains a guard in both — the `cube-coloring` case from #333: a rejected click must leave the local field selection alone.
- Add a `legality.spec.ts` per game.

### Why the unordered match matters

The board clients build the domino from the order the two fields were clicked, so `[b, a]` is as likely as `[a, b]`. More importantly, `dominoes-on-chessboard`'s smart bot mirrors the opponent's domino through the centre of the board — a 180° rotation, which reverses the pair relative to how `getPossibleMoves` lists it (always `[smaller, larger]`). With an ordered match, **every move that bot makes when playing second would be rejected**: a throw in dev, and in prod a no-op leaving the turn hung. There's a test pinning this.

## Verification

`npm run test` passes (97 files / 638 tests — baseline 95 / 626, plus the 12 new cases).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSxP4EAjGt4vDBxsQt32c)_