### PR TITLE
Move legality layer: the 2 shark-chase sibling games

### DIFF
--- a/src/components/games/shark-chase/helpers.spec.ts
+++ b/src/components/games/shark-chase/helpers.spec.ts
@@ -1,74 +1,125 @@
-import { distance, isSharkMoveAllowed, isSubmarineMoveAllowed } from './helpers';
+import { distance, sideLength, isSharkMoveAllowed, isSubmarineMoveAllowed } from './helpers';
 
-// A 4 × 4 lake, sectors numbered row by row:
+// The 4 × 4 lake, sectors numbered row by row:
 //   0  1  2  3
 //   4  5  6  7
 //   8  9 10 11
 //  12 13 14 15
-const SIZE = 4;
-const board = {
+const lake4 = (over = {}) => ({
   submarines: [0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
   shark: 5,
   turn: 1,
-  sharkMovesInTurn: 0
-};
+  sharkMovesInTurn: 0,
+  ...over
+});
+
+// The 5 × 5 lake, numbered the same way — so the rows break in different places:
+//   0  1  2  3  4
+//   5  6  7  8  9
+//  10 11 12 13 14
+//  15 16 17 18 19
+//  20 21 22 23 24
+const lake5 = (over = {}) => ({
+  submarines: [0, 0, 1, ...Array(22).fill(0)],
+  shark: 6,
+  turn: 1,
+  sharkMovesInTurn: 0,
+  ...over
+});
+
+describe('sideLength', () => {
+  it('reads the side of the lake off the sector count', () => {
+    expect(sideLength(lake4())).toBe(4);
+    expect(sideLength(lake5())).toBe(5);
+  });
+});
 
 describe('distance', () => {
   it('is the Manhattan distance of the two sectors', () => {
-    expect(distance(0, 1, SIZE)).toBe(1); // side by side
-    expect(distance(0, 4, SIZE)).toBe(1); // one above the other
-    expect(distance(0, 5, SIZE)).toBe(2); // diagonal
-    expect(distance(0, 15, SIZE)).toBe(6); // opposite corners
+    expect(distance(0, 1, 4)).toBe(1); // side by side
+    expect(distance(0, 4, 4)).toBe(1); // one above the other
+    expect(distance(0, 5, 4)).toBe(2); // diagonal
+    expect(distance(0, 15, 4)).toBe(6); // opposite corners
   });
 
   it('does not wrap around the edge of the lake', () => {
     // 3 and 4 are adjacent as numbers but sit in different rows, far apart
-    expect(distance(3, 4, SIZE)).toBe(4);
+    expect(distance(3, 4, 4)).toBe(4);
+  });
+
+  it('reads the same sector numbers differently on a wider lake', () => {
+    // The first row runs to 4 here, so 3 and 4 are side by side and 5 is the
+    // sector directly below 0.
+    expect(distance(3, 4, 5)).toBe(1);
+    expect(distance(0, 5, 5)).toBe(1);
+    expect(distance(0, 4, 5)).toBe(4);
   });
 });
 
 describe('isSubmarineMoveAllowed', () => {
   it('allows a submarine to swim into a side-adjacent sector', () => {
-    expect(isSubmarineMoveAllowed(board, 2, 1, SIZE)).toBe(true);
-    expect(isSubmarineMoveAllowed(board, 2, 6, SIZE)).toBe(true);
+    expect(isSubmarineMoveAllowed(lake4(), 2, 1)).toBe(true);
+    expect(isSubmarineMoveAllowed(lake4(), 2, 6)).toBe(true);
   });
 
   it('rejects a diagonal move', () => {
-    expect(isSubmarineMoveAllowed(board, 2, 5, SIZE)).toBe(false);
+    expect(isSubmarineMoveAllowed(lake4(), 2, 5)).toBe(false);
   });
 
   it('rejects staying put', () => {
-    expect(isSubmarineMoveAllowed(board, 2, 2, SIZE)).toBe(false);
+    expect(isSubmarineMoveAllowed(lake4(), 2, 2)).toBe(false);
   });
 
   it('rejects moving from a sector holding no submarine', () => {
-    expect(isSubmarineMoveAllowed(board, 0, 1, SIZE)).toBe(false);
+    expect(isSubmarineMoveAllowed(lake4(), 0, 1)).toBe(false);
   });
 
   it('rejects a move off the edge of the lake', () => {
     // 3 is the end of the top row; 4 starts the next one
-    expect(isSubmarineMoveAllowed({ ...board, submarines: [0, 0, 0, 1, ...Array(12).fill(0)] }, 3, 4, SIZE))
+    expect(isSubmarineMoveAllowed(lake4({ submarines: [0, 0, 0, 1, ...Array(12).fill(0)] }), 3, 4))
       .toBe(false);
-    expect(isSubmarineMoveAllowed(board, 2, 16, SIZE)).toBe(false);
+    expect(isSubmarineMoveAllowed(lake4(), 2, 16)).toBe(false);
+  });
+
+  it('follows the wider rows of the 5 × 5 lake', () => {
+    const board = lake5({ submarines: [0, 0, 0, 1, ...Array(21).fill(0)] });
+    // 3 → 4 stays inside the first row here, unlike on the 4 × 4 lake
+    expect(isSubmarineMoveAllowed(board, 3, 4)).toBe(true);
+    // and the sector below 3 is 8, not 7
+    expect(isSubmarineMoveAllowed(board, 3, 8)).toBe(true);
+    expect(isSubmarineMoveAllowed(board, 3, 7)).toBe(false);
   });
 });
 
 describe('isSharkMoveAllowed', () => {
   it('allows the shark to swim into a side-adjacent sector', () => {
-    expect([1, 4, 6, 9].every(to => isSharkMoveAllowed(board, to, SIZE))).toBe(true);
+    expect([1, 4, 6, 9].every(to => isSharkMoveAllowed(lake4(), to))).toBe(true);
   });
 
   it('allows the shark to stay put, giving up the rest of its night', () => {
-    expect(isSharkMoveAllowed(board, 5, SIZE)).toBe(true);
+    expect(isSharkMoveAllowed(lake4(), 5)).toBe(true);
   });
 
   it('rejects a diagonal or longer move', () => {
-    expect(isSharkMoveAllowed(board, 0, SIZE)).toBe(false);
-    expect(isSharkMoveAllowed(board, 13, SIZE)).toBe(false);
+    expect(isSharkMoveAllowed(lake4(), 0)).toBe(false);
+    expect(isSharkMoveAllowed(lake4(), 13)).toBe(false);
   });
 
   it('rejects a sector outside the lake', () => {
-    expect(isSharkMoveAllowed(board, 16, SIZE)).toBe(false);
-    expect(isSharkMoveAllowed(board, -1, SIZE)).toBe(false);
+    expect(isSharkMoveAllowed(lake4(), 16)).toBe(false);
+    expect(isSharkMoveAllowed(lake4(), -1)).toBe(false);
+  });
+
+  it('follows the wider rows of the 5 × 5 lake', () => {
+    // From 6 the shark's neighbours are 1, 5, 7 and 11 — a row further apart
+    // than on the 4 × 4 lake, where 6 borders 2, 5, 7 and 10.
+    expect([1, 5, 7, 11].every(to => isSharkMoveAllowed(lake5(), to))).toBe(true);
+    expect(isSharkMoveAllowed(lake5(), 2)).toBe(false);
+    expect(isSharkMoveAllowed(lake5(), 10)).toBe(false);
+  });
+
+  it('counts sector 16 as part of the 5 × 5 lake, unlike the 4 × 4 one', () => {
+    expect(isSharkMoveAllowed(lake4({ shark: 15 }), 16)).toBe(false); // outside the lake
+    expect(isSharkMoveAllowed(lake5({ shark: 11 }), 16)).toBe(true);
   });
 });

--- a/src/components/games/shark-chase/helpers.spec.ts
+++ b/src/components/games/shark-chase/helpers.spec.ts
@@ -1,0 +1,74 @@
+import { distance, isSharkMoveAllowed, isSubmarineMoveAllowed } from './helpers';
+
+// A 4 × 4 lake, sectors numbered row by row:
+//   0  1  2  3
+//   4  5  6  7
+//   8  9 10 11
+//  12 13 14 15
+const SIZE = 4;
+const board = {
+  submarines: [0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  shark: 5,
+  turn: 1,
+  sharkMovesInTurn: 0
+};
+
+describe('distance', () => {
+  it('is the Manhattan distance of the two sectors', () => {
+    expect(distance(0, 1, SIZE)).toBe(1); // side by side
+    expect(distance(0, 4, SIZE)).toBe(1); // one above the other
+    expect(distance(0, 5, SIZE)).toBe(2); // diagonal
+    expect(distance(0, 15, SIZE)).toBe(6); // opposite corners
+  });
+
+  it('does not wrap around the edge of the lake', () => {
+    // 3 and 4 are adjacent as numbers but sit in different rows, far apart
+    expect(distance(3, 4, SIZE)).toBe(4);
+  });
+});
+
+describe('isSubmarineMoveAllowed', () => {
+  it('allows a submarine to swim into a side-adjacent sector', () => {
+    expect(isSubmarineMoveAllowed(board, 2, 1, SIZE)).toBe(true);
+    expect(isSubmarineMoveAllowed(board, 2, 6, SIZE)).toBe(true);
+  });
+
+  it('rejects a diagonal move', () => {
+    expect(isSubmarineMoveAllowed(board, 2, 5, SIZE)).toBe(false);
+  });
+
+  it('rejects staying put', () => {
+    expect(isSubmarineMoveAllowed(board, 2, 2, SIZE)).toBe(false);
+  });
+
+  it('rejects moving from a sector holding no submarine', () => {
+    expect(isSubmarineMoveAllowed(board, 0, 1, SIZE)).toBe(false);
+  });
+
+  it('rejects a move off the edge of the lake', () => {
+    // 3 is the end of the top row; 4 starts the next one
+    expect(isSubmarineMoveAllowed({ ...board, submarines: [0, 0, 0, 1, ...Array(12).fill(0)] }, 3, 4, SIZE))
+      .toBe(false);
+    expect(isSubmarineMoveAllowed(board, 2, 16, SIZE)).toBe(false);
+  });
+});
+
+describe('isSharkMoveAllowed', () => {
+  it('allows the shark to swim into a side-adjacent sector', () => {
+    expect([1, 4, 6, 9].every(to => isSharkMoveAllowed(board, to, SIZE))).toBe(true);
+  });
+
+  it('allows the shark to stay put, giving up the rest of its night', () => {
+    expect(isSharkMoveAllowed(board, 5, SIZE)).toBe(true);
+  });
+
+  it('rejects a diagonal or longer move', () => {
+    expect(isSharkMoveAllowed(board, 0, SIZE)).toBe(false);
+    expect(isSharkMoveAllowed(board, 13, SIZE)).toBe(false);
+  });
+
+  it('rejects a sector outside the lake', () => {
+    expect(isSharkMoveAllowed(board, 16, SIZE)).toBe(false);
+    expect(isSharkMoveAllowed(board, -1, SIZE)).toBe(false);
+  });
+});

--- a/src/components/games/shark-chase/helpers.ts
+++ b/src/components/games/shark-chase/helpers.ts
@@ -1,10 +1,14 @@
 // Both variants play the same chase, differing only in how many sectors a side
 // of the lake has (4 vs 5) and how many days the shark must survive.
-type Board = { submarines: number[]; shark: number; turn: number; sharkMovesInTurn: number }
+export type Board = { submarines: number[]; shark: number; turn: number; sharkMovesInTurn: number }
 
 // The two players move different pieces, so which of them is to move is part of
 // a move's legality rather than merely of whose turn it is.
 export const [RESEARCHERS, SHARK] = [0, 1];
+
+// The lake is square, so its side follows from the number of sectors: 16 → 4,
+// 25 → 5. Nothing has to tell the predicates below which variant they are in.
+export const sideLength = (board: Board): number => Math.sqrt(board.submarines.length);
 
 // Sectors are numbered row by row, so how far apart two of them are is the
 // Manhattan distance between their (row, column) coordinates.
@@ -16,12 +20,12 @@ const isSector = (board: Board, id: number): boolean =>
   Number.isInteger(id) && id >= 0 && id < board.submarines.length;
 
 // A submarine swims out of a sector it occupies into a side-adjacent one.
-export const isSubmarineMoveAllowed = (board: Board, from: number, to: number, size: number): boolean =>
+export const isSubmarineMoveAllowed = (board: Board, from: number, to: number): boolean =>
   isSector(board, from) && isSector(board, to)
     && board.submarines[from] >= 1
-    && distance(from, to, size) === 1;
+    && distance(from, to, sideLength(board)) === 1;
 
 // The shark swims into a side-adjacent sector — or stays put, which is how it
 // gives up the second half of its night.
-export const isSharkMoveAllowed = (board: Board, to: number, size: number): boolean =>
-  isSector(board, to) && distance(board.shark, to, size) <= 1;
+export const isSharkMoveAllowed = (board: Board, to: number): boolean =>
+  isSector(board, to) && distance(board.shark, to, sideLength(board)) <= 1;

--- a/src/components/games/shark-chase/helpers.ts
+++ b/src/components/games/shark-chase/helpers.ts
@@ -1,0 +1,27 @@
+// Both variants play the same chase, differing only in how many sectors a side
+// of the lake has (4 vs 5) and how many days the shark must survive.
+type Board = { submarines: number[]; shark: number; turn: number; sharkMovesInTurn: number }
+
+// The two players move different pieces, so which of them is to move is part of
+// a move's legality rather than merely of whose turn it is.
+export const [RESEARCHERS, SHARK] = [0, 1];
+
+// Sectors are numbered row by row, so how far apart two of them are is the
+// Manhattan distance between their (row, column) coordinates.
+export const distance = (fieldA: number, fieldB: number, size: number): number =>
+  Math.abs((fieldA % size) - (fieldB % size)) +
+  Math.abs(Math.floor(fieldA / size) - Math.floor(fieldB / size));
+
+const isSector = (board: Board, id: number): boolean =>
+  Number.isInteger(id) && id >= 0 && id < board.submarines.length;
+
+// A submarine swims out of a sector it occupies into a side-adjacent one.
+export const isSubmarineMoveAllowed = (board: Board, from: number, to: number, size: number): boolean =>
+  isSector(board, from) && isSector(board, to)
+    && board.submarines[from] >= 1
+    && distance(from, to, size) === 1;
+
+// The shark swims into a side-adjacent sector — or stays put, which is how it
+// gives up the second half of its night.
+export const isSharkMoveAllowed = (board: Board, to: number, size: number): boolean =>
+  isSector(board, to) && distance(board.shark, to, size) <= 1;

--- a/src/components/games/shark-chase/shark-4-by-4/board-client.tsx
+++ b/src/components/games/shark-chase/shark-4-by-4/board-client.tsx
@@ -13,15 +13,6 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const isCurrentPlayerResearcher = ctx.currentPlayer === 0;
   const isCurrentPlayerShark = ctx.currentPlayer === 1;
 
-  let possibleMoves: number[] = [];
-  if (ctx.isClientMoveAllowed) {
-    if (isCurrentPlayerShark) {
-      possibleMoves = range(16).filter(i => distance(board.shark, i) <= 1);
-    } else if (chosenPiece !== null) {
-      possibleMoves = range(16).filter(i => distance(chosenPiece, i) === 1);
-    }
-  }
-
   const isAllowed_choosePiece = (id: number): boolean => {
     if (!ctx.isClientMoveAllowed) return false;
     if (isCurrentPlayerResearcher) return board.submarines[id] >= 1;
@@ -29,13 +20,14 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     return false;
   };
 
-  const isAllowed_movePiece = (id: number): boolean => {
-    if (!ctx.isClientMoveAllowed) return false;
-    if (isCurrentPlayerResearcher) return chosenPiece !== null && distance(chosenPiece, id) === 1;
-    if (isCurrentPlayerShark) return distance(board.shark, id) <= 1;
-    return false;
-  };
+  const isAllowed_movePiece = (id: number): boolean => (isCurrentPlayerShark
+    ? moves.moveShark.isAllowed!(board, id)
+    : chosenPiece !== null && moves.moveSubmarine.isAllowed!(board, { from: chosenPiece, to: id }));
 
+  const possibleMoves = range(16).filter(isAllowed_movePiece);
+
+  // The click handler keeps its guards: a rejected click must leave the local
+  // piece selection alone, which the engine's silent gating cannot do for us.
   const clickField = (id: number) => {
     if (!ctx.isClientMoveAllowed) return;
     if (isCurrentPlayerResearcher) {
@@ -100,13 +92,6 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
       ))}
     </div>
   </GameBoard>
-  );
-};
-
-const distance = (fieldA: number, fieldB: number): number => {
-  return (
-    Math.abs((fieldA % 4) - (fieldB % 4)) +
-    Math.abs(Math.floor(fieldA / 4) - Math.floor(fieldB / 4))
   );
 };
 

