### PR TITLE
Move legality layer: the 2 magic-box sibling games

### DIFF
--- a/src/components/games/magic-box/magic-box-a/helpers.spec.ts
+++ b/src/components/games/magic-box/magic-box-a/helpers.spec.ts
@@ -1,4 +1,4 @@
-import { hasFullLine, generateEmptyBoard } from './helpers';
+import { hasFullLine, generateEmptyBoard, isPlacementAllowed } from './helpers';
 
 describe('hasFullLine', () => {
   it('should be false for an empty board', () => {
@@ -40,5 +40,26 @@ describe('hasFullLine', () => {
       true, true, false
     ];
     expect(hasFullLine(board)).toBe(true);
+  });
+});
+
+describe('isPlacementAllowed', () => {
+  it('allows any empty compartment', () => {
+    const board = generateEmptyBoard();
+    expect([0, 4, 8].every(id => isPlacementAllowed(board, id))).toBe(true);
+  });
+
+  it('rejects a compartment that already holds a stone', () => {
+    const board = generateEmptyBoard();
+    board[4] = true;
+    expect(isPlacementAllowed(board, 4)).toBe(false);
+    expect(isPlacementAllowed(board, 3)).toBe(true);
+  });
+
+  it('rejects a compartment outside the box', () => {
+    const board = generateEmptyBoard();
+    expect(isPlacementAllowed(board, 9)).toBe(false);
+    expect(isPlacementAllowed(board, -1)).toBe(false);
+    expect(isPlacementAllowed(board, 1.5)).toBe(false);
   });
 });

--- a/src/components/games/magic-box/magic-box-a/helpers.ts
+++ b/src/components/games/magic-box/magic-box-a/helpers.ts
@@ -11,6 +11,10 @@ export const generateEmptyBoard = (): Board => Array(9).fill(false);
 
 export const placeStone = (board: Board, i: number): Board => [...board.slice(0, i), true, ...board.slice(i + 1)];
 
+// A stone goes into any compartment that is still empty.
+export const isPlacementAllowed = (board: Board, id: number): boolean =>
+  Number.isInteger(id) && id >= 0 && id < board.length && !board[id];
+
 const LINES = [
   [0, 1, 2],
   [3, 4, 5],

--- a/src/components/games/magic-box/magic-box-a/magic-box-a.tsx
+++ b/src/components/games/magic-box/magic-box-a/magic-box-a.tsx
@@ -2,19 +2,11 @@ import { range } from 'lodash';
 import {
   strategyGameFactory, type Events, type BoardClientProps, type Ctx, GameBoard
 } from '../../../strategy-game-factory';
-import { generateEmptyBoard, isGameEnd, placeStone, type Board } from './helpers';
+import { generateEmptyBoard, isGameEnd, isPlacementAllowed, placeStone, type Board } from './helpers';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 
-const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
-  const isMoveAllowed = (id) => {
-    if (!ctx.isClientMoveAllowed) return false;
-    return !board[id];
-  };
-  const clickField = (id) => {
-    if (!isMoveAllowed(id)) return;
-
-    moves.placeStone(board, id);
-  };
+const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
+  const isMoveAllowed = (id: number) => moves.placeStone.isAllowed!(board, id);
 
   return (
   <GameBoard>
@@ -23,7 +15,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
         <button
           key={id}
           disabled={!isMoveAllowed(id)}
-          onClick={() => clickField(id)}
+          onClick={() => moves.placeStone(board, id)}
           className="aspect-square p-[25%] bg-surface-elevated"
         >
           {board[id] && (
@@ -37,13 +29,16 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 };
 
 const moves = {
-  placeStone: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, id) => {
-    const nextBoard = placeStone(board, id);
-    events.endTurn();
-    if (isGameEnd(nextBoard)) {
-      events.endGame(ctx.currentPlayer === 0 ? 1 : 0);
+  placeStone: {
+    validate: (board: Board, _, id: number) => isPlacementAllowed(board, id),
+    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, id) => {
+      const nextBoard = placeStone(board, id);
+      events.endTurn();
+      if (isGameEnd(nextBoard)) {
+        events.endGame(ctx.currentPlayer === 0 ? 1 : 0);
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 }
 

--- a/src/components/games/magic-box/magic-box-a/magic-box-a.tsx
+++ b/src/components/games/magic-box/magic-box-a/magic-box-a.tsx
@@ -6,7 +6,6 @@ import { generateEmptyBoard, isGameEnd, isPlacementAllowed, placeStone, type Boa
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 
 const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
-  const isMoveAllowed = (id: number) => moves.placeStone.isAllowed!(board, id);
 
   return (
   <GameBoard>
@@ -14,7 +13,7 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
       {range(9).map(id => (
         <button
           key={id}
-          disabled={!isMoveAllowed(id)}
+          disabled={!moves.placeStone.isAllowed!(board, id)}
           onClick={() => moves.placeStone(board, id)}
           className="aspect-square p-[25%] bg-surface-elevated"
         >

--- a/src/components/games/magic-box/magic-box-a/magic-box-a.tsx
+++ b/src/components/games/magic-box/magic-box-a/magic-box-a.tsx
@@ -5,9 +5,7 @@ import {
 import { generateEmptyBoard, isGameEnd, isPlacementAllowed, placeStone, type Board } from './helpers';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 
-const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
-
-  return (
+const BoardClient = ({ board, moves }: BoardClientProps<Board>) => (
   <GameBoard>
     <div className="grid grid-cols-3 bg-slate-200 dark:bg-slate-600 gap-1 p-1">
       {range(9).map(id => (
@@ -24,8 +22,7 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
       ))}
     </div>
   </GameBoard>
-  );
-};
+);
 
 const moves = {
   placeStone: {

--- a/src/components/games/magic-box/magic-box-b/board-client.tsx
+++ b/src/components/games/magic-box/magic-box-b/board-client.tsx
@@ -9,7 +9,6 @@ export const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
   const { stones, pendingLine } = board;
 
-  const canDesignate = (lineIndex: number) => moves.designateLine.isAllowed!(board, lineIndex);
 
   const isCellHighlighted = (id) => pendingLine !== null && LINES[pendingLine].includes(id);
 
@@ -43,7 +42,7 @@ export const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
             {range(3).map(row => (
               <button
                 key={row}
-                disabled={!canDesignate(row)}
+                disabled={!moves.designateLine.isAllowed!(board, row)}
                 onClick={() => moves.designateLine(board, row)}
                 title={t(LINE_LABELS[row])}
                 aria-label={t(LINE_LABELS[row])}
@@ -59,7 +58,7 @@ export const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
           {range(3).map(col => (
             <button
               key={col}
-              disabled={!canDesignate(3 + col)}
+              disabled={!moves.designateLine.isAllowed!(board, 3 + col)}
               onClick={() => moves.designateLine(board, 3 + col)}
               title={t(LINE_LABELS[3 + col])}
               aria-label={t(LINE_LABELS[3 + col])}

--- a/src/components/games/magic-box/magic-box-b/board-client.tsx
+++ b/src/components/games/magic-box/magic-box-b/board-client.tsx
@@ -10,7 +10,6 @@ export const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
   const { stones, pendingLine } = board;
 
   const canDesignate = (lineIndex: number) => moves.designateLine.isAllowed!(board, lineIndex);
-  const isCellClickable = (id: number) => moves.placeStone.isAllowed!(board, id);
 
   const isCellHighlighted = (id) => pendingLine !== null && LINES[pendingLine].includes(id);
 
@@ -27,7 +26,7 @@ export const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
             {range(9).map(id => (
               <button
                 key={id}
-                disabled={!isCellClickable(id)}
+                disabled={!moves.placeStone.isAllowed!(board, id)}
                 onClick={() => moves.placeStone(board, id)}
                 className={`p-[20%] ${
                   isCellHighlighted(id) ? 'bg-amber-200 dark:bg-amber-700' : 'bg-surface-elevated'

--- a/src/components/games/magic-box/magic-box-b/board-client.tsx
+++ b/src/components/games/magic-box/magic-box-b/board-client.tsx
@@ -5,25 +5,12 @@ import { LINES, LINE_LABELS, type Board } from './helpers';
 
 const BOX_SIZE = 'w-64 sm:w-72';
 
-export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
+export const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
   const { stones, pendingLine } = board;
-  const canDesignate = ctx.isClientMoveAllowed && pendingLine === null;
 
-  const isCellClickable = (id) => {
-    if (!ctx.isClientMoveAllowed || pendingLine === null) return false;
-    return LINES[pendingLine].includes(id) && !stones[id];
-  };
-
-  const clickCell = (id) => {
-    if (!isCellClickable(id)) return;
-    moves.placeStone(board, id);
-  };
-
-  const designateLine = (lineIndex) => {
-    if (!canDesignate) return;
-    moves.designateLine(board, lineIndex);
-  };
+  const canDesignate = (lineIndex: number) => moves.designateLine.isAllowed!(board, lineIndex);
+  const isCellClickable = (id: number) => moves.placeStone.isAllowed!(board, id);
 
   const isCellHighlighted = (id) => pendingLine !== null && LINES[pendingLine].includes(id);
 
@@ -41,7 +28,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
               <button
                 key={id}
                 disabled={!isCellClickable(id)}
-                onClick={() => clickCell(id)}
+                onClick={() => moves.placeStone(board, id)}
                 className={`p-[20%] ${
                   isCellHighlighted(id) ? 'bg-amber-200 dark:bg-amber-700' : 'bg-surface-elevated'
                 }`}
@@ -57,8 +44,8 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
             {range(3).map(row => (
               <button
                 key={row}
-                disabled={!canDesignate}
-                onClick={() => designateLine(row)}
+                disabled={!canDesignate(row)}
+                onClick={() => moves.designateLine(board, row)}
                 title={t(LINE_LABELS[row])}
                 aria-label={t(LINE_LABELS[row])}
                 className={`${selectorButtonClass} w-10`}
@@ -73,8 +60,8 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
           {range(3).map(col => (
             <button
               key={col}
-              disabled={!canDesignate}
-              onClick={() => designateLine(3 + col)}
+              disabled={!canDesignate(3 + col)}
+              onClick={() => moves.designateLine(board, 3 + col)}
               title={t(LINE_LABELS[3 + col])}
               aria-label={t(LINE_LABELS[3 + col])}
               className={`${selectorButtonClass} h-10`}

--- a/src/components/games/magic-box/magic-box-b/helpers.spec.ts
+++ b/src/components/games/magic-box/magic-box-b/helpers.spec.ts
@@ -1,4 +1,6 @@
-import { isLineFull, emptyCellsInLine, placeStoneAt } from './helpers';
+import {
+  isLineFull, emptyCellsInLine, placeStoneAt, isPlacementAllowed, isDesignationAllowed, type Board
+} from './helpers';
 
 describe('isLineFull', () => {
   it('should be false when a row is not fully occupied', () => {
@@ -35,5 +37,51 @@ describe('placeStoneAt', () => {
     const next = placeStoneAt(stones, 4);
     expect(next).toEqual([false, false, false, false, true, false, false, false, false]);
     expect(stones[4]).toBe(false);
+  });
+});
+
+// Row 1 is line 0 (cells 0,1,2); column 1 is line 3 (cells 0,3,6).
+const boardAwaitingStoneInRow1 = (): Board => ({ stones: Array(9).fill(false), pendingLine: 0 });
+const boardAwaitingDesignation = (): Board => ({ stones: Array(9).fill(false), pendingLine: null });
+
+describe('isPlacementAllowed', () => {
+  it('allows an empty cell of the designated line', () => {
+    const board = boardAwaitingStoneInRow1();
+    expect([0, 1, 2].every(id => isPlacementAllowed(board, id))).toBe(true);
+  });
+
+  it('rejects a cell outside the designated line', () => {
+    expect(isPlacementAllowed(boardAwaitingStoneInRow1(), 3)).toBe(false);
+  });
+
+  it('rejects a cell of the designated line that is already taken', () => {
+    const board = boardAwaitingStoneInRow1();
+    board.stones[1] = true;
+    expect(isPlacementAllowed(board, 1)).toBe(false);
+  });
+
+  it('rejects placing while no line has been designated', () => {
+    expect(isPlacementAllowed(boardAwaitingDesignation(), 0)).toBe(false);
+  });
+
+  it('rejects a cell outside the box', () => {
+    expect(isPlacementAllowed(boardAwaitingStoneInRow1(), 9)).toBe(false);
+  });
+});
+
+describe('isDesignationAllowed', () => {
+  it('allows any of the six lines once the stone has been placed', () => {
+    const board = boardAwaitingDesignation();
+    expect([0, 1, 2, 3, 4, 5].every(line => isDesignationAllowed(board, line))).toBe(true);
+  });
+
+  it('rejects designating while a line is still awaiting its stone', () => {
+    expect(isDesignationAllowed(boardAwaitingStoneInRow1(), 2)).toBe(false);
+  });
+
+  it('rejects a line index that does not exist', () => {
+    const board = boardAwaitingDesignation();
+    expect(isDesignationAllowed(board, 6)).toBe(false);
+    expect(isDesignationAllowed(board, -1)).toBe(false);
   });
 });

--- a/src/components/games/magic-box/magic-box-b/helpers.ts
+++ b/src/components/games/magic-box/magic-box-b/helpers.ts
@@ -35,3 +35,18 @@ export const emptyCellsInLine = (stones: boolean[], lineIndex: number) => LINES[
 
 export const placeStoneAt = (stones: boolean[], cellId: number): boolean[] =>
   [...stones.slice(0, cellId), true, ...stones.slice(cellId + 1)];
+
+// The two halves of a turn alternate through `pendingLine`, which the board
+// itself carries — a designated line is waiting for a stone, and only once that
+// stone is placed may the next line be designated. So neither half needs turn
+// state to know whether it is its moment.
+export const isPlacementAllowed = (board: Board, cellId: number): boolean =>
+  board.pendingLine !== null
+    && LINES[board.pendingLine].includes(cellId)
+    && !board.stones[cellId];
+
+export const isDesignationAllowed = (board: Board, lineIndex: number): boolean =>
+  board.pendingLine === null
+    && Number.isInteger(lineIndex)
+    && lineIndex >= 0
+    && lineIndex < LINES.length;

--- a/src/components/games/magic-box/magic-box-b/magic-box-b.tsx
+++ b/src/components/games/magic-box/magic-box-b/magic-box-b.tsx
@@ -1,22 +1,30 @@
 import { strategyGameFactory, type Events, type Ctx } from '../../../strategy-game-factory';
 import { BoardClient } from './board-client';
-import { generateEmptyBoard, isLineFull, placeStoneAt, type Board } from './helpers';
+import {
+  generateEmptyBoard, isDesignationAllowed, isLineFull, isPlacementAllowed, placeStoneAt, type Board
+} from './helpers';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 
 const moves = {
-  placeStone: (board: Board, _, cellId) => {
-    const nextBoard: Board = { stones: placeStoneAt(board.stones, cellId), pendingLine: null };
-    return { nextBoard };
+  placeStone: {
+    validate: (board: Board, _, cellId: number) => isPlacementAllowed(board, cellId),
+    apply: (board: Board, _, cellId) => {
+      const nextBoard: Board = { stones: placeStoneAt(board.stones, cellId), pendingLine: null };
+      return { nextBoard };
+    }
   },
 
-  designateLine: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, lineIndex) => {
-    const nextBoard: Board = { stones: board.stones, pendingLine: lineIndex };
-    if (isLineFull(nextBoard.stones, lineIndex)) {
-      events.endGame(ctx.currentPlayer === 0 ? 0 : 1);
-    } else {
-      events.endTurn();
+  designateLine: {
+    validate: (board: Board, _, lineIndex: number) => isDesignationAllowed(board, lineIndex),
+    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, lineIndex) => {
+      const nextBoard: Board = { stones: board.stones, pendingLine: lineIndex };
+      if (isLineFull(nextBoard.stones, lineIndex)) {
+        events.endGame(ctx.currentPlayer === 0 ? 0 : 1);
+      } else {
+        events.endTurn();
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 };
 


### PR DESCRIPTION
Batch 10 of the follow-up to #333. Branched off `main`, mergeable in any order.

## Games covered

`magic-box-a`, `magic-box-b`. Different games on the same 3×3 box, so each keeps its own predicates in its own helpers.

## Changes

- **`magic-box-a`**: `isPlacementAllowed` — any compartment that is still empty.
- **`magic-box-b`**: `isPlacementAllowed` and `isDesignationAllowed`. Its turn has two halves that alternate through `board.pendingLine`, which the board itself carries: a designated line is waiting for a stone, and only once that stone is placed may the next line be designated. So **both halves stay pure functions of the board, with no turn state** — the same shape as the pile-splitters in #337.
- Both board clients drop their local predicates and click guards, reading `disabled` from `moves.<name>.isAllowed`; neither reads `ctx` any more. `magic-box-b`'s `canDesignate` becomes per-line rather than one flag shared by all six buttons.
- Add spec coverage for all three predicates.

No change to the bots: both already choose empty cells, and `-b` already threads the intermediate board into the designation that follows its placement.

## Verification

`npm run test` passes (95 files / 637 tests — baseline 95 / 626, plus the 11 new cases in existing spec files).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSxP4EAjGt4vDBxsQt32c)_