### PR TITLE
Move legality layer: triangle-circle-game, hunyadi-and-the-janissaries

### DIFF
--- a/src/components/games/hunyadi-and-the-janissaries/bot-strategy.spec.ts
+++ b/src/components/games/hunyadi-and-the-janissaries/bot-strategy.spec.ts
@@ -18,7 +18,7 @@ describe('HunyadiAndTheJanissaries strategy', () => {
     it('should split first row evenly if there are more soldiers', () => {
       const board = [[], ['blue', 'blue']] as Board;
       const soldiers = getOptimalSoldierGroups(board);
-      const { nextBoard } = moves.setGroupOfSoldiers(board, {}, soldiers);
+      const { nextBoard } = moves.setGroupOfSoldiers.apply(board, {}, soldiers);
       expect([[[], ['red', 'blue']], [[], ['blue', 'red']]]).toContainEqual(nextBoard);
     });
 
@@ -31,7 +31,7 @@ describe('HunyadiAndTheJanissaries strategy', () => {
         ['blue', 'blue', 'blue', 'blue']
       ] as Board;
       const soldiers = getOptimalSoldierGroups(board);
-      const { nextBoard } = moves.setGroupOfSoldiers(board, {}, soldiers);
+      const { nextBoard } = moves.setGroupOfSoldiers.apply(board, {}, soldiers);
       expect([
         [[], ['blue'], ['red'], [], ['red', 'red', 'red', 'red']],
         [[], ['red'], ['blue'], [], ['blue', 'blue', 'blue', 'blue']]
@@ -47,7 +47,7 @@ describe('HunyadiAndTheJanissaries strategy', () => {
         ['blue', 'blue']
       ] as Board;
       const soldiers = getOptimalSoldierGroups(board);
-      const { nextBoard } = moves.setGroupOfSoldiers(board, {}, soldiers);
+      const { nextBoard } = moves.setGroupOfSoldiers.apply(board, {}, soldiers);
       expect([
         [[], ['blue'], ['red', 'red', 'blue'], ['red'], ['red', 'red']],
         [[], ['red'], ['blue', 'blue', 'red'], ['blue'], ['blue', 'blue']]

--- a/src/components/games/hunyadi-and-the-janissaries/bot-strategy.ts
+++ b/src/components/games/hunyadi-and-the-janissaries/bot-strategy.ts
@@ -1,9 +1,9 @@
 import { random } from 'lodash';
 import type { StrategyArgs } from '../../strategy-game-factory';
-import { type Board, type SoldierColor, type Soldier } from './helpers';
+import { SULTAN, type Board, type SoldierColor, type Soldier } from './helpers';
 
 export const smartBotStrategy = ({ board, ctx, moves }: StrategyArgs<Board>) => {
-  if (ctx.chosenRoleIndex === 0) {
+  if (ctx.chosenRoleIndex === SULTAN) {
     const optimalGroupToKill = getOptimalGroupToKill(board);
     moves.killGroup(board, optimalGroupToKill);
   } else {

--- a/src/components/games/hunyadi-and-the-janissaries/helpers.spec.ts
+++ b/src/components/games/hunyadi-and-the-janissaries/helpers.spec.ts
@@ -1,4 +1,6 @@
-import { moves, generateStartBoard, type Board } from './helpers';
+import {
+  moves, generateStartBoard, isColor, isSoldierAssignmentAllowed, type Board
+} from './helpers';
 import { uniq, flatten } from 'lodash';
 import { makeEvents } from '../../../test-utils';
 
@@ -6,13 +8,13 @@ describe('HunyadiAndTheJanissaries helpers', () => {
   describe('moves', () => {
     it('should claim victory for Hunyadi if all soldiers are killed', () => {
       const events = makeEvents();
-      moves.killGroup([[], ['red', 'red']] as Board, { events }, 'red')
+      moves.killGroup.apply([[], ['red', 'red']] as Board, { events }, 'red')
       expect(events.endGame).toHaveBeenCalledWith(1);
     });
 
     it('should claim loss for Hunyadi if a soldier reaches the castle', () => {
       const events = makeEvents();
-      const { nextBoard } = moves.killGroup(
+      const { nextBoard } = moves.killGroup.apply(
         [[], ['red', 'blue'], ['blue']] as Board, { events }, 'red'
       );
       moves.stepUp(nextBoard, { events });
@@ -22,11 +24,36 @@ describe('HunyadiAndTheJanissaries helpers', () => {
     it('should report game as still in progress and advance remaining soldiers otherwise', () => {
       const events = makeEvents();
       const board = [[], ['red'], ['blue', 'red'], [], ['blue', 'blue']] as Board;
-      const { nextBoard } = moves.killGroup(board, { events }, 'red');
+      const { nextBoard } = moves.killGroup.apply(board, { events }, 'red');
       const state = moves.stepUp(nextBoard, { events });
       expect(state.nextBoard).toEqual([[], ['blue'], [], ['blue', 'blue'], []])
       expect(events.endGame).not.toHaveBeenCalled();
     });
+  });
+
+  describe('legality', () => {
+    const board = [[], ['red'], ['blue', 'red']] as Board;
+
+    it('only accepts the two group colours', () => {
+      expect(isColor('red')).toBe(true);
+      expect(isColor('blue')).toBe(true);
+      expect(isColor('green')).toBe(false);
+      expect(isColor('')).toBe(false);
+    });
+
+    it('accepts an assignment of soldiers that are actually on the staircase', () => {
+      expect(isSoldierAssignmentAllowed(board, [
+        { rowIndex: 1, pieceIndex: 0, group: 'blue' },
+        { rowIndex: 2, pieceIndex: 1, group: 'red' }
+      ])).toBe(true);
+    });
+
+    it('rejects an assignment referring to a step or a position with no soldier', () => {
+      expect(isSoldierAssignmentAllowed(board, [{ rowIndex: 0, pieceIndex: 0, group: 'red' }])).toBe(false);
+      expect(isSoldierAssignmentAllowed(board, [{ rowIndex: 1, pieceIndex: 1, group: 'red' }])).toBe(false);
+      expect(isSoldierAssignmentAllowed(board, [{ rowIndex: 9, pieceIndex: 0, group: 'red' }])).toBe(false);
+    });
+
   });
 
   describe('generateStartBoard', () => {

--- a/src/components/games/hunyadi-and-the-janissaries/helpers.ts
+++ b/src/components/games/hunyadi-and-the-janissaries/helpers.ts
@@ -46,28 +46,54 @@ export const generateStartBoard = (): Board => {
   return [[], ...board];
 };
 
-export const moves = {
-  killGroup: (board: Board, { events }: { events: Events }, group: SoldierColor) => {
-    const nextBoard = board.map(row => row.filter(soldier => soldier !== group));
+export const [SULTAN, HUNYADI] = [0, 1];
 
-    const isGameEnd = flatten(nextBoard).length === 0;
-    if (isGameEnd) {
+// Hunyadi destroys one of the two colours. Wiping out a colour nobody was
+// assigned to is allowed by the rules (it simply achieves nothing), so the
+// colour being present on the staircase is not part of legality.
+export const isColor = (group: string): group is SoldierColor => group === 'blue' || group === 'red';
+
+// A soldier reference points at an actual soldier on the staircase, and the
+// group it is assigned to is one of the two colours the sultan splits into.
+export const isSoldierAssignmentAllowed = (board: Board, soldiers: Soldier[]): boolean =>
+  Array.isArray(soldiers) && soldiers.every(
+    ({ rowIndex, pieceIndex, group }) =>
+      isColor(group) && board[rowIndex]?.[pieceIndex] !== undefined
+  );
+
+export const moves = {
+  killGroup: {
+    validate: (board: Board, { ctx }, group: SoldierColor) =>
+      ctx.currentPlayer === HUNYADI && isColor(group),
+    apply: (board: Board, { events }: { events: Events }, group: SoldierColor) => {
+      const nextBoard = board.map(row => row.filter(soldier => soldier !== group));
+
+      const isGameEnd = flatten(nextBoard).length === 0;
+      if (isGameEnd) {
+        events.endTurn();
+        events.endGame(1);
+        return { nextBoard, isGameEnd };
+      }
+      return { nextBoard, isGameEnd, autoEndOfTurn: true };
+    }
+  },
+  finalizeSeparation: {
+    validate: (board: Board, { ctx }) => ctx.currentPlayer === SULTAN,
+    apply: (board: Board, { events }: { events: Events }) => {
       events.endTurn();
-      events.endGame(1);
-      return { nextBoard, isGameEnd };
+      return { nextBoard: board };
     }
-    return { nextBoard, isGameEnd, autoEndOfTurn: true };
   },
-  finalizeSeparation: (board: Board, { events }: { events: Events }) => {
-    events.endTurn();
-    return { nextBoard: board };
-  },
-  setGroupOfSoldiers: (board: Board, _, soldiers: Soldier[]) => {
-    const nextBoard = cloneDeep(board);
-    for (const soldier of soldiers) {
-      nextBoard[soldier.rowIndex][soldier.pieceIndex] = soldier.group;
+  setGroupOfSoldiers: {
+    validate: (board: Board, { ctx }, soldiers: Soldier[]) =>
+      ctx.currentPlayer === SULTAN && isSoldierAssignmentAllowed(board, soldiers),
+    apply: (board: Board, _, soldiers: Soldier[]) => {
+      const nextBoard = cloneDeep(board);
+      for (const soldier of soldiers) {
+        nextBoard[soldier.rowIndex][soldier.pieceIndex] = soldier.group;
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   },
   // endOfTurn move automatically initiated by game engine
   stepUp: (board: Board, { events }: { events: Events }) => {

--- a/src/components/games/hunyadi-and-the-janissaries/hunyadi-and-the-janissaries.tsx
+++ b/src/components/games/hunyadi-and-the-janissaries/hunyadi-and-the-janissaries.tsx
@@ -4,7 +4,7 @@ import {
 import { CastleSvg } from './assets/castle-svg';
 import { SoldierSvg } from './assets/soldier-svg';
 import { smartBotStrategy } from './bot-strategy';
-import { generateStartBoard, moves, type Board, type SoldierColor } from './helpers';
+import { generateStartBoard, moves, SULTAN, type Board, type SoldierColor } from './helpers';
 import { useTranslation } from '../../../language';
 
 type Piece = { rowIndex: number, pieceIndex: number }
@@ -13,7 +13,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
   const { value: validHoveredPiece, hoverProps } = useHoverPreview<Piece>(ctx.moveCount);
 
-  const isPlayerSultan = ctx.currentPlayer === 0;
+  const isPlayerSultan = ctx.currentPlayer === SULTAN;
   const groupOfHoveredPiece = validHoveredPiece
     ? board[validHoveredPiece.rowIndex][validHoveredPiece.pieceIndex]
     : null;
@@ -106,7 +106,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 };
 
 const getPlayerStepDescription = ({ ctx }: { ctx: Ctx }) => {
-  return ctx.currentPlayer === 0
+  return ctx.currentPlayer === SULTAN
     ? {
       hu: 'Kattints a katonákra és válaszd két részre a seregedet.',
       en: 'Click soldiers to split your army in two.'

--- a/src/components/games/hunyadi-and-the-janissaries/hunyadi-and-the-janissaries.tsx
+++ b/src/components/games/hunyadi-and-the-janissaries/hunyadi-and-the-janissaries.tsx
@@ -24,14 +24,14 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     return group === groupOfHoveredPiece;
   };
 
+  // The same click means different things to the two roles: the sultan flips
+  // the clicked soldier's colour, Hunyadi wipes out everyone sharing it. The
+  // engine ignores whichever move is not the caller's to make, so no guard.
   const clickOnSoldier = ({ rowIndex, pieceIndex }: Piece) => {
-    if (!ctx.isClientMoveAllowed) return;
-
+    const group = board[rowIndex][pieceIndex];
     if (isPlayerSultan) {
-      const group = board[rowIndex][pieceIndex] === 'red' ? 'blue' : 'red';
-      moves.setGroupOfSoldiers(board, [{ rowIndex, pieceIndex, group }]);
+      moves.setGroupOfSoldiers(board, [{ rowIndex, pieceIndex, group: group === 'red' ? 'blue' : 'red' }]);
     } else {
-      const group = board[rowIndex][pieceIndex];
       moves.killGroup(board, group);
     }
   };
@@ -71,7 +71,9 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
           {board[rowIndex] && board[rowIndex].map((group, pieceIndex) => (
             <button
               key={pieceIndex}
-              disabled={!ctx.isClientMoveAllowed}
+              disabled={!(isPlayerSultan
+                ? moves.setGroupOfSoldiers.isAllowed!(board, [{ rowIndex, pieceIndex, group }])
+                : moves.killGroup.isAllowed!(board, group))}
               className="aspect-square w-[10%] mx-1"
               onClick={() => clickOnSoldier({ rowIndex, pieceIndex })}
               {...hoverProps({ rowIndex, pieceIndex })}
@@ -92,9 +94,9 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
       <button
         className={`
           primary-button w-auto m-auto mt-2
-          ${!ctx.isClientMoveAllowed || !isPlayerSultan ? 'invisible' : ''}
+          ${moves.finalizeSeparation.isAllowed!(board) ? '' : 'invisible'}
         `}
-        disabled={!ctx.isClientMoveAllowed || !isPlayerSultan}
+        disabled={!moves.finalizeSeparation.isAllowed!(board)}
         onClick={() => moves.finalizeSeparation(board)}
       >
         {t({ hu: 'Befejezem a kettéosztást', en: 'Finish the split' })}

--- a/src/components/games/triangle-circle-game/board-client.tsx
+++ b/src/components/games/triangle-circle-game/board-client.tsx
@@ -126,10 +126,9 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
         </g>
 
         {/* Invisible wide hit targets for edges — only on the line player's turn,
-            where `edgeClickable` (the move's own validator) is what makes the
-            list non-empty. */}
+            where the move's own validator is what makes the list non-empty. */}
         <g>
-          {EDGES.filter(edge => edgeClickable(edge.id)).map(edge => (
+          {EDGES.filter(edge => moves.shadeEdge.isAllowed!(board, edge.id)).map(edge => (
             <line
               key={`hit-${edge.id}`}
               x1={edge.x1} y1={edge.y1} x2={edge.x2} y2={edge.y2}

--- a/src/components/games/triangle-circle-game/board-client.tsx
+++ b/src/components/games/triangle-circle-game/board-client.tsx
@@ -28,7 +28,6 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 
   const triangleClickable = (t: number) => moves.placeCircle.isAllowed!(board, t);
 
-
   const triangleClass = (t: number) => {
     if (board.circles[t]) return 'fill-slate-900/5 dark:fill-white/5';
     if (triangleClickable(t)) {

--- a/src/components/games/triangle-circle-game/board-client.tsx
+++ b/src/components/games/triangle-circle-game/board-client.tsx
@@ -26,11 +26,8 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     setHoveredEdge(null);
   }, [ctx.moveCount]);
 
-  const edgeClickable = (e: number) => moves.shadeEdge.isAllowed!(board, e);
   const triangleClickable = (t: number) => moves.placeCircle.isAllowed!(board, t);
 
-  const shadeEdge = (e: number) => moves.shadeEdge(board, e);
-  const placeCircle = (t: number) => moves.placeCircle(board, t);
 
   const triangleClass = (t: number) => {
     if (board.circles[t]) return 'fill-slate-900/5 dark:fill-white/5';
@@ -54,8 +51,8 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
               key={`tri-${tri.id}`}
               points={tri.points}
               className={triangleClass(tri.id)}
-              onClick={() => placeCircle(tri.id)}
-              onKeyUp={event => { if (event.key === 'Enter') placeCircle(tri.id); }}
+              onClick={() => moves.placeCircle(board, tri.id)}
+              onKeyUp={event => { if (event.key === 'Enter') moves.placeCircle(board, tri.id); }}
               tabIndex={triangleClickable(tri.id) ? 0 : undefined}
               role={triangleClickable(tri.id) ? 'button' : undefined}
               aria-label={triangleClickable(tri.id)
@@ -136,12 +133,12 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
               strokeWidth="4"
               strokeLinecap="round"
               className="cursor-pointer outline-none"
-              onClick={() => shadeEdge(edge.id)}
+              onClick={() => moves.shadeEdge(board, edge.id)}
               onMouseEnter={() => setHoveredEdge(edge.id)}
               onMouseLeave={() => setHoveredEdge(null)}
               onFocus={() => setHoveredEdge(edge.id)}
               onBlur={() => setHoveredEdge(null)}
-              onKeyUp={event => { if (event.key === 'Enter') shadeEdge(edge.id); }}
+              onKeyUp={event => { if (event.key === 'Enter') moves.shadeEdge(board, edge.id); }}
               tabIndex={0}
               role="button"
               aria-label={t({ hu: `${edge.id + 1}. él — satírozd be`, en: `Edge ${edge.id + 1} — shade it` })}

--- a/src/components/games/triangle-circle-game/board-client.tsx
+++ b/src/components/games/triangle-circle-game/board-client.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from '../../../language';
 import { GameBoard, type BoardClientProps } from '../../strategy-game-factory';
 import { BOARD_OUTLINE, EDGES, TRIANGLES, type Edge } from './geometry';
-import { type Board, LINE, CIRCLE } from './helpers';
+import { type Board } from './helpers';
 
 // Two very different interactions share one board: on the line player's turn the
 // edges are clickable, on the circle player's turn the triangles are. Only the
@@ -26,21 +26,11 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     setHoveredEdge(null);
   }, [ctx.moveCount]);
 
-  const myTurn = ctx.isClientMoveAllowed;
-  const lineToMove = myTurn && ctx.currentPlayer === LINE;
-  const circleToMove = myTurn && ctx.currentPlayer === CIRCLE;
+  const edgeClickable = (e: number) => moves.shadeEdge.isAllowed!(board, e);
+  const triangleClickable = (t: number) => moves.placeCircle.isAllowed!(board, t);
 
-  const edgeClickable = (e: number) => lineToMove && !board.edges[e];
-  const triangleClickable = (t: number) => circleToMove && !board.circles[t];
-
-  const shadeEdge = (e: number) => {
-    if (!edgeClickable(e)) return;
-    moves.shadeEdge(board, e);
-  };
-  const placeCircle = (t: number) => {
-    if (!triangleClickable(t)) return;
-    moves.placeCircle(board, t);
-  };
+  const shadeEdge = (e: number) => moves.shadeEdge(board, e);
+  const placeCircle = (t: number) => moves.placeCircle(board, t);
 
   const triangleClass = (t: number) => {
     if (board.circles[t]) return 'fill-slate-900/5 dark:fill-white/5';
@@ -135,30 +125,30 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
           })}
         </g>
 
-        {/* Invisible wide hit targets for edges — only on the line player's turn */}
-        {lineToMove && (
-          <g>
-            {EDGES.filter(edge => !board.edges[edge.id]).map(edge => (
-              <line
-                key={`hit-${edge.id}`}
-                x1={edge.x1} y1={edge.y1} x2={edge.x2} y2={edge.y2}
-                stroke="transparent"
-                strokeWidth="4"
-                strokeLinecap="round"
-                className="cursor-pointer outline-none"
-                onClick={() => shadeEdge(edge.id)}
-                onMouseEnter={() => setHoveredEdge(edge.id)}
-                onMouseLeave={() => setHoveredEdge(null)}
-                onFocus={() => setHoveredEdge(edge.id)}
-                onBlur={() => setHoveredEdge(null)}
-                onKeyUp={event => { if (event.key === 'Enter') shadeEdge(edge.id); }}
-                tabIndex={0}
-                role="button"
-                aria-label={t({ hu: `${edge.id + 1}. él — satírozd be`, en: `Edge ${edge.id + 1} — shade it` })}
-              />
-            ))}
-          </g>
-        )}
+        {/* Invisible wide hit targets for edges — only on the line player's turn,
+            where `edgeClickable` (the move's own validator) is what makes the
+            list non-empty. */}
+        <g>
+          {EDGES.filter(edge => edgeClickable(edge.id)).map(edge => (
+            <line
+              key={`hit-${edge.id}`}
+              x1={edge.x1} y1={edge.y1} x2={edge.x2} y2={edge.y2}
+              stroke="transparent"
+              strokeWidth="4"
+              strokeLinecap="round"
+              className="cursor-pointer outline-none"
+              onClick={() => shadeEdge(edge.id)}
+              onMouseEnter={() => setHoveredEdge(edge.id)}
+              onMouseLeave={() => setHoveredEdge(null)}
+              onFocus={() => setHoveredEdge(edge.id)}
+              onBlur={() => setHoveredEdge(null)}
+              onKeyUp={event => { if (event.key === 'Enter') shadeEdge(edge.id); }}
+              tabIndex={0}
+              role="button"
+              aria-label={t({ hu: `${edge.id + 1}. él — satírozd be`, en: `Edge ${edge.id + 1} — shade it` })}
+            />
+          ))}
+        </g>
       </svg>
     </GameBoard>
   );

--- a/src/components/games/triangle-circle-game/helpers.spec.ts
+++ b/src/components/games/triangle-circle-game/helpers.spec.ts
@@ -2,7 +2,7 @@ import { EDGES, TRIANGLES } from './geometry';
 import {
   type Board,
   generateStartBoard, shadedCount,
-  isLineWin, isCircleWin, isWinningShade,
+  isLineWin, isCircleWin, isWinningShade, isShadeAllowed, isCirclePlacementAllowed,
   liveThreats, preThreatEdges, freeEdges, freeTriangles,
   applyShade, applyCircle
 } from './helpers';
@@ -93,5 +93,27 @@ describe('threat vocabulary', () => {
     expect(liveThreats(applyShade(board, edge)).length).toBeGreaterThanOrEqual(2);
     // Circling one partner defuses it.
     expect(preThreatEdges(applyCircle(board, t1))).not.toContain(edge);
+  });
+
+  it('allows shading a free edge and refuses an already shaded or non-existent one', () => {
+    const board = applyShade(generateStartBoard(), 3);
+    expect(isShadeAllowed(board, 4)).toBe(true);
+    expect(isShadeAllowed(board, 3)).toBe(false);
+    expect(isShadeAllowed(board, -1)).toBe(false);
+    expect(isShadeAllowed(board, EDGES.length)).toBe(false);
+  });
+
+  it('allows circling a free triangle and refuses an already circled or non-existent one', () => {
+    const board = applyCircle(generateStartBoard(), 2);
+    expect(isCirclePlacementAllowed(board, 1)).toBe(true);
+    expect(isCirclePlacementAllowed(board, 2)).toBe(false);
+    expect(isCirclePlacementAllowed(board, -1)).toBe(false);
+    expect(isCirclePlacementAllowed(board, TRIANGLES.length)).toBe(false);
+  });
+
+  it('agrees with the free-edge and free-triangle listings', () => {
+    const board = applyCircle(applyShade(generateStartBoard(), 3), 2);
+    expect(freeEdges(board).every(e => isShadeAllowed(board, e))).toBe(true);
+    expect(freeTriangles(board).every(t => isCirclePlacementAllowed(board, t))).toBe(true);
   });
 });

--- a/src/components/games/triangle-circle-game/helpers.ts
+++ b/src/components/games/triangle-circle-game/helpers.ts
@@ -42,6 +42,17 @@ export const freeTriangles = (board: Board): number[] => {
   return result;
 };
 
+// The two players never compete for the same resource: the line player only
+// shades edges, the circle player only fills triangles. Each may use anything
+// their opponent has not — and they cannot — touched, so "still free" is the
+// whole of legality on both sides.
+export const isShadeAllowed = (board: Board, edgeId: number): boolean =>
+  Number.isInteger(edgeId) && edgeId >= 0 && edgeId < EDGE_COUNT && !board.edges[edgeId];
+
+export const isCirclePlacementAllowed = (board: Board, triangleId: number): boolean =>
+  Number.isInteger(triangleId) && triangleId >= 0 && triangleId < TRIANGLE_COUNT
+    && !board.circles[triangleId];
+
 export const applyShade = (board: Board, edgeId: number): Board => {
   const edges = board.edges.slice();
   edges[edgeId] = true;

--- a/src/components/games/triangle-circle-game/triangle-circle-game.spec.ts
+++ b/src/components/games/triangle-circle-game/triangle-circle-game.spec.ts
@@ -6,7 +6,7 @@ import { makeEvents } from '../../../test-utils';
 describe('moves.shadeEdge', () => {
   it('shades the edge and passes the turn', () => {
     const events = makeEvents();
-    const { nextBoard } = moves.shadeEdge(generateStartBoard(), { events }, 0);
+    const { nextBoard } = moves.shadeEdge.apply(generateStartBoard(), { events }, 0);
     expect(nextBoard.edges[0]).toBe(true);
     expect(events.endTurn).toHaveBeenCalled();
     expect(events.endGame).not.toHaveBeenCalled();
@@ -16,7 +16,7 @@ describe('moves.shadeEdge', () => {
     const [e0, e1, e2] = TRIANGLES[0].edgeIds;
     const board = applyShade(applyShade(generateStartBoard(), e0), e1);
     const events = makeEvents();
-    moves.shadeEdge(board, { events }, e2);
+    moves.shadeEdge.apply(board, { events }, e2);
     expect(events.endGame).toHaveBeenCalledWith(LINE);
     expect(events.endTurn).not.toHaveBeenCalled();
   });
@@ -25,7 +25,7 @@ describe('moves.shadeEdge', () => {
     const [e0, e1, e2] = TRIANGLES[0].edgeIds;
     const board = applyCircle(applyShade(applyShade(generateStartBoard(), e0), e1), 0);
     const events = makeEvents();
-    moves.shadeEdge(board, { events }, e2);
+    moves.shadeEdge.apply(board, { events }, e2);
     expect(events.endTurn).toHaveBeenCalled();
     expect(events.endGame).not.toHaveBeenCalled();
   });
@@ -34,7 +34,7 @@ describe('moves.shadeEdge', () => {
 describe('moves.placeCircle', () => {
   it('places the circle and passes the turn', () => {
     const events = makeEvents();
-    const { nextBoard } = moves.placeCircle(generateStartBoard(), { events }, 7);
+    const { nextBoard } = moves.placeCircle.apply(generateStartBoard(), { events }, 7);
     expect(nextBoard.circles[7]).toBe(true);
     expect(events.endTurn).toHaveBeenCalled();
     expect(events.endGame).not.toHaveBeenCalled();
@@ -44,7 +44,7 @@ describe('moves.placeCircle', () => {
     const circles = new Array(TRIANGLE_COUNT).fill(true);
     circles[12] = false;
     const events = makeEvents();
-    moves.placeCircle({ edges: generateStartBoard().edges, circles }, { events }, 12);
+    moves.placeCircle.apply({ edges: generateStartBoard().edges, circles }, { events }, 12);
     expect(events.endGame).toHaveBeenCalledWith(CIRCLE);
     expect(events.endTurn).not.toHaveBeenCalled();
   });

--- a/src/components/games/triangle-circle-game/triangle-circle-game.tsx
+++ b/src/components/games/triangle-circle-game/triangle-circle-game.tsx
@@ -1,33 +1,44 @@
-import { strategyGameFactory, type Events } from '../../strategy-game-factory';
+import { strategyGameFactory, type Ctx, type Events } from '../../strategy-game-factory';
 import { BoardClient } from './board-client';
 import {
   type Board, LINE, CIRCLE,
-  applyShade, applyCircle, generateStartBoard, isLineWin, isCircleWin
+  applyShade, applyCircle, generateStartBoard, isLineWin, isCircleWin,
+  isShadeAllowed, isCirclePlacementAllowed
 } from './helpers';
 import { smartBotStrategy, randomBotStrategy } from './strategy/bot-strategy';
 
+// Each move belongs to exactly one role, so both validators check who is on
+// turn: shading is not a thing the circle player can do at all.
 export const moves = {
   // Line player shades one edge; they win at once if it completes an un-circled
   // triangle, otherwise the turn passes.
-  shadeEdge: (board: Board, { events }: { events: Events }, edgeId: number) => {
-    const nextBoard = applyShade(board, edgeId);
-    if (isLineWin(nextBoard)) {
-      events.endGame(LINE);
-    } else {
-      events.endTurn();
+  shadeEdge: {
+    validate: (board: Board, { ctx }: { ctx: Ctx }, edgeId: number) =>
+      ctx.currentPlayer === LINE && isShadeAllowed(board, edgeId),
+    apply: (board: Board, { events }: { events: Events }, edgeId: number) => {
+      const nextBoard = applyShade(board, edgeId);
+      if (isLineWin(nextBoard)) {
+        events.endGame(LINE);
+      } else {
+        events.endTurn();
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   },
   // Circle player drops a circle into one triangle; they win once every triangle
   // is circled, otherwise the turn passes.
-  placeCircle: (board: Board, { events }: { events: Events }, triangleId: number) => {
-    const nextBoard = applyCircle(board, triangleId);
-    if (isCircleWin(nextBoard)) {
-      events.endGame(CIRCLE);
-    } else {
-      events.endTurn();
+  placeCircle: {
+    validate: (board: Board, { ctx }: { ctx: Ctx }, triangleId: number) =>
+      ctx.currentPlayer === CIRCLE && isCirclePlacementAllowed(board, triangleId),
+    apply: (board: Board, { events }: { events: Events }, triangleId: number) => {
+      const nextBoard = applyCircle(board, triangleId);
+      if (isCircleWin(nextBoard)) {
+        events.endGame(CIRCLE);
+      } else {
+        events.endTurn();
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 };
 


### PR DESCRIPTION
Continues the per-move `validate` migration started in #333. Both games in this batch give the two players entirely different kinds of move, so every validator here also pins down whose move it is.

That is deliberate, and it is not the "whose turn is it" check AGENTS.md keeps out of `validate`: shading an edge is not something the circle player can do at all, however long they wait. The engine still folds `ctx.isClientMoveAllowed` in separately for the client. (This is the same reasoning used in #341, #344, #346 and #348 — if you'd rather it were spelled out in AGENTS.md, say so and I'll add a sentence in a later batch.)

## triangle-circle-game

- `shadeEdge` — the line player, on an edge that exists and is not yet shaded.
- `placeCircle` — the circle player, on a triangle that exists and holds no circle.

`edgeClickable` / `triangleClickable` in the board client now call the validators. That also lets the invisible edge hit-target layer drop its separate `lineToMove` condition: on the circle player's turn the filtered list is empty, so no hit targets are rendered either way.

## hunyadi-and-the-janissaries

- `setGroupOfSoldiers` — the sultan, and every soldier in the assignment must actually stand on the staircase. This one is more than a formality: an out-of-range `rowIndex` used to throw a `TypeError` inside `apply`, and a validator that throws is no use to the engine as a tamper check.
- `killGroup` — Hunyadi, on one of the two group colours. Destroying a colour nobody was assigned to stays legal: the rules permit it, it simply achieves nothing, so "the colour is present on the staircase" is not part of legality.
- `finalizeSeparation` — the sultan's alone.
- `stepUp` stays a plain apply function: it is the engine's `endOfTurnMove`.

The soldier buttons and the "finish the split" button now derive `disabled` from the corresponding move's `isAllowed`.

## Tests

`isColor` and `isSoldierAssignmentAllowed` get direct tests (missing step, empty position, out-of-range row); the triangle game gets free/used/out-of-range cases plus a check that the validators agree with `freeEdges` and `freeTriangles`. Existing specs that call the converted moves directly now go through `.apply`.

Full suite: 95 files, 632 tests, all passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSxP4EAjGt4vDBxsQt32c)_