### PR TITLE
Move legality layer: the 2 thief-sheriff-mean sibling games

### DIFF
--- a/src/components/games/thief-sheriff-mean/helpers.spec.ts
+++ b/src/components/games/thief-sheriff-mean/helpers.spec.ts
@@ -1,8 +1,7 @@
-import { isCardAvailable, Sheriff, Thief, type Board } from './helpers';
+import { isCardAvailable, type Board } from './helpers';
 
-const board: Board = { cards: [[], []], numTurns: 0 };
-board.cards[Sheriff] = [2, 5];
-board.cards[Thief] = [3];
+// cards[Sheriff] first, then cards[Thief].
+const board: Board = { cards: [[2, 5], [3]], numTurns: 0 };
 
 describe('isCardAvailable', () => {
   it('allows a card no-one is holding yet', () => {

--- a/src/components/games/thief-sheriff-mean/helpers.spec.ts
+++ b/src/components/games/thief-sheriff-mean/helpers.spec.ts
@@ -1,0 +1,28 @@
+import { isCardAvailable, Sheriff, Thief, type Board } from './helpers';
+
+const board: Board = { cards: [[], []], numTurns: 0 };
+board.cards[Sheriff] = [2, 5];
+board.cards[Thief] = [3];
+
+describe('isCardAvailable', () => {
+  it('allows a card no-one is holding yet', () => {
+    expect([1, 4, 6, 7].every(index => isCardAvailable(board, 7, index))).toBe(true);
+  });
+
+  it("rejects a card either player already holds", () => {
+    expect(isCardAvailable(board, 7, 2)).toBe(false); // sheriff's
+    expect(isCardAvailable(board, 7, 3)).toBe(false); // thief's
+  });
+
+  it('rejects a card outside the deck', () => {
+    expect(isCardAvailable(board, 7, 8)).toBe(false);
+    expect(isCardAvailable(board, 7, 0)).toBe(false);
+    expect(isCardAvailable(board, 7, 1.5)).toBe(false);
+  });
+
+  it('follows the deck size it is given', () => {
+    // 8 and 9 exist in the nine-card variant but not in the seven-card one
+    expect(isCardAvailable(board, 9, 8)).toBe(true);
+    expect(isCardAvailable(board, 7, 8)).toBe(false);
+  });
+});

--- a/src/components/games/thief-sheriff-mean/helpers.ts
+++ b/src/components/games/thief-sheriff-mean/helpers.ts
@@ -30,6 +30,11 @@ export const getUntakenCards = (board: Board, total: number) => {
   );
 }
 
+// Each step of either variant takes one card off the table, and only a card
+// neither player is holding yet.
+export const isCardAvailable = (board: Board, total: number, index: number): boolean =>
+  getUntakenCards(board, total).includes(index);
+
 export const generateStartBoard = (): Board => {
   return {
     cards: [[], []],

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/moves.ts
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/moves.ts
@@ -1,5 +1,5 @@
 import { cloneDeep } from 'lodash';
-import { Sheriff, Thief, hasWinningTriple, getUntakenCards, type Board } from '../helpers';
+import { Sheriff, Thief, hasWinningTriple, getUntakenCards, isCardAvailable, type Board } from '../helpers';
 import type { Ctx, Events } from '../../../strategy-game-factory';
 
 export const CARD_COUNT = 7;
@@ -17,13 +17,19 @@ export const applyTakeCard = (board: Board, player: number, indices: number[]): 
 };
 
 export const moves = {
-  takeCard: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, indices: number[]): { nextBoard: Board } => {
-    const nextBoard = applyTakeCard(board, ctx.currentPlayer!, indices);
-    if (nextBoard.numTurns >= 5) {
-      const winner = hasWinningTriple(nextBoard.cards[Thief]) ? Thief : Sheriff;
-      events.endGame(winner);
+  takeCard: {
+    // A step takes a single card; the sweep of whatever is left at the end of
+    // the game happens inside `applyTakeCard`, not as a move argument.
+    validate: (board: Board, _, indices: number[]) =>
+      Array.isArray(indices) && indices.length === 1 && isCardAvailable(board, CARD_COUNT, indices[0]),
+    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, indices: number[]): { nextBoard: Board } => {
+      const nextBoard = applyTakeCard(board, ctx.currentPlayer!, indices);
+      if (nextBoard.numTurns >= 5) {
+        const winner = hasWinningTriple(nextBoard.cards[Thief]) ? Thief : Sheriff;
+        events.endGame(winner);
+      }
+      events.endTurn();
+      return { nextBoard };
     }
-    events.endTurn();
-    return { nextBoard };
   }
 };

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/thief-sheriff-mean-7.tsx
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/thief-sheriff-mean-7.tsx
@@ -4,22 +4,15 @@ import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import {
   Sheriff,
   Thief,
-  getUntakenCards,
   generateStartBoard,
   type Board
 } from "../helpers";
 import { moves, CARD_COUNT } from './moves';
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
-  const isAllowedMove = index => {
-    if (!ctx.isClientMoveAllowed) return false;
-    return getUntakenCards(board, CARD_COUNT).includes(index);
-  }
+  const isAllowedMove = (index: number) => moves.takeCard.isAllowed!(board, [index]);
 
-  const clickCard = (index) => {
-    if (!isAllowedMove(index)) return;
-    moves.takeCard(board, [index]);
-  }
+  const clickCard = (index: number) => moves.takeCard(board, [index]);
 
   const getCardColor = num => {
     if (board.cards[Thief].includes(num)) return 'bg-red-800';

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/thief-sheriff-mean-7.tsx
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/thief-sheriff-mean-7.tsx
@@ -10,9 +10,7 @@ import {
 import { moves, CARD_COUNT } from './moves';
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
-  const isAllowedMove = (index: number) => moves.takeCard.isAllowed!(board, [index]);
 
-  const clickCard = (index: number) => moves.takeCard(board, [index]);
 
   const getCardColor = num => {
     if (board.cards[Thief].includes(num)) return 'bg-red-800';
@@ -26,8 +24,8 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
         {range(1, CARD_COUNT + 1).map(num =>
         <button
           key={num}
-          disabled={!isAllowedMove(num)}
-          onClick={() => clickCard(num)}
+          disabled={!moves.takeCard.isAllowed!(board, [num])}
+          onClick={() => moves.takeCard(board, [num])}
           className={`
             m-1 min-h-28 w-18 border-2 rounded-lg shadow-md border-slate-900 dark:border-slate-400 text-4xl font-bold
             ${ctx.currentPlayer === Thief

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/thief-sheriff-mean-7.tsx
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/thief-sheriff-mean-7.tsx
@@ -10,8 +10,6 @@ import {
 import { moves, CARD_COUNT } from './moves';
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
-
-
   const getCardColor = num => {
     if (board.cards[Thief].includes(num)) return 'bg-red-800';
     if (board.cards[Sheriff].includes(num)) return 'bg-blue-800 text-white';

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/moves.ts
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/moves.ts
@@ -1,5 +1,5 @@
 import { cloneDeep } from 'lodash';
-import { Sheriff, Thief, hasWinningTriple, getUntakenCards, type Board } from '../helpers';
+import { Sheriff, Thief, hasWinningTriple, getUntakenCards, isCardAvailable, type Board } from '../helpers';
 import type { Ctx, Events } from '../../../strategy-game-factory';
 
 export const CARD_COUNT = 9;
@@ -15,15 +15,18 @@ export const applyTakeCard = (board: Board, player: number, idx: number): Board 
 };
 
 export const moves = {
-  takeCard: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, idx: number): { nextBoard: Board } => {
-    const nextBoard = applyTakeCard(board, ctx.currentPlayer!, idx);
-    if (nextBoard.numTurns === 8) {
-      const winner = hasWinningTriple(nextBoard.cards[Thief]) ? Thief : Sheriff;
-      events.endGame(winner);
-    } else if (hasWinningTriple(nextBoard.cards[Thief])) {
-      events.endGame(Thief);
+  takeCard: {
+    validate: (board: Board, _, idx: number) => isCardAvailable(board, CARD_COUNT, idx),
+    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, idx: number): { nextBoard: Board } => {
+      const nextBoard = applyTakeCard(board, ctx.currentPlayer!, idx);
+      if (nextBoard.numTurns === 8) {
+        const winner = hasWinningTriple(nextBoard.cards[Thief]) ? Thief : Sheriff;
+        events.endGame(winner);
+      } else if (hasWinningTriple(nextBoard.cards[Thief])) {
+        events.endGame(Thief);
+      }
+      events.endTurn();
+      return { nextBoard };
     }
-    events.endTurn();
-    return { nextBoard };
   }
 };

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/thief-sheriff-mean-9.tsx
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/thief-sheriff-mean-9.tsx
@@ -10,8 +10,6 @@ import {
 import { moves, CARD_COUNT } from './moves';
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
-
-
   const getCardColor = num => {
     if (board.cards[Thief].includes(num)) return 'bg-red-800';
     if (board.cards[Sheriff].includes(num)) return 'bg-blue-800 text-white';

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/thief-sheriff-mean-9.tsx
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/thief-sheriff-mean-9.tsx
@@ -10,9 +10,7 @@ import {
 import { moves, CARD_COUNT } from './moves';
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
-  const isAllowedMove = (index: number) => moves.takeCard.isAllowed!(board, index);
 
-  const clickCard = (index: number) => moves.takeCard(board, index);
 
   const getCardColor = num => {
     if (board.cards[Thief].includes(num)) return 'bg-red-800';
@@ -26,8 +24,8 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
         {range(1, CARD_COUNT + 1).map(num =>
         <button
           key={num}
-          disabled={!isAllowedMove(num)}
-          onClick={() => clickCard(num)}
+          disabled={!moves.takeCard.isAllowed!(board, num)}
+          onClick={() => moves.takeCard(board, num)}
           className={`
             m-1 min-h-28 w-18 border-2 rounded-lg shadow-md border-slate-900 dark:border-slate-400 text-4xl font-bold
             ${ctx.currentPlayer === Thief

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/thief-sheriff-mean-9.tsx
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/thief-sheriff-mean-9.tsx
@@ -4,22 +4,15 @@ import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import {
   Sheriff,
   Thief,
-  getUntakenCards,
   generateStartBoard,
   type Board
 } from "../helpers";
 import { moves, CARD_COUNT } from './moves';
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
-  const isAllowedMove = index => {
-    if (!ctx.isClientMoveAllowed) return false;
-    return getUntakenCards(board, CARD_COUNT).includes(index);
-  }
+  const isAllowedMove = (index: number) => moves.takeCard.isAllowed!(board, index);
 
-  const clickCard = (index) => {
-    if (!isAllowedMove(index)) return;
-    moves.takeCard(board, index);
-  }
+  const clickCard = (index: number) => moves.takeCard(board, index);
 
   const getCardColor = num => {
     if (board.cards[Thief].includes(num)) return 'bg-red-800';


### PR DESCRIPTION
Batch 12 of the follow-up to #333. Branched off `main`, mergeable in any order.

## Games covered

`thief-sheriff-mean-7`, `thief-sheriff-mean-9`.

## Changes

Both variants take one card per step off a shared deck, so `isCardAvailable` joins the `getUntakenCards` helper the two siblings already share; only the deck size differs.

- Both `takeCard` moves switch to the long-form `{ validate, apply }`.
- The seven-card variant's move takes its card in a **one-element array** — a shape left over from `applyTakeCard`, which can add several cards at once. Its validator pins the step down to a single card, matching the rule ("minden lépésben az egyik játékos kezébe vesz egyet"); the end-of-game sweep of whatever is left happens inside `applyTakeCard`, not as a move argument.
- Both board clients drop their local predicate and click guard, reading `disabled` from `moves.takeCard.isAllowed`.
- Add `helpers.spec.ts` for `isCardAvailable`, including that it respects the deck size it is given (8 and 9 exist only in the nine-card variant).

No change to the bots: both already sample from `getUntakenCards`.

## Verification

`npm run test` passes (96 files / 630 tests — baseline 95 / 626, plus the 4 new cases).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSxP4EAjGt4vDBxsQt32c)_