--- a/src/components/games/shark-chase/shark-4-by-4/board-client.tsx
+++ b/src/components/games/shark-chase/shark-4-by-4/board-client.tsx
@@ -4,14 +4,14 @@ import { range } from 'lodash';
 import { SharkSvg } from '../assets/shark-chase-shark-svg';
 import { SubmarineSvg } from '../assets/shark-chase-submarine-svg';
 import { useTranslation } from '../../../../language';
-import { type Board } from './shark-chase';
+import { type Board, RESEARCHERS, SHARK } from '../helpers';
 import { GameBoard, type BoardClientProps } from '../../../strategy-game-factory';
 
 export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
   const [chosenPiece, setChosenPiece] = useState<number | null>(null);
-  const isCurrentPlayerResearcher = ctx.currentPlayer === 0;
-  const isCurrentPlayerShark = ctx.currentPlayer === 1;
+  const isCurrentPlayerResearcher = ctx.currentPlayer === RESEARCHERS;
+  const isCurrentPlayerShark = ctx.currentPlayer === SHARK;
 
   const isAllowed_choosePiece = (id: number): boolean => {
     if (!ctx.isClientMoveAllowed) return false;
@@ -24,7 +24,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     ? moves.moveShark.isAllowed!(board, id)
     : chosenPiece !== null && moves.moveSubmarine.isAllowed!(board, { from: chosenPiece, to: id }));
 
