### PR TITLE
Move legality layer: the 4 multi-pile take-away games

### DIFF
--- a/src/components/games/four-piles-spread-ahead/four-piles-spread-ahead.tsx
+++ b/src/components/games/four-piles-spread-ahead/four-piles-spread-ahead.tsx
@@ -19,18 +19,10 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     return pieceId >= board[pileId];
   };
 
-  const isDisabled = ({ pileId, pieceId }: Piece) => {
-    if (!ctx.isClientMoveAllowed) return true;
-    // Clicking piece `pieceId` removes it and everything above it (from the top),
-    // i.e. `board[pileId] - pieceId` pieces; that count must be between 1 and pileId.
-    return pieceId < board[pileId] - pileId || pieceId > board[pileId] - 1;
-  };
-
-  const clickPiece = ({ pileId, pieceId }: Piece) => {
-    if (isDisabled({ pileId, pieceId })) return;
-
-    moves.spreadPieces(board, { pileId, pieceCount: board[pileId] - pieceId });
-  };
+  // Clicking piece `pieceId` removes it and everything above it (from the top),
+  // i.e. `board[pileId] - pieceId` pieces.
+  const isDisabled = ({ pileId, pieceId }: Piece) =>
+    !moves.spreadPieces.isAllowed!(board, { pileId, pieceCount: board[pileId] - pieceId });
 
   // The pieces removed by clicking the hovered piece: it and everything above it.
   const removedCount = () => (validHoveredPiece ? board[validHoveredPiece.pileId] - validHoveredPiece.pieceId : 0);
@@ -118,7 +110,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
                 pieceVisibility({ pileId, pieceId }),
                 pieceColor({ pileId, pieceId })
               ].join(' ')}
-              onClick={() => clickPiece({ pileId, pieceId })}
+              onClick={() => moves.spreadPieces(board, { pileId, pieceCount: board[pileId] - pieceId })}
               {...(isDisabled({ pileId, pieceId }) ? {} : hoverProps({ pileId, pieceId }))}
             >
               {!isDisabled({ pileId, pieceId }) &&
@@ -133,20 +125,33 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   );
 };
 
+// A move takes `pieceCount` pieces off pile `pileId` and puts one on each of the
+// `pieceCount` piles immediately in front of it, so it can never reach past the
+// first pile — hence the cap at `pileId`.
+export const isSpreadAllowed = (board: Board, pileId: number, pieceCount: number): boolean =>
+  Number.isInteger(pileId) && pileId >= 0 && pileId < board.length
+    && Number.isInteger(pieceCount)
+    && pieceCount >= 1
+    && pieceCount <= pileId
+    && pieceCount <= board[pileId];
+
 const moves = {
-  spreadPieces: (board: Board, { events }: { events: Events }, { pileId, pieceCount }) => {
-    if (pieceCount > pileId) console.error('invalid_move');
-    const nextBoard = cloneDeep(board);
-    nextBoard[pileId] = board[pileId] - pieceCount;
-    for (let i = pileId - pieceCount; i < pileId; i++) {
-      nextBoard[i] = board[i] + 1;
+  spreadPieces: {
+    validate: (board: Board, _, { pileId, pieceCount }: { pileId: number; pieceCount: number }) =>
+      isSpreadAllowed(board, pileId, pieceCount),
+    apply: (board: Board, { events }: { events: Events }, { pileId, pieceCount }) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard[pileId] = board[pileId] - pieceCount;
+      for (let i = pileId - pieceCount; i < pileId; i++) {
+        nextBoard[i] = board[i] + 1;
+      }
+      const isGameEnd = nextBoard[1]===0 && nextBoard[2]===0 && nextBoard[3]===0;
+      events.endTurn();
+      if (isGameEnd) {
+        events.endGame();
+      }
+      return { nextBoard };
     }
-    const isGameEnd = nextBoard[1]===0 && nextBoard[2]===0 && nextBoard[3]===0;
-    events.endTurn();
-    if (isGameEnd) {
-      events.endGame();
-    }
-    return { nextBoard };
   }
 };
 

--- a/src/components/games/four-piles-spread-ahead/legality.spec.ts
+++ b/src/components/games/four-piles-spread-ahead/legality.spec.ts
@@ -1,0 +1,32 @@
+import { isSpreadAllowed, type Board } from './four-piles-spread-ahead';
+
+const board: Board = [2, 3, 4, 5];
+
+describe('isSpreadAllowed', () => {
+  it('allows spreading onto every pile in front of the chosen one', () => {
+    expect([1, 2, 3].every(pieceCount => isSpreadAllowed(board, 3, pieceCount))).toBe(true);
+  });
+
+  it('rejects spreading further forward than the first pile', () => {
+    expect(isSpreadAllowed(board, 3, 4)).toBe(false);
+    expect(isSpreadAllowed(board, 1, 2)).toBe(false);
+  });
+
+  it('rejects any move from the first pile, which has nothing in front of it', () => {
+    expect(isSpreadAllowed(board, 0, 1)).toBe(false);
+  });
+
+  it('rejects taking more pieces than the pile holds', () => {
+    expect(isSpreadAllowed([2, 3, 1, 5], 2, 2)).toBe(false);
+    expect(isSpreadAllowed([2, 3, 1, 5], 2, 1)).toBe(true);
+  });
+
+  it('rejects taking nothing', () => {
+    expect(isSpreadAllowed(board, 3, 0)).toBe(false);
+  });
+
+  it('rejects a pile id outside the board or a non-integer count', () => {
+    expect(isSpreadAllowed(board, 4, 1)).toBe(false);
+    expect(isSpreadAllowed(board, 3, 1.5)).toBe(false);
+  });
+});

--- a/src/components/games/four-piles-two-grabs/four-piles-two-grabs.tsx
+++ b/src/components/games/four-piles-two-grabs/four-piles-two-grabs.tsx
@@ -105,8 +105,6 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     setRemovals(prev => prev.map((r, idx) => (idx === i ? r + delta : r)));
   };
 
