### PR TITLE
Move legality layer: 3 take-one-from-a-set games

### DIFF
--- a/src/components/games/five-five-card/five-five-card.tsx
+++ b/src/components/games/five-five-card/five-five-card.tsx
@@ -9,15 +9,7 @@ export type Board = (number | null)[][]
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
-  const isMoveAllowed = (id: number) => {
-    if (!ctx.isClientMoveAllowed) return false;
-    return board[1 - ctx.currentPlayer!][id] !== null;
-  };
-  const clickField = (id: number) => {
-    if (!isMoveAllowed(id)) return;
-
-    moves.removeCard(board, id + 1);
-  };
+  const isMoveAllowed = (id: number) => moves.removeCard.isAllowed!(board, id + 1);
 
   return (
   <GameBoard>
@@ -34,7 +26,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
           <button
             key={`${playerIdx}-${id}`}
             disabled={playerIdx === ctx.currentPlayer || !isMoveAllowed(id)}
-            onClick={() => clickField(id)}
+            onClick={() => moves.removeCard(board, id + 1)}
             className={`
               ${playerIdx === 0 ? 'col-start-1' : 'col-start-4'}
               aspect-3/2 text-2xl border-4 rounded-lg
@@ -72,15 +64,24 @@ export const getWinnerIndex = (board: Board) => {
   }
 }
 
+// Cards are addressed by their 1-based position in the other player's hand, and
+// only a card still lying there may be taken.
+export const isRemovalAllowed = (board: Board, opponent: number, id: number): boolean =>
+  Number.isInteger(id) && id >= 1 && id <= board[opponent].length && board[opponent][id - 1] !== null;
+
 const moves = {
-  removeCard: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, id: number) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard[1 - ctx.currentPlayer!][id - 1] = null;
-    events.endTurn();
-    if (isGameEnd(nextBoard)) {
-      events.endGame(getWinnerIndex(nextBoard));
+  removeCard: {
+    validate: (board: Board, { ctx }: { ctx: Ctx }, id: number) =>
+      isRemovalAllowed(board, 1 - ctx.currentPlayer!, id),
+    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, id: number) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard[1 - ctx.currentPlayer!][id - 1] = null;
+      events.endTurn();
+      if (isGameEnd(nextBoard)) {
+        events.endGame(getWinnerIndex(nextBoard));
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 }
 

--- a/src/components/games/five-five-card/five-five-card.tsx
+++ b/src/components/games/five-five-card/five-five-card.tsx
@@ -9,7 +9,6 @@ export type Board = (number | null)[][]
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
-  const isMoveAllowed = (id: number) => moves.removeCard.isAllowed!(board, id + 1);
 
   return (
   <GameBoard>
@@ -25,7 +24,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
         [0, 1].map(playerIdx => (
           <button
             key={`${playerIdx}-${id}`}
-            disabled={playerIdx === ctx.currentPlayer || !isMoveAllowed(id)}
+            disabled={playerIdx === ctx.currentPlayer || !moves.removeCard.isAllowed!(board, id + 1)}
             onClick={() => moves.removeCard(board, id + 1)}
             className={`
               ${playerIdx === 0 ? 'col-start-1' : 'col-start-4'}

--- a/src/components/games/five-five-card/legality.spec.ts
+++ b/src/components/games/five-five-card/legality.spec.ts
@@ -1,0 +1,23 @@
+import { isRemovalAllowed, type Board } from './five-five-card';
+
+// Cards are addressed by their 1-based position in the other player's hand.
+const board: Board = [
+  [1, 2, null, 4, 5],
+  [1, 2, 3, 4, 5]
+];
+
+describe('isRemovalAllowed', () => {
+  it("allows taking a card the other player still holds", () => {
+    expect([1, 2, 3, 4, 5].every(id => isRemovalAllowed(board, 1, id))).toBe(true);
+  });
+
+  it('rejects a card the other player has already lost', () => {
+    expect(isRemovalAllowed(board, 0, 3)).toBe(false);
+    expect(isRemovalAllowed(board, 0, 2)).toBe(true);
+  });
+
+  it('rejects a position outside the hand, including the 0 of 0-based indexing', () => {
+    expect(isRemovalAllowed(board, 1, 0)).toBe(false);
+    expect(isRemovalAllowed(board, 1, 6)).toBe(false);
+  });
+});

--- a/src/components/games/number-covering/legality.spec.ts
+++ b/src/components/games/number-covering/legality.spec.ts
@@ -1,0 +1,19 @@
+import { isCoveringAllowed, COVERED } from './number-covering';
+
+const board = [1, 2, COVERED, 4, 5];
+
+describe('isCoveringAllowed', () => {
+  it('allows covering a number still showing', () => {
+    expect([1, 2, 4, 5].every(number => isCoveringAllowed(board, number))).toBe(true);
+  });
+
+  it('rejects a number already covered', () => {
+    expect(isCoveringAllowed(board, 3)).toBe(false);
+  });
+
+  it('rejects a number not on the table', () => {
+    expect(isCoveringAllowed(board, 6)).toBe(false);
+    expect(isCoveringAllowed(board, 0)).toBe(false);
+    expect(isCoveringAllowed(board, 2.5)).toBe(false);
+  });
+});

--- a/src/components/games/number-covering/number-covering.tsx
+++ b/src/components/games/number-covering/number-covering.tsx
@@ -10,13 +10,15 @@ export const COVERED = -1 as const;
 
 const getRemaining = (board: Board) => board.filter(i => i !== COVERED);
 
-const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
+// Numbers are addressed by their value, which is also their 1-based position;
+// only one that is still showing may be covered.
+export const isCoveringAllowed = (board: Board, number: number): boolean =>
+  Number.isInteger(number) && number >= 1 && number <= board.length && board[number - 1] !== COVERED;
+
+const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
 
-  const clickNumber = (number) => {
-    if (!ctx.isClientMoveAllowed) return;
-    moves.coverNumber(board, number);
-  };
+  const isNumberAllowed = (number: number) => moves.coverNumber.isAllowed!(board, number);
 
   return(
     <GameBoard>
@@ -24,9 +26,9 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
       {range(board.length).map(i => (
         <button
           key={i}
-          disabled={!ctx.isClientMoveAllowed || board[i] === COVERED}
+          disabled={!isNumberAllowed(i + 1)}
           className={`secondary-button w-auto text-2xl min-w-[3ch]`}
-          onClick={() => clickNumber(i+1)}
+          onClick={() => moves.coverNumber(board, i + 1)}
         >
           {board[i] === COVERED ? 'X' : board[i]}
         </button>
@@ -95,16 +97,19 @@ const genericRule = {
 };
 
 export const moves = {
-  coverNumber: (board: Board, { events }: { events: Events }, number) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard[number-1] = COVERED;
-    events.endTurn();
+  coverNumber: {
+    validate: (board: Board, _, number: number) => isCoveringAllowed(board, number),
+    apply: (board: Board, { events }: { events: Events }, number) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard[number-1] = COVERED;
+      events.endTurn();
 
-    const remaining = getRemaining(nextBoard);
-    if (remaining.length === 2) {
-      events.endGame(sum(remaining) % 2);
+      const remaining = getRemaining(nextBoard);
+      if (remaining.length === 2) {
+        events.endGame(sum(remaining) % 2);
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 }
 

--- a/src/components/games/number-covering/number-covering.tsx
+++ b/src/components/games/number-covering/number-covering.tsx
@@ -18,7 +18,6 @@ export const isCoveringAllowed = (board: Board, number: number): boolean =>
 const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
 
-  const isNumberAllowed = (number: number) => moves.coverNumber.isAllowed!(board, number);
 
   return(
     <GameBoard>
@@ -26,7 +25,7 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
       {range(board.length).map(i => (
         <button
           key={i}
-          disabled={!isNumberAllowed(i + 1)}
+          disabled={!moves.coverNumber.isAllowed!(board, i + 1)}
           className={`secondary-button w-auto text-2xl min-w-[3ch]`}
           onClick={() => moves.coverNumber(board, i + 1)}
         >

--- a/src/components/games/rock-paper-scissor/legality.spec.ts
+++ b/src/components/games/rock-paper-scissor/legality.spec.ts
@@ -1,0 +1,23 @@
+import { isRemovalAllowed, type Board } from './rock-paper-scissor';
+
+// Each player holds rock (0), paper (1) and scissors (2) until taken away.
+const board: Board = [
+  ['rock', null, 'scissor'],
+  ['rock', 'paper', 'scissor']
+];
+
+describe('isRemovalAllowed', () => {
+  it("allows taking a symbol the other player still holds", () => {
+    expect([0, 1, 2].every(idx => isRemovalAllowed(board, 1, idx))).toBe(true);
+  });
+
+  it('rejects a symbol the other player has already lost', () => {
+    expect(isRemovalAllowed(board, 0, 1)).toBe(false);
+    expect(isRemovalAllowed(board, 0, 0)).toBe(true);
+  });
+
+  it('rejects a symbol that does not exist', () => {
+    expect(isRemovalAllowed(board, 1, 3)).toBe(false);
+    expect(isRemovalAllowed(board, 1, -1)).toBe(false);
+  });
+});

--- a/src/components/games/rock-paper-scissor/rock-paper-scissor.tsx
+++ b/src/components/games/rock-paper-scissor/rock-paper-scissor.tsx
@@ -14,7 +14,6 @@ const symbolSvgs = [RockSvg, PaperSvg, ScissorSvg];
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
-  const isMoveAllowed = (symbolIdx: number) => moves.removeSymbol.isAllowed!(board, symbolIdx);
 
   return (
   <GameBoard>
@@ -27,7 +26,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
         return [0, 1].map(playerIdx => (
           <button
             key={`${playerIdx}-${symbolIdx}`}
-            disabled={playerIdx === ctx.currentPlayer || !isMoveAllowed(symbolIdx)}
+            disabled={playerIdx === ctx.currentPlayer || !moves.removeSymbol.isAllowed!(board, symbolIdx)}
             onClick={() => moves.removeSymbol(board, symbolIdx)}
             className={`
               ${playerIdx === 0 ? 'col-start-1' : 'col-start-3'}

--- a/src/components/games/rock-paper-scissor/rock-paper-scissor.tsx
+++ b/src/components/games/rock-paper-scissor/rock-paper-scissor.tsx
@@ -14,16 +14,7 @@ const symbolSvgs = [RockSvg, PaperSvg, ScissorSvg];
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
-  const isMoveAllowed = (symbolIdx: number) => {
-    if (!ctx.isClientMoveAllowed) return false;
-    return board[1 - ctx.currentPlayer!][symbolIdx] !== null;
-  };
-
-  const clickField = (symbolIdx: number) => {
-    if (!isMoveAllowed(symbolIdx)) return;
-
-    moves.removeSymbol(board, symbolIdx)
-  };
+  const isMoveAllowed = (symbolIdx: number) => moves.removeSymbol.isAllowed!(board, symbolIdx);
 
   return (
   <GameBoard>
@@ -37,7 +28,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
           <button
             key={`${playerIdx}-${symbolIdx}`}
             disabled={playerIdx === ctx.currentPlayer || !isMoveAllowed(symbolIdx)}
-            onClick={() => clickField(symbolIdx)}
+            onClick={() => moves.removeSymbol(board, symbolIdx)}
             className={`
               ${playerIdx === 0 ? 'col-start-1' : 'col-start-3'}
               p-2 m-2 aspect-4/5 bg-surface-elevated rounded-lg drop-shadow-lg
@@ -71,15 +62,23 @@ const getWinnerIndex = (board: Board) => {
   return 1;
 };
 
+// Only a symbol the other player still holds may be taken away.
+export const isRemovalAllowed = (board: Board, opponent: number, idx: number): boolean =>
+  Number.isInteger(idx) && idx >= 0 && idx < board[opponent].length && board[opponent][idx] !== null;
+
 const moves = {
-  removeSymbol: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, idx: number) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard[1 - ctx.currentPlayer!][idx] = null;
-    events.endTurn();
-    if (isGameEnd(nextBoard)) {
-      events.endGame(getWinnerIndex(nextBoard));
+  removeSymbol: {
+    validate: (board: Board, { ctx }: { ctx: Ctx }, idx: number) =>
+      isRemovalAllowed(board, 1 - ctx.currentPlayer!, idx),
+    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, idx: number) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard[1 - ctx.currentPlayer!][idx] = null;
+      events.endTurn();
+      if (isGameEnd(nextBoard)) {
+        events.endGame(getWinnerIndex(nextBoard));
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 }
 


### PR DESCRIPTION
Batch 15 of the follow-up to #333. Branched off `main`, mergeable in any order.

## Games covered

`five-five-card`, `rock-paper-scissor`, `number-covering` — three games that take a single item out of a set which shrinks as the game goes on. Separate games, so each keeps its own predicate.

## Changes

- **`five-five-card`** and **`rock-paper-scissor`** take from the *other* player's row, so their validators read `ctx.currentPlayer`: the two players have different targets, which makes this move legality rather than merely whose turn it is. `currentPlayer` is stable within a turn, so this needs none of the mid-turn `ctx` handling.
- **`number-covering`** addresses a number by its value, which doubles as its 1-based position; `isCoveringAllowed` pins both the range and that the number is still showing.
- `five-five-card`'s move is **1-based** while its board client is 0-based (it dispatches `id + 1`), so the validator also rules out the `0` a 0-based caller would pass — there's a test for it.
- All three board clients drop their local predicates and click guards, reading `disabled` from `moves.<name>.isAllowed`; `number-covering` no longer reads `ctx`.
- Add a `legality.spec.ts` per game.

No change to the bots: each already picks from the items still in play.

## Verification

`npm run test` passes (98 files / 635 tests — baseline 95 / 626, plus the 9 new cases).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSxP4EAjGt4vDBxsQt32c)_