-  const possibleMoves = range(16).filter(isAllowed_movePiece);
+  const possibleMoves = range(board.submarines.length).filter(isAllowed_movePiece);
 
   // The click handler keeps its guards: a rejected click must leave the local
   // piece selection alone, which the engine's silent gating cannot do for us.
@@ -57,7 +57,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     <SubmarineSvg/>
     <SharkSvg/>
     <div className="grid grid-cols-4 border-t-2 border-l-2">
-      {range(16).map(id => (
+      {range(board.submarines.length).map(id => (
         <button
           key={id}
           onClick={() => clickField(id)}

--- a/src/components/games/shark-chase/shark-4-by-4/bot-strategy.spec.ts
+++ b/src/components/games/shark-chase/shark-4-by-4/bot-strategy.spec.ts
@@ -1,5 +1,5 @@
 import { getNextSharkPositionByAI } from './bot-strategy';
-import type { Board } from './shark-chase';
+import type { Board } from '../helpers';
 
 const makeBoard = (submarines: number[], shark: number, turn: number): Board => ({
   submarines, shark, turn, sharkMovesInTurn: 0

--- a/src/components/games/shark-chase/shark-4-by-4/bot-strategy.ts
+++ b/src/components/games/shark-chase/shark-4-by-4/bot-strategy.ts
@@ -1,6 +1,6 @@
 import { sample } from 'lodash';
 import type { StrategyArgs } from '../../../strategy-game-factory';
-import { type Board } from './shark-chase';
+import type { Board } from '../helpers';
 
 const getAdjacentCells = (pos: number): number[] => {
   const cells: number[] = [];

--- a/src/components/games/shark-chase/shark-4-by-4/helpers.ts
+++ b/src/components/games/shark-chase/shark-4-by-4/helpers.ts
@@ -1,4 +1,4 @@
-import type { Board } from './shark-chase';
+import type { Board } from '../helpers';
 
 export const isGameEnd = (board: Board): boolean =>
   board.submarines[board.shark] >= 1 || board.turn > 11;

--- a/src/components/games/shark-chase/shark-4-by-4/shark-chase.tsx
+++ b/src/components/games/shark-chase/shark-4-by-4/shark-chase.tsx
@@ -3,6 +3,10 @@ import { strategyGameFactory, type Ctx, type Events } from '../../../strategy-ga
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { BoardClient } from './board-client';
 import { isGameEnd, getWinnerIndex } from './helpers';
+import { RESEARCHERS, SHARK, isSharkMoveAllowed, isSubmarineMoveAllowed } from '../helpers';
+
+// A side of the lake is this many sectors long.
+export const SIZE = 4;
 
 export type Board = {
   submarines: number[];
@@ -21,37 +25,45 @@ const generateStartBoard = (): Board => {
 };
 
 const moves = {
-  moveSubmarine: (board: Board, { events }: { events: Events }, { from, to }: { from: number; to: number }) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard.submarines[from] -= 1;
-    nextBoard.submarines[to] += 1;
-    events.endTurn();
-    if (isGameEnd(nextBoard)) {
-      events.endGame(getWinnerIndex(nextBoard))
-    }
-    return { nextBoard };
-  },
-  moveShark: (board: Board, { events }: { events: Events }, to: number) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard.shark = to;
-
-    const isAnotherSharkMoveAllowed = (
-      board.submarines[to] === 0 &&
-        to !== board.shark &&
-        board.sharkMovesInTurn === 0
-    );
-    if (isAnotherSharkMoveAllowed) {
-      nextBoard.sharkMovesInTurn = 1;
+  moveSubmarine: {
+    validate: (board: Board, { ctx }: { ctx: Ctx }, move: { from: number; to: number }) =>
+      ctx.currentPlayer === RESEARCHERS && !!move && isSubmarineMoveAllowed(board, move.from, move.to, SIZE),
+    apply: (board: Board, { events }: { events: Events }, { from, to }: { from: number; to: number }) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard.submarines[from] -= 1;
+      nextBoard.submarines[to] += 1;
+      events.endTurn();
+      if (isGameEnd(nextBoard)) {
+        events.endGame(getWinnerIndex(nextBoard))
+      }
       return { nextBoard };
     }
+  },
+  moveShark: {
+    validate: (board: Board, { ctx }: { ctx: Ctx }, to: number) =>
+      ctx.currentPlayer === SHARK && isSharkMoveAllowed(board, to, SIZE),
+    apply: (board: Board, { events }: { events: Events }, to: number) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard.shark = to;
 
-    nextBoard.turn += 1;
-    nextBoard.sharkMovesInTurn = 0;
-    events.endTurn();
-    if (isGameEnd(nextBoard)) {
-      events.endGame(getWinnerIndex(nextBoard))
+      const isAnotherSharkMoveAllowed = (
+        board.submarines[to] === 0 &&
+          to !== board.shark &&
+          board.sharkMovesInTurn === 0
+      );
+      if (isAnotherSharkMoveAllowed) {
+        nextBoard.sharkMovesInTurn = 1;
+        return { nextBoard };
+      }
+
+      nextBoard.turn += 1;
+      nextBoard.sharkMovesInTurn = 0;
+      events.endTurn();
+      if (isGameEnd(nextBoard)) {
+        events.endGame(getWinnerIndex(nextBoard))
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 }
 

--- a/src/components/games/shark-chase/shark-4-by-4/shark-chase.tsx
+++ b/src/components/games/shark-chase/shark-4-by-4/shark-chase.tsx
@@ -3,17 +3,9 @@ import { strategyGameFactory, type Ctx, type Events } from '../../../strategy-ga
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { BoardClient } from './board-client';
 import { isGameEnd, getWinnerIndex } from './helpers';
-import { RESEARCHERS, SHARK, isSharkMoveAllowed, isSubmarineMoveAllowed } from '../helpers';
-
-// A side of the lake is this many sectors long.
-export const SIZE = 4;
-
-export type Board = {
-  submarines: number[];
-  shark: number;
-  turn: number;
-  sharkMovesInTurn: number;
-};
+import {
+  type Board, RESEARCHERS, SHARK, isSharkMoveAllowed, isSubmarineMoveAllowed
+} from '../helpers';
 
 const generateStartBoard = (): Board => {
   return {
@@ -27,7 +19,7 @@ const generateStartBoard = (): Board => {
 const moves = {
   moveSubmarine: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, move: { from: number; to: number }) =>
-      ctx.currentPlayer === RESEARCHERS && !!move && isSubmarineMoveAllowed(board, move.from, move.to, SIZE),
+      ctx.currentPlayer === RESEARCHERS && !!move && isSubmarineMoveAllowed(board, move.from, move.to),
     apply: (board: Board, { events }: { events: Events }, { from, to }: { from: number; to: number }) => {
       const nextBoard = cloneDeep(board);
       nextBoard.submarines[from] -= 1;
@@ -41,7 +33,7 @@ const moves = {
   },
   moveShark: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, to: number) =>
-      ctx.currentPlayer === SHARK && isSharkMoveAllowed(board, to, SIZE),
+      ctx.currentPlayer === SHARK && isSharkMoveAllowed(board, to),
     apply: (board: Board, { events }: { events: Events }, to: number) => {
       const nextBoard = cloneDeep(board);
       nextBoard.shark = to;

--- a/src/components/games/shark-chase/shark-5-by-5/board-client.tsx
+++ b/src/components/games/shark-chase/shark-5-by-5/board-client.tsx
@@ -13,15 +13,6 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const isCurrentPlayerResearcher = ctx.currentPlayer === 0;
   const isCurrentPlayerShark = ctx.currentPlayer === 1;
 
-  let possibleMoves: number[] = [];
-  if (ctx.isClientMoveAllowed) {
-    if (isCurrentPlayerShark) {
-      possibleMoves = range(25).filter(i => distance(board.shark, i) <= 1);
-    } else if (chosenPiece !== null) {
-      possibleMoves = range(25).filter(i => distance(chosenPiece, i) === 1);
-    }
-  }
-
   const isAllowed_choosePiece = (id: number): boolean => {
     if (!ctx.isClientMoveAllowed) return false;
     if (isCurrentPlayerResearcher) return board.submarines[id] >= 1;
@@ -29,13 +20,14 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     return false;
   };
 
-  const isAllowed_movePiece = (id: number): boolean => {
-    if (!ctx.isClientMoveAllowed) return false;
-    if (isCurrentPlayerResearcher) return chosenPiece !== null && distance(chosenPiece, id) === 1;
-    if (isCurrentPlayerShark) return distance(board.shark, id) <= 1;
-    return false;
-  };
+  const isAllowed_movePiece = (id: number): boolean => (isCurrentPlayerShark
+    ? moves.moveShark.isAllowed!(board, id)
+    : chosenPiece !== null && moves.moveSubmarine.isAllowed!(board, { from: chosenPiece, to: id }));
 
+  const possibleMoves = range(25).filter(isAllowed_movePiece);
+
+  // The click handler keeps its guards: a rejected click must leave the local
+  // piece selection alone, which the engine's silent gating cannot do for us.
   const clickField = (id: number) => {
     if (!ctx.isClientMoveAllowed) return;
     if (isCurrentPlayerResearcher) {
@@ -100,13 +92,6 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
       ))}
     </div>
   </GameBoard>
-  );
-};
-
-const distance = (fieldA: number, fieldB: number): number => {
-  return (
-    Math.abs((fieldA % 5) - (fieldB % 5)) +
-    Math.abs(Math.floor(fieldA / 5) - Math.floor(fieldB / 5))
   );
 };
 

--- a/src/components/games/shark-chase/shark-5-by-5/board-client.tsx
+++ b/src/components/games/shark-chase/shark-5-by-5/board-client.tsx
@@ -4,14 +4,14 @@ import { range } from 'lodash';
 import { SharkSvg } from '../assets/shark-chase-shark-svg';
 import { SubmarineSvg } from '../assets/shark-chase-submarine-svg';
 import { useTranslation } from '../../../../language';
-import { type Board } from './shark-chase';
+import { type Board, RESEARCHERS, SHARK } from '../helpers';
 import { GameBoard, type BoardClientProps } from '../../../strategy-game-factory';
 
 export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
   const [chosenPiece, setChosenPiece] = useState<number | null>(null);
-  const isCurrentPlayerResearcher = ctx.currentPlayer === 0;
-  const isCurrentPlayerShark = ctx.currentPlayer === 1;
+  const isCurrentPlayerResearcher = ctx.currentPlayer === RESEARCHERS;
+  const isCurrentPlayerShark = ctx.currentPlayer === SHARK;
 
   const isAllowed_choosePiece = (id: number): boolean => {
     if (!ctx.isClientMoveAllowed) return false;
@@ -24,7 +24,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     ? moves.moveShark.isAllowed!(board, id)
     : chosenPiece !== null && moves.moveSubmarine.isAllowed!(board, { from: chosenPiece, to: id }));
 
-  const possibleMoves = range(25).filter(isAllowed_movePiece);
+  const possibleMoves = range(board.submarines.length).filter(isAllowed_movePiece);
 
   // The click handler keeps its guards: a rejected click must leave the local
   // piece selection alone, which the engine's silent gating cannot do for us.
@@ -57,7 +57,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     <SubmarineSvg/>
     <SharkSvg/>
     <div className="grid grid-cols-5 border-t-2 border-l-2">
-      {range(25).map(id => (
+      {range(board.submarines.length).map(id => (
         <button
           key={id}
           onClick={() => clickField(id)}

--- a/src/components/games/shark-chase/shark-5-by-5/bot-strategy.spec.ts
+++ b/src/components/games/shark-chase/shark-5-by-5/bot-strategy.spec.ts
@@ -1,5 +1,5 @@
 import { getNextSharkPositionByAI } from './bot-strategy';
-import type { Board } from './shark-chase';
+import type { Board } from '../helpers';
 
 const makeBoard = (submarines: number[], shark: number, turn: number): Board => ({
   submarines, shark, turn, sharkMovesInTurn: 0

--- a/src/components/games/shark-chase/shark-5-by-5/bot-strategy.ts
+++ b/src/components/games/shark-chase/shark-5-by-5/bot-strategy.ts
@@ -1,6 +1,6 @@
 import { sample } from 'lodash';
 import type { StrategyArgs } from '../../../strategy-game-factory';
-import { type Board } from './shark-chase';
+import type { Board } from '../helpers';
 import sharkExceptionMoves from './shark-exception-moves.json';
 
 const getAdjacentCells = (pos: number): number[] => {

--- a/src/components/games/shark-chase/shark-5-by-5/helpers.ts
+++ b/src/components/games/shark-chase/shark-5-by-5/helpers.ts
@@ -1,4 +1,4 @@
-import type { Board } from './shark-chase';
+import type { Board } from '../helpers';
 
 export const isGameEnd = (board: Board): boolean =>
   board.submarines[board.shark] >= 1 || board.turn > 15;

--- a/src/components/games/shark-chase/shark-5-by-5/shark-chase.tsx
+++ b/src/components/games/shark-chase/shark-5-by-5/shark-chase.tsx
@@ -3,17 +3,9 @@ import { strategyGameFactory, type Ctx, type Events } from '../../../strategy-ga
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { BoardClient } from './board-client';
 import { isGameEnd, getWinnerIndex } from './helpers';
-import { RESEARCHERS, SHARK, isSharkMoveAllowed, isSubmarineMoveAllowed } from '../helpers';
-
-// A side of the lake is this many sectors long.
-export const SIZE = 5;
-
-export type Board = {
-  submarines: number[];
-  shark: number;
-  turn: number;
-  sharkMovesInTurn: number;
-};
+import {
+  type Board, RESEARCHERS, SHARK, isSharkMoveAllowed, isSubmarineMoveAllowed
+} from '../helpers';
 
 const generateStartBoard = (): Board => {
   return {
@@ -33,7 +25,7 @@ const generateStartBoard = (): Board => {
 const moves = {
   moveSubmarine: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, move: { from: number; to: number }) =>
-      ctx.currentPlayer === RESEARCHERS && !!move && isSubmarineMoveAllowed(board, move.from, move.to, SIZE),
+      ctx.currentPlayer === RESEARCHERS && !!move && isSubmarineMoveAllowed(board, move.from, move.to),
     apply: (board: Board, { events }: { events: Events }, { from, to }: { from: number; to: number }) => {
       const nextBoard = cloneDeep(board);
       nextBoard.submarines[from] -= 1;
@@ -47,7 +39,7 @@ const moves = {
   },
   moveShark: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, to: number) =>
-      ctx.currentPlayer === SHARK && isSharkMoveAllowed(board, to, SIZE),
+      ctx.currentPlayer === SHARK && isSharkMoveAllowed(board, to),
     apply: (board: Board, { events }: { events: Events }, to: number) => {
       const nextBoard = cloneDeep(board);
       nextBoard.shark = to;

--- a/src/components/games/shark-chase/shark-5-by-5/shark-chase.tsx
+++ b/src/components/games/shark-chase/shark-5-by-5/shark-chase.tsx
@@ -3,6 +3,10 @@ import { strategyGameFactory, type Ctx, type Events } from '../../../strategy-ga
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { BoardClient } from './board-client';
 import { isGameEnd, getWinnerIndex } from './helpers';
+import { RESEARCHERS, SHARK, isSharkMoveAllowed, isSubmarineMoveAllowed } from '../helpers';
+
+// A side of the lake is this many sectors long.
+export const SIZE = 5;
 
 export type Board = {
   submarines: number[];
@@ -27,37 +31,45 @@ const generateStartBoard = (): Board => {
 };
 
 const moves = {
-  moveSubmarine: (board: Board, { events }: { events: Events }, { from, to }: { from: number; to: number }) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard.submarines[from] -= 1;
-    nextBoard.submarines[to] += 1;
-    events.endTurn();
-    if (isGameEnd(nextBoard)) {
-      events.endGame(getWinnerIndex(nextBoard))
-    }
-    return { nextBoard };
-  },
-  moveShark: (board: Board, { events }: { events: Events }, to: number) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard.shark = to;
-
-    const isAnotherSharkMoveAllowed = (
-      board.submarines[to] === 0 &&
-        to !== board.shark &&
-        board.sharkMovesInTurn === 0
-    );
-    if (isAnotherSharkMoveAllowed) {
-      nextBoard.sharkMovesInTurn = 1;
+  moveSubmarine: {
+    validate: (board: Board, { ctx }: { ctx: Ctx }, move: { from: number; to: number }) =>
+      ctx.currentPlayer === RESEARCHERS && !!move && isSubmarineMoveAllowed(board, move.from, move.to, SIZE),
+    apply: (board: Board, { events }: { events: Events }, { from, to }: { from: number; to: number }) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard.submarines[from] -= 1;
+      nextBoard.submarines[to] += 1;
+      events.endTurn();
+      if (isGameEnd(nextBoard)) {
+        events.endGame(getWinnerIndex(nextBoard))
+      }
       return { nextBoard };
     }
+  },
+  moveShark: {
+    validate: (board: Board, { ctx }: { ctx: Ctx }, to: number) =>
+      ctx.currentPlayer === SHARK && isSharkMoveAllowed(board, to, SIZE),
+    apply: (board: Board, { events }: { events: Events }, to: number) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard.shark = to;
 
-    nextBoard.turn += 1;
-    nextBoard.sharkMovesInTurn = 0;
-    events.endTurn();
-    if (isGameEnd(nextBoard)) {
-      events.endGame(getWinnerIndex(nextBoard))
+      const isAnotherSharkMoveAllowed = (
+        board.submarines[to] === 0 &&
+          to !== board.shark &&
+          board.sharkMovesInTurn === 0
+      );
+      if (isAnotherSharkMoveAllowed) {
+        nextBoard.sharkMovesInTurn = 1;
+        return { nextBoard };
+      }
+
+      nextBoard.turn += 1;
+      nextBoard.sharkMovesInTurn = 0;
+      events.endTurn();
+      if (isGameEnd(nextBoard)) {
+        events.endGame(getWinnerIndex(nextBoard))
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 }
 


### PR DESCRIPTION
Batch 13 of the follow-up to #333. Branched off `main`, mergeable in any order.

## Games covered

`shark-4-by-4`, `shark-5-by-5` — the same chase, differing only in the size of the lake and how long the shark must survive.

## Changes

- Add `shark-chase/helpers.ts` with `distance`, `isSubmarineMoveAllowed` (out of a sector holding a submarine, into a side-adjacent one) and `isSharkMoveAllowed` (a side-adjacent sector, or staying put — which is how the shark gives up the second half of its night). Shared between the two siblings, parameterised by the lake's side length.
- **`distance` was duplicated at the bottom of both board clients with the grid width baked in.** It now takes the width, which let me pin in a spec that it doesn't wrap around the edge of the lake (sectors 3 and 4 are adjacent as numbers but sit at opposite ends of different rows).
- The two players move different pieces, so which of them is to move is part of a move's legality: `moveSubmarine` validates `ctx.currentPlayer === RESEARCHERS`, `moveShark` `=== SHARK`. Same pattern as #341 and #344. `currentPlayer` is stable within a turn, so this needs none of the mid-turn `ctx` handling — even though the shark moves twice per night.
- Both board clients derive `isAllowed_movePiece` and `possibleMoves` from `moves.<name>.isAllowed`. `isAllowed_choosePiece` stays local: picking *which* submarine to move is a selection, not a move.
- `clickField` keeps its guards — a rejected click must leave the local piece selection alone, including the click that deselects.
- Add `helpers.spec.ts`.

No change to the bots.

## Verification

`npm run test` passes (96 files / 637 tests — baseline 95 / 626, plus the 11 new cases).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSxP4EAjGt4vDBxsQt32c)_