-  const submit = () => moves.takeStones(board, removals);
-
   return (
     <GameBoard>
       <div className="flex gap-2 sm:gap-6 justify-center items-end">
@@ -127,7 +125,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
         <div className="mt-4 flex flex-col items-center gap-2">
           <button
             disabled={!readyToMove}
-            onClick={submit}
+            onClick={() => moves.takeStones(board, removals)}
             className="primary-button w-auto"
           >
             {t({ hu: 'Elveszem a kavicsokat', en: 'Remove the stones' })}

--- a/src/components/games/four-piles-two-grabs/four-piles-two-grabs.tsx
+++ b/src/components/games/four-piles-two-grabs/four-piles-two-grabs.tsx
@@ -10,6 +10,7 @@ import {
   type Board,
   type Move,
   applyMove,
+  isMoveLegal,
   isTerminal,
   getSmartBotMove,
   getRandomBotMove,
@@ -97,17 +98,14 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   }, [ctx.moveCount]);
 
   const activeCount = removals.filter(r => r > 0).length;
-  const readyToMove = activeCount === 2;
+  const readyToMove = moves.takeStones.isAllowed!(board, removals);
 
   const adjust = (i: number, delta: number) => {
     if (!ctx.isClientMoveAllowed) return;
     setRemovals(prev => prev.map((r, idx) => (idx === i ? r + delta : r)));
   };
 
