### PR TITLE
Move legality layer: bacteria, take-and-point

### DIFF
--- a/src/components/games/bacteria/bacteria.tsx
+++ b/src/components/games/bacteria/bacteria.tsx
@@ -9,6 +9,7 @@ import {
   isShiftLeft,
   hasBacterium,
   moves,
+  ATTACKER,
   type Board
 } from "./helpers";
 import {
@@ -43,7 +44,7 @@ const BoardClient = ({ board: { bacteria, goals }, ctx, moves }: BoardClientProp
 
   const boardWidth = bacteria[0].length;
 
-  const isPlayerAttacker = ctx.currentPlayer === 0;
+  const isPlayerAttacker = ctx.currentPlayer === ATTACKER;
 
   // Which of the four attacks the second click means is decided by where it
   // lands relative to the first.
@@ -184,7 +185,7 @@ const BoardClient = ({ board: { bacteria, goals }, ctx, moves }: BoardClientProp
 };
 
 const getPlayerStepDescription = ({ ctx }) => {
-  if (ctx.currentPlayer === 0) {
+  if (ctx.currentPlayer === ATTACKER) {
     return {
       hu: "Kattints egy mezőre, amin van baktérium és hajtsd végre " +
         "a három lehetséges támadás egyikét egy további szabályos kattintással.",

--- a/src/components/games/bacteria/bacteria.tsx
+++ b/src/components/games/bacteria/bacteria.tsx
@@ -7,7 +7,7 @@ import {
   isSpread,
   isShiftRight,
   isShiftLeft,
-  isAllowedAttackClick,
+  hasBacterium,
   moves,
   type Board
 } from "./helpers";
@@ -45,9 +45,24 @@ const BoardClient = ({ board: { bacteria, goals }, ctx, moves }: BoardClientProp
 
   const isPlayerAttacker = ctx.currentPlayer === 0;
 
+  // Which of the four attacks the second click means is decided by where it
+  // lands relative to the first.
+  const attackMoveName = (attack) => {
+    if (isJump(attack)) return 'jump';
+    if (isSpread(attack)) return 'spread';
+    if (isShiftRight(attack)) return 'shiftRight';
+    if (isShiftLeft(attack)) return 'shiftLeft';
+    return null;
+  };
+
+  // A second click is a real attack when the target exists on the board, its
+  // position spells out one of the four attacks, and that attack's own
+  // validator accepts the selected source cell.
   const isAllowedAttack = ({ row, col }) => {
     if (bacteria[row][col] === undefined) return false;
-    return isAllowedAttackClick({ attackRow, attackCol, row, col });
+    const name = attackMoveName({ attackRow, attackCol, row, col });
+    return name !== null
+      && moves[name].isAllowed!({ bacteria, goals }, { row: attackRow, col: attackCol });
   };
 
   const isGoal = ({ row, col }) => row === (bacteria.length - 1) && goals.includes(col);
@@ -73,19 +88,8 @@ const BoardClient = ({ board: { bacteria, goals }, ctx, moves }: BoardClientProp
       return;
     }
 
-    const attack = { attackRow, attackCol, row, col };
-    if (isJump(attack)) {
-      moves.jump({ bacteria, goals }, { row: attackRow, col: attackCol });
-    }
-    if (isSpread(attack)) {
-      moves.spread({ bacteria, goals }, { row: attackRow, col: attackCol });
-    }
-    if (isShiftRight(attack)) {
-      moves.shiftRight({ bacteria, goals }, { row: attackRow, col: attackCol });
-    }
-    if (isShiftLeft(attack)) {
-      moves.shiftLeft({ bacteria, goals }, { row: attackRow, col: attackCol });
-    }
+    const name = attackMoveName({ attackRow, attackCol, row, col });
+    if (name) moves[name]({ bacteria, goals }, { row: attackRow, col: attackCol });
 
     setAttackRow(null);
     setAttackCol(null);
@@ -96,7 +100,7 @@ const BoardClient = ({ board: { bacteria, goals }, ctx, moves }: BoardClientProp
   const isForbidden = ({ row, col }) => {
     if (attackRow !== null && row === attackRow && col === attackCol) return false;
     if (attackRow !== null && !isAllowedAttack({ row, col })) return true;
-    if (attackRow === null && bacteria[row][col] < 1) return true;
+    if (attackRow === null && !hasBacterium({ bacteria, goals }, { row, col })) return true;
     return false;
   };
 

--- a/src/components/games/bacteria/bot-strategy.ts
+++ b/src/components/games/bacteria/bot-strategy.ts
@@ -8,6 +8,7 @@ import {
   bacteriaCoords,
   totalBacteria,
   inBoard,
+  isAttackAllowed,
   spreadChildren,
   isGoalCell,
   topRowIdx
@@ -21,16 +22,16 @@ export const simulate = (board: Board, move: AttackMove): { board: Board; reache
   return { board: nextBoard, reachedGoal };
 };
 
-export const legalAttackMoves = (board: Board): AttackMove[] => {
-  const moves: AttackMove[] = [];
-  for (const [row, col] of bacteriaCoords(board)) {
-    if (inBoard(board, row, col + 1)) moves.push({ type: 'shiftRight', row, col });
-    if (inBoard(board, row, col - 1)) moves.push({ type: 'shiftLeft', row, col });
-    if (inBoard(board, row + 2, col)) moves.push({ type: 'jump', row, col });
-    if (spreadChildren(board, row, col).length >= 1) moves.push({ type: 'spread', row, col });
-  }
-  return moves;
-};
+const ATTACK_TYPES = ['shiftRight', 'shiftLeft', 'jump', 'spread'] as const;
+
+// The bot enumerates its options with the very predicate the engine validates
+// dispatches against, so the two can never disagree.
+export const legalAttackMoves = (board: Board): AttackMove[] =>
+  bacteriaCoords(board).flatMap(([row, col]) =>
+    ATTACK_TYPES
+      .map(type => ({ type, row, col }))
+      .filter(move => isAttackAllowed(board, move))
+  );
 
 // A move is winning-preserving when, after every possible defender removal,
 // the attacker is still winning (or has already reached a goal).

--- a/src/components/games/bacteria/bot-strategy.ts
+++ b/src/components/games/bacteria/bot-strategy.ts
@@ -11,7 +11,9 @@ import {
   isAttackAllowed,
   spreadChildren,
   isGoalCell,
-  topRowIdx
+  topRowIdx,
+  ATTACKER,
+  DEFENDER
 } from "./helpers";
 
 export type { AttackMove };
@@ -119,7 +121,7 @@ export const defenderMove = (board: Board): { row: number; col: number } => {
 };
 
 export const smartBotStrategy = ({ board, ctx, moves }: StrategyArgs<Board>) => {
-  if (ctx.chosenRoleIndex === 0) {
+  if (ctx.chosenRoleIndex === ATTACKER) {
     const { row, col } = defenderMove(board);
     moves.defend(board, { row, col });
   } else {
@@ -132,7 +134,7 @@ export const smartBotStrategy = ({ board, ctx, moves }: StrategyArgs<Board>) => 
 export const randomBotStrategy = ({ board, ctx, moves }: StrategyArgs<Board>) => {
   const coords = bacteriaCoords(board);
 
-  if (ctx.currentPlayer === 1) {
+  if (ctx.currentPlayer === DEFENDER) {
     const [row, col] = sample(coords)!;
     moves.defend(board, { row, col });
     return;

--- a/src/components/games/bacteria/helpers.spec.ts
+++ b/src/components/games/bacteria/helpers.spec.ts
@@ -1,4 +1,8 @@
-import { distanceFromDangerousAttackZone, isDangerous, moves, applyAttackMove, type MoveType } from "./helpers";
+import {
+  distanceFromDangerousAttackZone, isDangerous, moves, applyAttackMove,
+  hasBacterium, isAttackAllowed, type MoveType
+} from "./helpers";
+import { legalAttackMoves } from "./bot-strategy";
 import { reverse } from 'lodash';
 import { makeEvents } from '../../../test-utils';
 
@@ -59,7 +63,7 @@ describe('moves', () => {
     ]);
     const board = { bacteria, goals: [1] };
     const events = makeEvents();
-    const { nextBoard } = moves.defend(board, { events }, { row: 2, col: 0 });
+    const { nextBoard } = moves.defend.apply(board, { events }, { row: 2, col: 0 });
     expect(nextBoard.bacteria[2][0]).toEqual(1);
     expect(events.endGame).not.toHaveBeenCalled();
   });
@@ -72,7 +76,7 @@ describe('moves', () => {
     ]);
     const board = { bacteria, goals: [1] };
     const events = makeEvents();
-    moves.defend(board, { events }, { row: 2, col: 0 });
+    moves.defend.apply(board, { events }, { row: 2, col: 0 });
     expect(events.endGame).toHaveBeenCalled();
   });
 
@@ -94,7 +98,7 @@ describe('moves', () => {
     for (const type of types) {
       const { nextBoard, reachedGoal } = applyAttackMove(makeBoard(), { type, row: 2, col: 1 });
       const events = makeEvents();
-      const viaMoves = moves[type](makeBoard(), { events }, { row: 2, col: 1 });
+      const viaMoves = moves[type].apply(makeBoard(), { events }, { row: 2, col: 1 });
       expect(viaMoves.nextBoard.bacteria).toEqual(nextBoard.bacteria);
       if (reachedGoal) {
         expect(events.endGame).toHaveBeenCalled();
@@ -104,3 +108,57 @@ describe('moves', () => {
     }
   });
 })
+
+describe('legality', () => {
+  // Three rows: wide (3), narrow (2), wide (3). A single bacterium sits in the
+  // middle of the bottom row.
+  const board = {
+    bacteria: [
+      [0, 1, 0],
+       [0, 0],
+      [0, 0, 0]
+    ],
+    goals: [1]
+  };
+
+  it('requires a bacterium on the cell every move starts from', () => {
+    expect(hasBacterium(board, { row: 0, col: 1 })).toBe(true);
+    expect(hasBacterium(board, { row: 0, col: 0 })).toBe(false);
+    expect(hasBacterium(board, { row: 9, col: 0 })).toBe(false);
+    expect(hasBacterium(board, { row: 0, col: -1 })).toBe(false);
+  });
+
+  it('allows the attacks that stay on the board', () => {
+    expect(isAttackAllowed(board, { type: 'shiftLeft', row: 0, col: 1 })).toBe(true);
+    expect(isAttackAllowed(board, { type: 'shiftRight', row: 0, col: 1 })).toBe(true);
+    expect(isAttackAllowed(board, { type: 'jump', row: 0, col: 1 })).toBe(true);
+    expect(isAttackAllowed(board, { type: 'spread', row: 0, col: 1 })).toBe(true);
+  });
+
+  it('refuses a shift off the side of the row', () => {
+    const atEdge = { ...board, bacteria: [[1, 0, 0], [0, 0], [0, 0, 0]] };
+    expect(isAttackAllowed(atEdge, { type: 'shiftLeft', row: 0, col: 0 })).toBe(false);
+    expect(isAttackAllowed(atEdge, { type: 'shiftRight', row: 0, col: 0 })).toBe(true);
+  });
+
+  it('refuses a jump or a division that would leave the board', () => {
+    // Top row: nothing above it, so neither a jump nor a division has anywhere
+    // to go. Without this a division would silently delete the bacteria.
+    const onTop = { ...board, bacteria: [[0, 0, 0], [0, 0], [0, 1, 0]] };
+    expect(isAttackAllowed(onTop, { type: 'jump', row: 2, col: 1 })).toBe(false);
+    expect(isAttackAllowed(onTop, { type: 'spread', row: 2, col: 1 })).toBe(false);
+    expect(isAttackAllowed(onTop, { type: 'shiftLeft', row: 2, col: 1 })).toBe(true);
+  });
+
+  it('refuses any attack from a cell with no bacteria', () => {
+    for (const type of ['shiftLeft', 'shiftRight', 'jump', 'spread'] as MoveType[]) {
+      expect(isAttackAllowed(board, { type, row: 0, col: 0 })).toBe(false);
+    }
+  });
+
+  it('accepts every move the bot enumerates', () => {
+    const busy = { ...board, bacteria: [[1, 2, 1], [3, 0], [0, 1, 0]] };
+    expect(legalAttackMoves(busy).length).toBeGreaterThan(0);
+    expect(legalAttackMoves(busy).every(m => isAttackAllowed(busy, m))).toBe(true);
+  });
+});

--- a/src/components/games/bacteria/helpers.spec.ts
+++ b/src/components/games/bacteria/helpers.spec.ts
@@ -63,7 +63,7 @@ describe('moves', () => {
     ]);
     const board = { bacteria, goals: [1] };
     const events = makeEvents();
-    const { nextBoard } = moves.defend.apply(board, { events }, { row: 2, col: 0 });
+    const { nextBoard } = moves.defend.legacyApply(board, { events }, { row: 2, col: 0 });
     expect(nextBoard.bacteria[2][0]).toEqual(1);
     expect(events.endGame).not.toHaveBeenCalled();
   });
@@ -76,7 +76,7 @@ describe('moves', () => {
     ]);
     const board = { bacteria, goals: [1] };
     const events = makeEvents();
-    moves.defend.apply(board, { events }, { row: 2, col: 0 });
+    moves.defend.legacyApply(board, { events }, { row: 2, col: 0 });
     expect(events.endGame).toHaveBeenCalled();
   });
 
@@ -98,7 +98,7 @@ describe('moves', () => {
     for (const type of types) {
       const { nextBoard, reachedGoal } = applyAttackMove(makeBoard(), { type, row: 2, col: 1 });
       const events = makeEvents();
-      const viaMoves = moves[type].apply(makeBoard(), { events }, { row: 2, col: 1 });
+      const viaMoves = moves[type].legacyApply(makeBoard(), { events }, { row: 2, col: 1 });
       expect(viaMoves.nextBoard.bacteria).toEqual(nextBoard.bacteria);
       if (reachedGoal) {
         expect(events.endGame).toHaveBeenCalled();

--- a/src/components/games/bacteria/helpers.ts
+++ b/src/components/games/bacteria/helpers.ts
@@ -78,26 +78,51 @@ export const applyAttackMove = (board: Board, { type, row, col }: AttackMove) =>
   return { nextBoard, reached, reachedGoal };
 };
 
-const attackerMove = (type: MoveType) =>
-  (board: Board, { events }: { events: Events }, { row, col }) => {
+export const [ATTACKER, DEFENDER] = [0, 1];
+
+// Every move of either player starts from a cell that holds at least one
+// bacterium.
+export const hasBacterium = (board: Board, { row, col }): boolean =>
+  inBoard(board, row, col) && board.bacteria[row][col] >= 1;
+
+// An attack additionally needs somewhere to go: the sideways step, the two-row
+// jump and at least one of the division's two children must land on the board.
+// Without this a spread from the top row would simply delete the bacteria.
+export const isAttackAllowed = (board: Board, { type, row, col }: AttackMove): boolean => {
+  if (!hasBacterium(board, { row, col })) return false;
+  if (type === 'shiftRight') return inBoard(board, row, col + 1);
+  if (type === 'shiftLeft') return inBoard(board, row, col - 1);
+  if (type === 'jump') return inBoard(board, row + 2, col);
+  return spreadChildren(board, row, col).length >= 1;
+};
+
+const attackerMove = (type: MoveType) => ({
+  validate: (board: Board, { ctx }, { row, col }) =>
+    ctx.currentPlayer === ATTACKER && isAttackAllowed(board, { type, row, col }),
+  apply: (board: Board, { events }: { events: Events }, { row, col }) => {
     const { nextBoard, reachedGoal } = applyAttackMove(board, { type, row, col });
     events.endTurn();
     if (reachedGoal) events.endGame();
     return { nextBoard };
-  };
+  }
+});
 
 export const moves = {
-  defend: (board: Board, { events }: { events: Events }, { row, col }) => {
-    const nextBoard = cloneDeep(board);
+  defend: {
+    validate: (board: Board, { ctx }, cell) =>
+      ctx.currentPlayer === DEFENDER && hasBacterium(board, cell),
+    apply: (board: Board, { events }: { events: Events }, { row, col }) => {
+      const nextBoard = cloneDeep(board);
 
-    nextBoard.bacteria[row][col] -= 1;
-    events.endTurn();
+      nextBoard.bacteria[row][col] -= 1;
+      events.endTurn();
 
-    if (areAllBacteriaRemoved(nextBoard.bacteria)) {
-      events.endGame();
+      if (areAllBacteriaRemoved(nextBoard.bacteria)) {
+        events.endGame();
+      }
+
+      return { nextBoard };
     }
-
-    return { nextBoard };
   },
   shiftRight: attackerMove('shiftRight'),
   shiftLeft: attackerMove('shiftLeft'),
@@ -122,12 +147,6 @@ export const isSpread = ({ attackRow, attackCol, row, col }) => {
 
 export const isJump = ({ attackRow, attackCol, row, col }) => {
   return row === attackRow + 2 && col === attackCol;
-};
-
-export const isAllowedAttackClick = (attack) => {
-  return (
-    isShiftRight(attack) || isShiftLeft(attack) || isSpread(attack) || isJump(attack)
-  );
 };
 
 const areAllBacteriaRemoved = (bacteria) => {

--- a/src/components/games/bacteria/helpers.ts
+++ b/src/components/games/bacteria/helpers.ts
@@ -99,7 +99,7 @@ export const isAttackAllowed = (board: Board, { type, row, col }: AttackMove): b
 const attackerMove = (type: MoveType) => ({
   validate: (board: Board, { ctx }, { row, col }) =>
     ctx.currentPlayer === ATTACKER && isAttackAllowed(board, { type, row, col }),
-  apply: (board: Board, { events }: { events: Events }, { row, col }) => {
+  legacyApply: (board: Board, { events }: { events: Events }, { row, col }) => {
     const { nextBoard, reachedGoal } = applyAttackMove(board, { type, row, col });
     events.endTurn();
     if (reachedGoal) events.endGame();
@@ -111,7 +111,7 @@ export const moves = {
   defend: {
     validate: (board: Board, { ctx }, cell) =>
       ctx.currentPlayer === DEFENDER && hasBacterium(board, cell),
-    apply: (board: Board, { events }: { events: Events }, { row, col }) => {
+    legacyApply: (board: Board, { events }: { events: Events }, { row, col }) => {
       const nextBoard = cloneDeep(board);
 
       nextBoard.bacteria[row][col] -= 1;

--- a/src/components/games/take-and-point/board-client.tsx
+++ b/src/components/games/take-and-point/board-client.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { range } from 'lodash';
 import { useTranslation } from '../../../language';
 import { GameBoard, type BoardClientProps } from '../../strategy-game-factory';
-import { type Board, nonEmptyIndices } from './helpers';
+import { type Board, requiredPointCount } from './helpers';
 
 const Chips = ({ count, removeCount = 0 }: { count: number; removeCount?: number }) => (
   // rotate(180deg) makes the heap fill from the bottom up, leaving the
@@ -65,21 +65,19 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   }, [ctx.moveCount]);
 
   const canInteract = ctx.isClientMoveAllowed;
-  const requiredPointCount = nonEmptyIndices(piles).length === 1 ? 1 : 2;
+  const pointCount = requiredPointCount(piles);
+  const pointingReady = moves.pointPiles.isAllowed!(board, selectedForPoint);
 
   const togglePoint = (i: number) => {
     if (!canInteract || stage !== 'point' || piles[i] === 0) return;
     setSelectedForPoint(prev => {
       if (prev.includes(i)) return prev.filter(x => x !== i);
-      if (prev.length >= requiredPointCount) return prev;
+      if (prev.length >= pointCount) return prev;
       return [...prev, i];
     });
   };
 
-  const submitPoint = () => {
-    if (!canInteract || selectedForPoint.length !== requiredPointCount) return;
-    moves.pointPiles(board, selectedForPoint);
-  };
+  const submitPoint = () => moves.pointPiles(board, selectedForPoint);
 
   const adjustRemoval = (i: number, delta: number) => {
     if (!canInteract || stage !== 'remove') return;
@@ -91,8 +89,11 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     });
   };
 
+  const removalReady = removal !== null
+    && moves.takeStones.isAllowed!(board, removal.index, removal.amount);
+
   const submitRemoval = () => {
-    if (!canInteract || !removal) return;
+    if (!removal) return;
     moves.takeStones(board, removal.index, removal.amount);
   };
 
@@ -144,7 +145,9 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
                   >−</Stepper>
                   <Stepper
                     label={t({ hu: `+1 a(z) ${i + 1}. kupacból`, en: `+1 from pile ${i + 1}` })}
-                    disabled={!canInteract || removeCount >= count
+                    // One more stone must itself be a legal take; the second
+                    // clause is local UI state (only one pile per turn).
+                    disabled={!moves.takeStones.isAllowed!(board, i, removeCount + 1)
                       || (removal !== null && removal.index !== i)}
                     onClick={() => adjustRemoval(i, 1)}
                   >+</Stepper>
@@ -157,18 +160,18 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 
       {canInteract && stage === 'point' && (
         <button
-          disabled={selectedForPoint.length !== requiredPointCount}
+          disabled={!pointingReady}
           onClick={submitPoint}
           className="primary-button w-auto mt-4 mx-auto"
         >
-          {requiredPointCount === 1
+          {pointCount === 1
             ? t({ hu: 'Rámutatok az utolsó kupacra', en: 'Point at the last pile' })
             : t({ hu: 'Rámutatok e két kupacra', en: 'Point at these two piles' })}
         </button>
       )}
       {canInteract && stage === 'remove' && (
         <button
-          disabled={!removal}
+          disabled={!removalReady}
           onClick={submitRemoval}
           className="primary-button w-auto mt-4 mx-auto"
         >

--- a/src/components/games/take-and-point/board-client.tsx
+++ b/src/components/games/take-and-point/board-client.tsx
@@ -77,7 +77,6 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     });
   };
 
-  const submitPoint = () => moves.pointPiles(board, selectedForPoint);
 
   const adjustRemoval = (i: number, delta: number) => {
     if (!canInteract || stage !== 'remove') return;
@@ -161,7 +160,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
       {canInteract && stage === 'point' && (
         <button
           disabled={!pointingReady}
-          onClick={submitPoint}
+          onClick={() => moves.pointPiles(board, selectedForPoint)}
           className="primary-button w-auto mt-4 mx-auto"
         >
           {pointCount === 1

--- a/src/components/games/take-and-point/helpers.spec.ts
+++ b/src/components/games/take-and-point/helpers.spec.ts
@@ -6,8 +6,12 @@ import {
   isTerminal,
   minPileSize,
   nonEmptyIndices,
-  removerWins
+  removerWins,
+  requiredPointCount,
+  isPointingAllowed,
+  isRemovalAllowed
 } from './helpers';
+import { choosePointing, chooseRemoval } from './bot-strategy';
 
 // Brute-force ground truth: does the player who is about to be pointed at (and
 // then takes) win the rest of the game with optimal play from both sides?
@@ -98,5 +102,49 @@ describe('helpers', () => {
     // Roughly 50/50 between the two roles.
     expect(odd / samples).toBeGreaterThan(0.3);
     expect(odd / samples).toBeLessThan(0.7);
+  });
+});
+
+describe('legality', () => {
+  it('requires two piles while more than one is non-empty, one when a single pile is left', () => {
+    expect(requiredPointCount([3, 2, 1])).toBe(2);
+    expect(requiredPointCount([0, 4, 0])).toBe(1);
+  });
+
+  it('accepts pointing at the required number of distinct non-empty piles', () => {
+    const board = { piles: [3, 2, 0], pointed: null };
+    expect(isPointingAllowed(board, [0, 1])).toBe(true);
+    expect(isPointingAllowed(board, [0])).toBe(false); // too few
+    expect(isPointingAllowed(board, [0, 1, 2])).toBe(false); // too many
+    expect(isPointingAllowed(board, [0, 0])).toBe(false); // same pile twice
+    expect(isPointingAllowed(board, [0, 2])).toBe(false); // pile 2 is empty
+    expect(isPointingAllowed(board, [0, 9])).toBe(false); // no such pile
+  });
+
+  it('refuses pointing once someone has already pointed this turn', () => {
+    expect(isPointingAllowed({ piles: [3, 2, 0], pointed: [0, 1] }, [0, 1])).toBe(false);
+  });
+
+  it('accepts taking between one stone and the whole of a pointed pile', () => {
+    const board = { piles: [3, 2, 4], pointed: [0, 1] };
+    expect(isRemovalAllowed(board, 0, 1)).toBe(true);
+    expect(isRemovalAllowed(board, 0, 3)).toBe(true);
+    expect(isRemovalAllowed(board, 0, 4)).toBe(false); // more than the pile holds
+    expect(isRemovalAllowed(board, 0, 0)).toBe(false);
+    expect(isRemovalAllowed(board, 0, 1.5)).toBe(false);
+    expect(isRemovalAllowed(board, 2, 1)).toBe(false); // pile 2 was not pointed at
+  });
+
+  it('refuses taking before anyone has pointed', () => {
+    expect(isRemovalAllowed({ piles: [3, 2, 4], pointed: null }, 0, 1)).toBe(false);
+  });
+
+  it('accepts everything the bot chooses', () => {
+    const board = { piles: [2, 3, 3, 1], pointed: null };
+    const pointed = choosePointing(board);
+    expect(isPointingAllowed(board, pointed)).toBe(true);
+    const afterPointing = { piles: board.piles, pointed };
+    const { index, amount } = chooseRemoval(afterPointing);
+    expect(isRemovalAllowed(afterPointing, index, amount)).toBe(true);
   });
 });

--- a/src/components/games/take-and-point/helpers.ts
+++ b/src/components/games/take-and-point/helpers.ts
@@ -1,4 +1,4 @@
-import { random, range, shuffle } from 'lodash';
+import { random, range, shuffle, uniq } from 'lodash';
 
 // piles: sizes of the piles; a value of 0 means that pile is empty (kept in the
 // array so pile indices stay stable across a game). pointed: indices of the
@@ -25,6 +25,28 @@ export const removerWins = (piles: number[]): boolean => countMinPiles(piles) % 
 
 export const applyRemoval = (piles: number[], index: number, amount: number): number[] =>
   piles.map((p, i) => (i === index ? p - amount : p));
+
+// How many piles the pointing player must indicate: two, or just the one when
+// a single non-empty pile is left.
+export const requiredPointCount = (piles: number[]): number =>
+  nonEmptyIndices(piles).length === 1 ? 1 : 2;
+
+// The two halves of a turn are told apart by the board alone: `pointed` is null
+// until someone has pointed, and `takeStones` clears it again. Pointing means
+// naming exactly the required number of distinct non-empty piles.
+export const isPointingAllowed = (board: Board, indices: number[]): boolean =>
+  board.pointed === null
+    && Array.isArray(indices)
+    && indices.length === requiredPointCount(board.piles)
+    && uniq(indices).length === indices.length
+    && indices.every(i => board.piles[i] > 0);
+
+// Taking means removing between one stone and the whole pile from one of the
+// piles the other player pointed at.
+export const isRemovalAllowed = (board: Board, index: number, amount: number): boolean =>
+  board.pointed !== null
+    && board.pointed.includes(index)
+    && Number.isInteger(amount) && amount >= 1 && amount <= board.piles[index];
 
 // Random start position. Every extra pile is strictly larger than the smallest
 // pile size, so the number of minimal piles (which decides who wins) is `mCount`

--- a/src/components/games/take-and-point/take-and-point.tsx
+++ b/src/components/games/take-and-point/take-and-point.tsx
@@ -12,7 +12,7 @@ const moves = {
   takeStones: {
     validate: (board: Board, _, index: number, amount: number) =>
       isRemovalAllowed(board, index, amount),
-    apply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, index: number, amount: number) => {
+    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, index: number, amount: number) => {
       const nextBoard: Board = { piles: applyRemoval(board.piles, index, amount), pointed: null };
       if (isTerminal(nextBoard)) {
         // Whoever takes the last stone wins.
@@ -25,7 +25,7 @@ const moves = {
   // Point at the piles the other player will choose from, then hand over the turn.
   pointPiles: {
     validate: (board: Board, _, indices: number[]) => isPointingAllowed(board, indices),
-    apply: (board: Board, { events }: { ctx: Ctx; events: Events }, indices: number[]) => {
+    legacyApply: (board: Board, { events }: { ctx: Ctx; events: Events }, indices: number[]) => {
       const nextBoard: Board = { piles: board.piles, pointed: indices };
       events.endTurn();
       return { nextBoard };

--- a/src/components/games/take-and-point/take-and-point.tsx
+++ b/src/components/games/take-and-point/take-and-point.tsx
@@ -1,25 +1,35 @@
 import { strategyGameFactory, type Ctx, type Events } from '../../strategy-game-factory';
 import { BoardClient } from './board-client';
-import { type Board, applyRemoval, generateStartBoard, isTerminal, nonEmptyIndices } from './helpers';
+import {
+  type Board, applyRemoval, generateStartBoard, isTerminal, nonEmptyIndices,
+  isPointingAllowed, isRemovalAllowed
+} from './helpers';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 
 const moves = {
   // Take `amount` stones from a pointed pile. The turn does NOT end here: the
   // same player then points at piles for the other player (see `pointPiles`).
-  takeStones: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, index: number, amount: number) => {
-    const nextBoard: Board = { piles: applyRemoval(board.piles, index, amount), pointed: null };
-    if (isTerminal(nextBoard)) {
-      // Whoever takes the last stone wins.
-      events.endGame(ctx.currentPlayer!);
+  takeStones: {
+    validate: (board: Board, _, index: number, amount: number) =>
+      isRemovalAllowed(board, index, amount),
+    apply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, index: number, amount: number) => {
+      const nextBoard: Board = { piles: applyRemoval(board.piles, index, amount), pointed: null };
+      if (isTerminal(nextBoard)) {
+        // Whoever takes the last stone wins.
+        events.endGame(ctx.currentPlayer!);
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   },
 
   // Point at the piles the other player will choose from, then hand over the turn.
-  pointPiles: (board: Board, { events }: { ctx: Ctx; events: Events }, indices: number[]) => {
-    const nextBoard: Board = { piles: board.piles, pointed: indices };
-    events.endTurn();
-    return { nextBoard };
+  pointPiles: {
+    validate: (board: Board, _, indices: number[]) => isPointingAllowed(board, indices),
+    apply: (board: Board, { events }: { ctx: Ctx; events: Events }, indices: number[]) => {
+      const nextBoard: Board = { piles: board.piles, pointed: indices };
+      events.endTurn();
+      return { nextBoard };
+    }
   }
 };
 


### PR DESCRIPTION
Continues the per-move `validate` migration started in #333. Both games in this batch spread a turn over two clicks, and in both the board itself records how far the turn has got — so the validators stay pure board functions and no `turnState` is involved.

## bacteria

- `defend(cell)` — the defender, on a cell that holds at least one bacterium.
- `shiftRight` / `shiftLeft` / `jump` / `spread` — the attacker, from a cell with a bacterium, and the move must have somewhere to go.

That last condition is worth more than bounds checking: a division from the top row has no children, and `applyAttackMove` would zero the source cell and drop those bacteria on the floor. The UI never offered it (the second click has no cell to land on up there), but nothing stopped a stray dispatch.

`legalAttackMoves` in the bot used to repeat the same four conditions inline; it now enumerates the four attack types and filters with `isAttackAllowed`, so the bot's idea of a legal move and the engine's are the same function. Output is unchanged, including order.

The board client's `isAllowedAttack` — which drives both the highlighting and the second click — now names the attack from the click geometry and then asks that move's validator. `isAllowedAttackClick` was left with no callers and is removed.

## take-and-point

The turn is "the other player points at piles, then you take from one of them", and `board.pointed` (null → someone has to point; non-null → someone has to take) already distinguishes the halves.

- `pointPiles(indices)` — while `pointed` is null, naming exactly `requiredPointCount(piles)` distinct non-empty piles: two normally, one when a single non-empty pile is left.
- `takeStones(index, amount)` — once someone has pointed, from a pile they pointed at, between one stone and the whole pile.

The two submit buttons and the `+` stepper now derive `disabled` from these. The stepper keeps its second clause ("only one pile per turn") — that is local UI state, not game legality.

## Tests

Legality suites for both games, including the top-row division case for bacteria, and — for each game — a check that everything the bot picks passes the validator.

Full suite: 95 files, 638 tests, all passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSxP4EAjGt4vDBxsQt32c)_