### PR TITLE
Move legality layer: modified-mill, recolouring-discs

### DIFF
--- a/src/components/games/modified-mill/board-client.tsx
+++ b/src/components/games/modified-mill/board-client.tsx
@@ -11,8 +11,8 @@ const pos = COORDS.map(([x, y]) => ({ cx: px(x), cy: px(y) }));
 // adjacency belongs to exactly one line, so this renders the whole board.
 const segments = LINES.flatMap(([a, b, c]) => [[a, b], [b, c]] as const);
 
-export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
-  const isClickable = (node: number) => ctx.isClientMoveAllowed && board[node] === null;
+export const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
+  const isClickable = (node: number) => moves.placePiece.isAllowed!(board, node);
 
   const handleClick = (node: number) => {
     if (!isClickable(node)) return;

--- a/src/components/games/modified-mill/helpers.spec.ts
+++ b/src/components/games/modified-mill/helpers.spec.ts
@@ -1,6 +1,6 @@
 import {
   generateEmptyBoard, playerColor, playerHasLine, isBoardFull, boardMasks,
-  completesLine, hasLine, CELL_COUNT
+  completesLine, hasLine, isPlacementAllowed, CELL_COUNT
 } from './helpers';
 import { LINES, SYMMETRIES } from './board-data';
 import { canonicalize } from './bot-strategy';
@@ -57,6 +57,22 @@ describe('modified mill helpers', () => {
     expect(isBoardFull(board)).toBe(false);
     board.fill('red');
     expect(isBoardFull(board)).toBe(true);
+  });
+
+  it('allows placing on an empty cell but not on an occupied one', () => {
+    const board = generateEmptyBoard();
+    board[7] = 'red';
+    board[8] = 'blue';
+    expect(isPlacementAllowed(board, 0)).toBe(true);
+    expect(isPlacementAllowed(board, 7)).toBe(false);
+    expect(isPlacementAllowed(board, 8)).toBe(false);
+  });
+
+  it('rejects cells outside the board', () => {
+    const board = generateEmptyBoard();
+    expect(isPlacementAllowed(board, -1)).toBe(false);
+    expect(isPlacementAllowed(board, CELL_COUNT)).toBe(false);
+    expect(isPlacementAllowed(board, 1.5)).toBe(false);
   });
 
   it('canonicalize gives every symmetric image of a position the same key', () => {

--- a/src/components/games/modified-mill/helpers.ts
+++ b/src/components/games/modified-mill/helpers.ts
@@ -48,3 +48,8 @@ export const playerHasLine = (board: Board, playerIndex: number): boolean => {
 };
 
 export const isBoardFull = (board: Board): boolean => board.every((cell) => cell !== null);
+
+// A disc may go on any cell of the board that is still empty; both players draw
+// from the same pool of cells, so whose turn it is does not matter.
+export const isPlacementAllowed = (board: Board, node: number): boolean =>
+  Number.isInteger(node) && node >= 0 && node < CELL_COUNT && board[node] === null;

--- a/src/components/games/modified-mill/modified-mill.tsx
+++ b/src/components/games/modified-mill/modified-mill.tsx
@@ -1,6 +1,6 @@
 import { strategyGameFactory, type Ctx, type Events } from '../../strategy-game-factory';
 import {
-  type Board, generateEmptyBoard, playerColor, playerHasLine, isBoardFull
+  type Board, generateEmptyBoard, playerColor, playerHasLine, isBoardFull, isPlacementAllowed
 } from './helpers';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { BoardClient } from './board-client';
@@ -8,18 +8,21 @@ import { BoardClient } from './board-client';
 export type { Board };
 
 const moves = {
-  placePiece: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, node: number) => {
-    const nextBoard = board.slice();
-    nextBoard[node] = playerColor(ctx.currentPlayer!);
-    events.endTurn();
-    if (playerHasLine(nextBoard, ctx.currentPlayer!)) {
-      // Three of your discs adjacent in a line: the player who placed them wins.
-      events.endGame(ctx.currentPlayer);
-    } else if (isBoardFull(nextBoard)) {
-      // Board full with no line: the second player wins.
-      events.endGame(1);
+  placePiece: {
+    validate: (board: Board, _, node: number) => isPlacementAllowed(board, node),
+    apply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, node: number) => {
+      const nextBoard = board.slice();
+      nextBoard[node] = playerColor(ctx.currentPlayer!);
+      events.endTurn();
+      if (playerHasLine(nextBoard, ctx.currentPlayer!)) {
+        // Three of your discs adjacent in a line: the player who placed them wins.
+        events.endGame(ctx.currentPlayer);
+      } else if (isBoardFull(nextBoard)) {
+        // Board full with no line: the second player wins.
+        events.endGame(1);
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 };
 

--- a/src/components/games/recolouring-discs/board-client.tsx
+++ b/src/components/games/recolouring-discs/board-client.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
+import { range } from 'lodash';
 import { useTranslation } from '../../../language';
 import { GameBoard, type BoardClientProps } from '../../strategy-game-factory';
-import { type Board, type Cell, colorOf, moveTargets, placeTargets } from './helpers';
+import { type Board, type Cell, colorOf } from './helpers';
 
 // Translucent version of each disc colour, used for the recolour pulse ring.
 const pulseColor: Record<'red' | 'blue', string> = {
@@ -63,22 +64,28 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     });
   }, [ctx.moveCount, cells]);
 
-  const targets = selectedFrom !== null ? moveTargets(cells, selectedFrom) : [];
-  const placeable = canInteract && myColor !== null ? placeTargets(cells, myColor) : [];
+  // Every "may I?" question the board asks goes through the moves' own
+  // validators, so the highlighting and the engine agree by construction.
+  const isTarget = (to: number) =>
+    selectedFrom !== null && moves.moveDisc.isAllowed!(board, selectedFrom, to);
+  const isPlaceable = (at: number) => moves.placeDisc.isAllowed!(board, at);
+  // A disc is worth picking up only if it has somewhere to go; being of the
+  // player's own colour is already implied by `moveDisc`'s validator.
+  const isMovable = (from: number) => range(cells.length).some(to => moves.moveDisc.isAllowed!(board, from, to));
 
   const clickCell = (i: number) => {
     if (!canInteract || myColor === null) return;
     if (selectedFrom !== null) {
-      if (targets.includes(i)) {
+      if (isTarget(i)) {
         moves.moveDisc(board, selectedFrom, i);
         return;
       }
       if (i === selectedFrom) return setSelectedFrom(null);
     }
     if (cells[i] === myColor) {
-      return setSelectedFrom(moveTargets(cells, i).length > 0 ? i : null);
+      return setSelectedFrom(isMovable(i) ? i : null);
     }
-    if (cells[i] === null && placeable.includes(i)) {
+    if (isPlaceable(i)) {
       moves.placeDisc(board, i);
       return;
     }
@@ -87,10 +94,10 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 
   const cellState = (i: number): 'selected' | 'target' | 'placeable' | 'movable' | 'plain' => {
     if (i === selectedFrom) return 'selected';
-    if (selectedFrom !== null && targets.includes(i)) return 'target';
-    if (selectedFrom === null && canInteract) {
-      if (cells[i] === myColor && moveTargets(cells, i).length > 0) return 'movable';
-      if (cells[i] === null && placeable.includes(i)) return 'placeable';
+    if (isTarget(i)) return 'target';
+    if (selectedFrom === null) {
+      if (isMovable(i)) return 'movable';
+      if (isPlaceable(i)) return 'placeable';
     }
     return 'plain';
   };

--- a/src/components/games/recolouring-discs/helpers.spec.ts
+++ b/src/components/games/recolouring-discs/helpers.spec.ts
@@ -5,6 +5,8 @@ import {
   BLUE,
   applyMove,
   encode,
+  isDiscMoveAllowed,
+  isPlacementAllowed,
   legalMoves,
   majorityWinner,
   moveTargets,
@@ -42,6 +44,40 @@ describe('recolouring-discs helpers', () => {
 
   it('always offers a pass move', () => {
     expect(legalMoves(startCells(7), RED).some(m => m.type === 'pass')).toBe(true);
+  });
+
+  it('only lets a player move a disc of their own colour', () => {
+    const board = cells('R...B.');
+    expect(isDiscMoveAllowed(board, RED, 0, 1)).toBe(true);
+    expect(isDiscMoveAllowed(board, BLUE, 0, 1)).toBe(false); // red's disc
+    expect(isDiscMoveAllowed(board, RED, 2, 3)).toBe(false); // no disc at all
+  });
+
+  it('rejects moves further than two fields, off the board or onto an occupied cell', () => {
+    const board = cells('RB..B.');
+    expect(isDiscMoveAllowed(board, RED, 0, 2)).toBe(true); // jump over the blue on 1
+    expect(isDiscMoveAllowed(board, RED, 0, 1)).toBe(false); // occupied
+    expect(isDiscMoveAllowed(board, RED, 0, 3)).toBe(false); // three fields away
+    expect(isDiscMoveAllowed(board, RED, 0, -1)).toBe(false);
+    expect(isDiscMoveAllowed(board, RED, -1, 0)).toBe(false);
+  });
+
+  it('only lets a player place next to one of their own discs', () => {
+    const board = cells('R...B.');
+    expect(isPlacementAllowed(board, RED, 1)).toBe(true);
+    expect(isPlacementAllowed(board, RED, 3)).toBe(false); // next to blue only
+    expect(isPlacementAllowed(board, BLUE, 3)).toBe(true);
+    expect(isPlacementAllowed(board, BLUE, 4)).toBe(false); // occupied by blue itself
+  });
+
+  it('agrees with the move generator on every legal move', () => {
+    const board = cells('R.B.R.B.');
+    for (const player of [RED, BLUE]) {
+      for (const move of legalMoves(board, player)) {
+        if (move.type === 'move') expect(isDiscMoveAllowed(board, player, move.from, move.to)).toBe(true);
+        if (move.type === 'place') expect(isPlacementAllowed(board, player, move.to)).toBe(true);
+      }
+    }
   });
 
   it('applies the asymmetric majority thresholds', () => {

--- a/src/components/games/recolouring-discs/helpers.ts
+++ b/src/components/games/recolouring-discs/helpers.ts
@@ -68,6 +68,15 @@ export const placeTargets = (cells: Cell[], color: 'red' | 'blue'): number[] =>
         (j + 1 < cells.length && cells[j + 1] === color))
   );
 
+// A player may only pick up a disc of their own colour, and only drop it on a
+// cell `moveTargets` offers (empty, 1–2 away).
+export const isDiscMoveAllowed = (cells: Cell[], player: number, from: number, to: number): boolean =>
+  cells[from] === colorOf(player) && moveTargets(cells, from).includes(to);
+
+// A new disc may only go on an empty cell next to one of the player's own discs.
+export const isPlacementAllowed = (cells: Cell[], player: number, at: number): boolean =>
+  placeTargets(cells, colorOf(player)).includes(at);
+
 export const legalMoves = (cells: Cell[], player: number): Move[] => {
   const color = colorOf(player);
   const result: Move[] = [{ type: 'pass' }];

--- a/src/components/games/recolouring-discs/recolouring-discs.tsx
+++ b/src/components/games/recolouring-discs/recolouring-discs.tsx
@@ -6,6 +6,8 @@ import {
   applyMove,
   countColor,
   generateStartBoard,
+  isDiscMoveAllowed,
+  isPlacementAllowed,
   majorityWinner,
   targetCounts
 } from './helpers';
@@ -31,11 +33,22 @@ const finalize = (
   return { nextBoard };
 };
 
+// Which discs a player may touch depends on their colour, so both validators
+// read `ctx.currentPlayer`. Passing is always available, so it needs no
+// validator.
 const moves = {
-  moveDisc: (board: Board, meta: { ctx: Ctx; events: Events }, from: number, to: number) =>
-    finalize(applyMove(board.cells, meta.ctx.currentPlayer!, { type: 'move', from, to }), meta),
-  placeDisc: (board: Board, meta: { ctx: Ctx; events: Events }, at: number) =>
-    finalize(applyMove(board.cells, meta.ctx.currentPlayer!, { type: 'place', to: at }), meta),
+  moveDisc: {
+    validate: (board: Board, { ctx }: { ctx: Ctx }, from: number, to: number) =>
+      isDiscMoveAllowed(board.cells, ctx.currentPlayer!, from, to),
+    apply: (board: Board, meta: { ctx: Ctx; events: Events }, from: number, to: number) =>
+      finalize(applyMove(board.cells, meta.ctx.currentPlayer!, { type: 'move', from, to }), meta)
+  },
+  placeDisc: {
+    validate: (board: Board, { ctx }: { ctx: Ctx }, at: number) =>
+      isPlacementAllowed(board.cells, ctx.currentPlayer!, at),
+    apply: (board: Board, meta: { ctx: Ctx; events: Events }, at: number) =>
+      finalize(applyMove(board.cells, meta.ctx.currentPlayer!, { type: 'place', to: at }), meta)
+  },
   pass: (board: Board, meta: { ctx: Ctx; events: Events }) =>
     finalize([...board.cells], meta)
 };


### PR DESCRIPTION
Continues the per-move `validate` migration started in #333. This batch covers the two disc-placement games.

## modified-mill

`placePiece` gets `isPlacementAllowed(board, node)` — the node is on the board and the cell is still empty. Both players draw from the same pool of cells, so the validator needs no `ctx`.

The board client's `isClickable` was an independent copy of the same predicate; it now calls `moves.placePiece.isAllowed`.

## recolouring-discs

Two of the three moves have real legality:

- `moveDisc(from, to)` — `from` holds a disc of the mover's own colour and `to` is one of `moveTargets(cells, from)` (empty, one or two fields away, possibly jumping).
- `placeDisc(at)` — `at` is one of `placeTargets(cells, colour)` (empty and adjacent to an own disc).
- `pass` stays a plain apply function: it is legal in every position.

Both validators read `ctx.currentPlayer`, because which discs a player may touch depends on their colour — the two players have genuinely disjoint move sets here, so this is move legality rather than turn ownership (which the engine still folds in separately).

The board client used to recompute the target and placeable lists from the helpers to drive its highlighting. It now asks the validators instead (`isTarget` / `isPlaceable` / `isMovable`), which removes the duplicated logic and means the highlighting, the click handling and the engine cannot drift apart. `isMovable` no longer needs its own "is this my colour" check — `moveDisc`'s validator already implies it.

## Tests

Extended each game's existing `helpers.spec.ts`: occupied and out-of-range cells for the mill, wrong-colour / too-far / off-board cases for the discs, plus a check that every move `legalMoves` generates passes the corresponding validator.

Full suite: 95 files, 632 tests, all passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSxP4EAjGt4vDBxsQt32c)_