-  const submit = () => {
-    if (!ctx.isClientMoveAllowed || !readyToMove) return;
-    moves.takeStones(board, removals);
-  };
+  const submit = () => moves.takeStones(board, removals);
 
   return (
     <GameBoard>
@@ -141,15 +139,18 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 };
 
 const moves = {
-  takeStones: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, move: Move) => {
-    const nextBoard = applyMove(board, move);
-    if (isTerminal(nextBoard)) {
-      // The opponent cannot move, so the player who just moved wins.
-      events.endGame(ctx.currentPlayer!);
-    } else {
-      events.endTurn();
+  takeStones: {
+    validate: (board: Board, _, move: Move) => isMoveLegal(board, move),
+    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, move: Move) => {
+      const nextBoard = applyMove(board, move);
+      if (isTerminal(nextBoard)) {
+        // The opponent cannot move, so the player who just moved wins.
+        events.endGame(ctx.currentPlayer!);
+      } else {
+        events.endTurn();
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 };
 

--- a/src/components/games/four-piles-two-grabs/helpers.spec.ts
+++ b/src/components/games/four-piles-two-grabs/helpers.spec.ts
@@ -1,6 +1,7 @@
 import {
   type Board,
   applyMove,
+  isMoveLegal,
   canMove,
   isTerminal,
   getLegalMoves,
@@ -133,6 +134,36 @@ describe('four-piles-two-grabs helpers', () => {
       const results = new Set<boolean>();
       for (let i = 0; i < 500; i++) results.add(isWinningBoard(generateStartBoard()));
       expect(results).toEqual(new Set([true, false]));
+    });
+  });
+
+  describe('isMoveLegal', () => {
+    const board: Board = [3, 4, 0, 5];
+
+    it('allows taking from exactly two non-empty piles', () => {
+      expect(isMoveLegal(board, [1, 2, 0, 0])).toBe(true);
+      expect(isMoveLegal(board, [3, 0, 0, 5])).toBe(true);
+    });
+
+    it('rejects taking from fewer or more than two piles', () => {
+      expect(isMoveLegal(board, [1, 0, 0, 0])).toBe(false);
+      expect(isMoveLegal(board, [0, 0, 0, 0])).toBe(false);
+      expect(isMoveLegal(board, [1, 1, 0, 1])).toBe(false);
+    });
+
+    it('rejects taking more than a pile holds', () => {
+      expect(isMoveLegal(board, [4, 1, 0, 0])).toBe(false);
+    });
+
+    it('rejects taking from an empty pile', () => {
+      expect(isMoveLegal(board, [1, 0, 1, 0])).toBe(false);
+    });
+
+    it('rejects a malformed move', () => {
+      expect(isMoveLegal(board, [1, 2])).toBe(false);
+      expect(isMoveLegal(board, [1.5, 2, 0, 0])).toBe(false);
+      expect(isMoveLegal(board, [-1, 2, 0, 0])).toBe(false);
+      expect(isMoveLegal(board, undefined as unknown as number[])).toBe(false);
     });
   });
 });

--- a/src/components/games/four-piles-two-grabs/helpers.ts
+++ b/src/components/games/four-piles-two-grabs/helpers.ts
@@ -18,6 +18,15 @@ export const isTerminal = (board: Board): boolean => !canMove(board);
 export const applyMove = (board: Board, move: Move): Board =>
   board.map((v, i) => v - move[i]);
 
+// A move takes from exactly two piles, at least one stone and at most the whole
+// pile from each. Checked directly rather than as membership in getLegalMoves,
+// which enumerates a quadratic number of moves.
+export const isMoveLegal = (board: Board, move: Move): boolean =>
+  Array.isArray(move)
+    && move.length === board.length
+    && move.every((removed, i) => Number.isInteger(removed) && removed >= 0 && removed <= board[i])
+    && move.filter(removed => removed > 0).length === 2;
+
 // Every legal move: pick two non-empty piles, remove between 1 and the whole
 // pile from each. Amounts removed from the two piles are independent.
 export const getLegalMoves = (board: Board): Move[] => {

--- a/src/components/games/matchstick-piles/legality.spec.ts
+++ b/src/components/games/matchstick-piles/legality.spec.ts
@@ -1,0 +1,35 @@
+import { isRemovalAllowed, isSplitAllowed, type Board } from './matchstick-piles';
+
+const board: Board = [1, 3, 5];
+
+describe('isRemovalAllowed', () => {
+  it('allows taking a match from any pile', () => {
+    expect([0, 1, 2].every(pileId => isRemovalAllowed(board, pileId))).toBe(true);
+  });
+
+  it('rejects a pile id outside the board', () => {
+    expect(isRemovalAllowed(board, 3)).toBe(false);
+    expect(isRemovalAllowed(board, -1)).toBe(false);
+    expect(isRemovalAllowed(board, 1.5)).toBe(false);
+  });
+});
+
+describe('isSplitAllowed', () => {
+  it('allows any split leaving both halves non-empty', () => {
+    expect([1, 2].every(firstPart => isSplitAllowed(board, 1, firstPart))).toBe(true);
+  });
+
+  it('rejects a split that would leave a half empty', () => {
+    expect(isSplitAllowed(board, 1, 0)).toBe(false);
+    expect(isSplitAllowed(board, 1, 3)).toBe(false);
+  });
+
+  it('rejects splitting a single-match pile', () => {
+    expect(isSplitAllowed(board, 0, 1)).toBe(false);
+  });
+
+  it('rejects a non-integer split point or pile id', () => {
+    expect(isSplitAllowed(board, 1, 1.5)).toBe(false);
+    expect(isSplitAllowed(board, 3, 1)).toBe(false);
+  });
+});

--- a/src/components/games/matchstick-piles/matchstick-piles.tsx
+++ b/src/components/games/matchstick-piles/matchstick-piles.tsx
@@ -29,7 +29,6 @@ const Matchstick = ({ removed }: { removed: boolean }) => (
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { value: activeHover, hoverProps } = useHoverPreview<Hover>(ctx.moveCount);
 
-  const canRemove = (pileId: number) => moves.removeMatch.isAllowed!(board, pileId);
   const canSplit = (pileId: number, splitAfter: number) =>
     moves.splitPile.isAllowed!(board, pileId, splitAfter + 1);
 
@@ -89,14 +88,14 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
                   <button
                     type="button"
                     aria-label="remove a match from this pile"
-                    disabled={!canRemove(pileId)}
+                    disabled={!moves.removeMatch.isAllowed!(board, pileId)}
                     className={`
                       p-1 rounded-sm
                       enabled:hover:bg-slate-200 dark:enabled:hover:bg-slate-700
                       enabled:focus:bg-slate-200 dark:enabled:focus:bg-slate-700
                     `}
                     onClick={() => moves.removeMatch(board, pileId)}
-                    {...(canRemove(pileId) ? hoverProps({ pileId, kind: 'remove' }) : {})}
+                    {...(moves.removeMatch.isAllowed!(board, pileId) ? hoverProps({ pileId, kind: 'remove' }) : {})}
                   >
                     <Matchstick removed={isMatchRemoved(pileId, matchId, size)} />
                   </button>

--- a/src/components/games/matchstick-piles/matchstick-piles.tsx
+++ b/src/components/games/matchstick-piles/matchstick-piles.tsx
@@ -29,15 +29,9 @@ const Matchstick = ({ removed }: { removed: boolean }) => (
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { value: activeHover, hoverProps } = useHoverPreview<Hover>(ctx.moveCount);
 
-  const clickRemove = (pileId: number) => {
-    if (!ctx.isClientMoveAllowed) return;
-    moves.removeMatch(board, pileId);
-  };
-
-  const clickSplit = (pileId: number, splitAfter: number) => {
-    if (!ctx.isClientMoveAllowed) return;
-    moves.splitPile(board, pileId, splitAfter + 1);
-  };
+  const canRemove = (pileId: number) => moves.removeMatch.isAllowed!(board, pileId);
+  const canSplit = (pileId: number, splitAfter: number) =>
+    moves.splitPile.isAllowed!(board, pileId, splitAfter + 1);
 
   const pileDescription = (pileId: number, size: number) => {
     if (!activeHover || activeHover.pileId !== pileId) return `${size}`;
@@ -77,10 +71,10 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
                     <button
                       type="button"
                       aria-label="split pile here"
-                      disabled={!ctx.isClientMoveAllowed}
+                      disabled={!canSplit(pileId, matchId - 1)}
                       className="self-stretch w-4 flex items-center justify-center group"
-                      onClick={() => clickSplit(pileId, matchId - 1)}
-                      {...(ctx.isClientMoveAllowed
+                      onClick={() => moves.splitPile(board, pileId, matchId)}
+                      {...(canSplit(pileId, matchId - 1)
                         ? hoverProps({ pileId, kind: 'split', splitAfter: matchId - 1 })
                         : {})}
                     >
@@ -95,14 +89,14 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
                   <button
                     type="button"
                     aria-label="remove a match from this pile"
-                    disabled={!ctx.isClientMoveAllowed}
+                    disabled={!canRemove(pileId)}
                     className={`
                       p-1 rounded-sm
                       enabled:hover:bg-slate-200 dark:enabled:hover:bg-slate-700
                       enabled:focus:bg-slate-200 dark:enabled:focus:bg-slate-700
                     `}
-                    onClick={() => clickRemove(pileId)}
-                    {...(ctx.isClientMoveAllowed ? hoverProps({ pileId, kind: 'remove' }) : {})}
+                    onClick={() => moves.removeMatch(board, pileId)}
+                    {...(canRemove(pileId) ? hoverProps({ pileId, kind: 'remove' }) : {})}
                   >
                     <Matchstick removed={isMatchRemoved(pileId, matchId, size)} />
                   </button>
@@ -116,24 +110,45 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   );
 };
 
+const isPileId = (board: Board, pileId: number): boolean =>
+  Number.isInteger(pileId) && pileId >= 0 && pileId < board.length;
+
+// Empty piles are dropped from the board, so every pile has a match to give up.
+export const isRemovalAllowed = (board: Board, pileId: number): boolean =>
+  isPileId(board, pileId) && board[pileId] >= 1;
+
+// A split has to leave both halves non-empty.
+export const isSplitAllowed = (board: Board, pileId: number, firstPart: number): boolean =>
+  isPileId(board, pileId)
+    && Number.isInteger(firstPart)
+    && firstPart >= 1
+    && firstPart <= board[pileId] - 1;
+
 const moves = {
-  removeMatch: (board: Board, { events }: { events: Events }, pileId: number) => {
-    const nextBoard = board
-      .map((n, i) => (i === pileId ? n - 1 : n))
-      .filter(n => n > 0);
-    events.endTurn();
-    // The player who takes the last match leaves the other player unable to
-    // move, and therefore wins.
-    if (nextBoard.length === 0) events.endGame();
-    return { nextBoard };
+  removeMatch: {
+    validate: (board: Board, _, pileId: number) => isRemovalAllowed(board, pileId),
+    apply: (board: Board, { events }: { events: Events }, pileId: number) => {
+      const nextBoard = board
+        .map((n, i) => (i === pileId ? n - 1 : n))
+        .filter(n => n > 0);
+      events.endTurn();
+      // The player who takes the last match leaves the other player unable to
+      // move, and therefore wins.
+      if (nextBoard.length === 0) events.endGame();
+      return { nextBoard };
+    }
   },
-  splitPile: (board: Board, _meta: { events: Events }, pileId: number, firstPart: number) => {
-    const size = board[pileId];
-    const nextBoard = board.flatMap((n, i) =>
-      i === pileId ? [firstPart, size - firstPart] : [n]
-    );
-    _meta.events.endTurn();
-    return { nextBoard };
+  splitPile: {
+    validate: (board: Board, _, pileId: number, firstPart: number) =>
+      isSplitAllowed(board, pileId, firstPart),
+    apply: (board: Board, { events }: { events: Events }, pileId: number, firstPart: number) => {
+      const size = board[pileId];
+      const nextBoard = board.flatMap((n, i) =>
+        i === pileId ? [firstPart, size - firstPart] : [n]
+      );
+      events.endTurn();
+      return { nextBoard };
+    }
   }
 };
 

--- a/src/components/games/three-piles-rebuild/helpers.spec.ts
+++ b/src/components/games/three-piles-rebuild/helpers.spec.ts
@@ -1,5 +1,8 @@
 import { range } from 'lodash';
 import {
+  isKeepAllowed,
+  isSplitAllowed,
+  keptPileId,
   isWinningNumber,
   isLosingNumber,
   isWinningBoard,
@@ -151,6 +154,63 @@ describe('three-piles-rebuild helpers', () => {
       for (let i = 0; i < 100; i++) {
         expect(isTerminal(generateTestStartBoard())).toBe(false);
       }
+    });
+  });
+
+  describe('keptPileId', () => {
+    it('is undefined at the start of a turn, when all three piles stand', () => {
+      expect(keptPileId([7, 8, 9])).toBe(undefined);
+    });
+
+    it('is the surviving pile once the other two are discarded', () => {
+      expect(keptPileId([0, 8, 0])).toBe(1);
+    });
+  });
+
+  describe('isKeepAllowed', () => {
+    it('allows keeping a pile that can still be split', () => {
+      expect(isKeepAllowed([7, 8, 9], 1)).toBe(true);
+    });
+
+    it('rejects keeping a pile too small to split into three', () => {
+      expect(isKeepAllowed([7, 2, 9], 1)).toBe(false);
+    });
+
+    it('rejects a second keep in the same turn', () => {
+      expect(keptPileId([0, 8, 0])).toBe(1);
+      expect(isKeepAllowed([0, 8, 0], 1)).toBe(false);
+    });
+
+    it('rejects a pile id outside the board', () => {
+      expect(isKeepAllowed([7, 8, 9], 3)).toBe(false);
+      expect(isKeepAllowed([7, 8, 9], -1)).toBe(false);
+    });
+  });
+
+  describe('isSplitAllowed', () => {
+    it('allows three non-empty parts summing to the kept pile', () => {
+      expect(isSplitAllowed([0, 8, 0], [1, 1, 6])).toBe(true);
+      expect(isSplitAllowed([0, 8, 0], [3, 3, 2])).toBe(true);
+    });
+
+    it('rejects parts that do not use up the kept pile', () => {
+      expect(isSplitAllowed([0, 8, 0], [1, 1, 5])).toBe(false);
+      expect(isSplitAllowed([0, 8, 0], [1, 1, 7])).toBe(false);
+    });
+
+    it('rejects an empty or negative part', () => {
+      expect(isSplitAllowed([0, 8, 0], [0, 2, 6])).toBe(false);
+      expect(isSplitAllowed([0, 8, 0], [-1, 3, 6])).toBe(false);
+    });
+
+    it('rejects anything that is not three whole parts', () => {
+      expect(isSplitAllowed([0, 8, 0], [4, 4])).toBe(false);
+      expect(isSplitAllowed([0, 8, 0], [1, 1, 3, 3])).toBe(false);
+      expect(isSplitAllowed([0, 8, 0], [1.5, 1.5, 5])).toBe(false);
+    });
+
+    it('rejects splitting before a pile has been kept this turn', () => {
+      expect(isSplitAllowed([7, 8, 9], [1, 1, 6])).toBe(false);
     });
   });
 });

--- a/src/components/games/three-piles-rebuild/helpers.ts
+++ b/src/components/games/three-piles-rebuild/helpers.ts
@@ -9,6 +9,34 @@ export const canSplit = (n: number): boolean => n >= 3;
 // A player facing a triple loses exactly when no pile can be split any more.
 export const isTerminal = (board: Board): boolean => !board.some(canSplit);
 
+// Between the two halves of a turn the two discarded piles are 0, so the board
+// itself records whether a turn is half-done; no turn state is needed. Every
+// pile of a finished turn holds at least one pebble, so a 0 can only be a
+// discarded pile.
+export const keptPileId = (board: Board): number | undefined =>
+  board.filter(v => v === 0).length === 2 ? board.findIndex(v => v > 0) : undefined;
+
+// The board `keepPile` leaves behind. The board client needs it too: it must
+// judge the rebuild half of the turn before the keep has been dispatched.
+export const withOtherPilesDiscarded = (board: Board, keepId: number): Board =>
+  board.map((v, i) => (i === keepId ? v : 0));
+
+// A pile can be kept only at the start of a turn, and only if it can be split.
+export const isKeepAllowed = (board: Board, keepId: number): boolean =>
+  Number.isInteger(keepId) && keepId >= 0 && keepId < board.length
+    && keptPileId(board) === undefined
+    && canSplit(board[keepId]);
+
+// The rebuild has to use up the kept pile exactly, in three non-empty parts.
+export const isSplitAllowed = (board: Board, parts: number[]): boolean => {
+  const keptId = keptPileId(board);
+  if (keptId === undefined) return false;
+  return Array.isArray(parts)
+    && parts.length === 3
+    && parts.every(part => Number.isInteger(part) && part >= 1)
+    && parts.reduce((a, b) => a + b, 0) === board[keptId];
+};
+
 // Winning ("N") numbers are n >= 3 with n % 6 in {0,3,4,5}; the losing ("P")
 // numbers are exactly n % 6 in {1,2} (1,2,7,8,13,14,...). See helpers.spec.ts /
 // the written proof: a number is winning iff it can be split into three losing

--- a/src/components/games/three-piles-rebuild/three-piles-rebuild.tsx
+++ b/src/components/games/three-piles-rebuild/three-piles-rebuild.tsx
@@ -11,7 +11,10 @@ import { useTranslation } from '../../../language';
 import {
   type Board,
   canSplit,
+  isKeepAllowed,
+  isSplitAllowed,
   isTerminal,
+  withOtherPilesDiscarded,
   getSmartBotStep,
   getRandomBotStep,
   generateStartBoard,
@@ -41,8 +44,10 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const isMidMove = board.filter(v => v === 0).length === 2;
   const activeKeepId = keepId ?? (isMidMove ? board.findIndex(v => v > 0) : null);
 
+  // A rejected click must leave the local selection alone, so this keeps a guard
+  // rather than relying on the engine silently ignoring the dispatch.
   const clickPile = (pileId: number) => {
-    if (!ctx.isClientMoveAllowed || isMidMove || !canSplit(board[pileId])) return;
+    if (!moves.keepPile.isAllowed!(board, pileId)) return;
     setInputs({ p1: '', p2: '' });
     setKeepId(prev => (prev === pileId ? null : pileId));
   };
@@ -51,7 +56,10 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const p1 = parsePart(inputs.p1);
   const p2 = parsePart(inputs.p2);
   const p3 = p1 !== null && p2 !== null ? n - p1 - p2 : null;
-  const splitValid = p1 !== null && p2 !== null && p3 !== null && p3 >= 1;
+  // The rebuild is judged against the board the keep would leave behind, since
+  // both halves of the turn are submitted by this one button.
+  const splitValid = keepId !== null && p1 !== null && p2 !== null && p3 !== null
+    && isSplitAllowed(withOtherPilesDiscarded(board, keepId), [p1, p2, p3]);
 
   const submit = () => {
     if (!ctx.isClientMoveAllowed || keepId === null || !splitValid) return;
@@ -81,7 +89,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
           return (
             <button
               key={pileId}
-              disabled={!ctx.isClientMoveAllowed || isMidMove || !canSplit(board[pileId])}
+              disabled={!moves.keepPile.isAllowed!(board, pileId)}
               onClick={() => clickPile(pileId)}
               className={`
                 flex-1 max-w-32 rounded-lg border-2 p-3 sm:p-4 flex flex-col items-center gap-1
@@ -165,17 +173,21 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 
 const moves = {
   // Step 1 of a turn: keep one pile, discard the other two (shown as 0).
-  keepPile: (board: Board, _: unknown, keepId: number) => {
-    const nextBoard = board.map((v, i) => (i === keepId ? v : 0));
-    return { nextBoard };
+  keepPile: {
+    validate: (board: Board, _, keepId: number) => isKeepAllowed(board, keepId),
+    apply: (board: Board, _, keepId: number) =>
+      ({ nextBoard: withOtherPilesDiscarded(board, keepId) })
   },
   // Step 2: rebuild three new piles from the kept pile's pebbles.
-  splitPile: (_board: Board, { events }: { events: Events }, parts: number[]) => {
-    const nextBoard = [...parts];
-    events.endTurn();
-    // The opponent now faces nextBoard; if they cannot split any pile they lose.
-    if (isTerminal(nextBoard)) events.endGame();
-    return { nextBoard };
+  splitPile: {
+    validate: (board: Board, _, parts: number[]) => isSplitAllowed(board, parts),
+    apply: (_board: Board, { events }: { events: Events }, parts: number[]) => {
+      const nextBoard = [...parts];
+      events.endTurn();
+      // The opponent now faces nextBoard; if they cannot split any pile they lose.
+      if (isTerminal(nextBoard)) events.endGame();
+      return { nextBoard };
+    }
   }
 };
 


### PR DESCRIPTION
Batch 9 of the follow-up to #333. Branched off `main`, mergeable in any order.

## Games covered

`matchstick-piles`, `three-piles-rebuild`, `four-piles-two-grabs`, `four-piles-spread-ahead`.

All four move stones between or out of several piles, but each has its own rule, so **nothing is shared between them** — each keeps its own validators.

## Changes

- **`matchstick-piles`**: `isRemovalAllowed` and `isSplitAllowed`. Both buttons now read `disabled` from `moves.<name>.isAllowed` rather than turn ownership alone, so a split point that would leave a half empty is properly disabled instead of merely never rendered.
- **`three-piles-rebuild`**: `isKeepAllowed` / `isSplitAllowed` in helpers, plus `keptPileId` and `withOtherPilesDiscarded`. As in the pile-splitters (#337), the two discarded piles being 0 is what records that a turn is half-done, so both halves stay pure functions of the board with no turn state. The submit button judges the rebuild against the board the keep *would* leave behind, since one click submits both halves.
- **`four-piles-two-grabs`**: `isMoveLegal` — exactly two piles, at least one and at most the whole pile from each. Written directly rather than as membership in `getLegalMoves`, which enumerates a quadratic number of moves. `readyToMove` now comes from the validator, so the button also catches a removal exceeding its pile (previously only the stepper's own bounds prevented that).
- **`four-piles-spread-ahead`**: `isSpreadAllowed`, replacing the board client's inline arithmetic. As in #340, the apply drops its `console.error('invalid_move')` branch — the engine now rejects the move outright instead of logging and proceeding.
- Add specs for all four games' validators.

No change to the bots: each already picks a legal move, and both two-step turns already thread the intermediate board into their second dispatch.

## Verification

`npm run test` passes (97 files / 654 tests — baseline 95 / 626, plus the 28 new cases).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSxP4EAjGt4vDBxsQt32c)_