### PR TITLE
Move legality layer: policeman-thief-ab, policeman-thief-c

### DIFF
--- a/src/components/games/policeman-thief/policeman-thief-ab/board-client.tsx
+++ b/src/components/games/policeman-thief/policeman-thief-ab/board-client.tsx
@@ -1,5 +1,6 @@
 import { range } from "lodash";
 import type { Board } from "./policeman-thief-ab";
+import { POLICE, THIEF } from "./helpers";
 import { GameBoard, type BoardClientProps } from "../../../strategy-game-factory";
 
 const cubeCoords = [
@@ -17,7 +18,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   // Exactly one piece is due to move at any moment; the same move then decides
   // both what a click does and which intersections are offered.
   const activeMove = () => {
-    if (ctx.currentPlayer === 1) return moves.moveThief;
+    if (ctx.currentPlayer === THIEF) return moves.moveThief;
     return board.firstPolicemanMoved ? moves.moveSecondPoliceman : moves.moveFirstPoliceman;
   };
 
@@ -27,12 +28,12 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 
   const getColor = (vertex: number) => {
     if (isClickable(vertex)) {
-      if (ctx.currentPlayer === 1) {
+      if (ctx.currentPlayer === THIEF) {
         if (board.policemen[0] === vertex) return "url(#thief-and-first-policeman)";
         if (board.policemen[1] === vertex) return "url(#thief-and-second-policeman)";
         return "var(--color-red-500)";
       }
-      if (ctx.currentPlayer === 0) {
+      if (ctx.currentPlayer === POLICE) {
         if (board.firstPolicemanMoved) {
           if (board.thief === vertex) return "url(#thief-and-second-policeman)";
           if (board.policemen[0] === vertex) return "url(#2policemen)";

--- a/src/components/games/policeman-thief/policeman-thief-ab/board-client.tsx
+++ b/src/components/games/policeman-thief/policeman-thief-ab/board-client.tsx
@@ -1,5 +1,4 @@
 import { range } from "lodash";
-import { neighbours } from "./helpers";
 import type { Board } from "./policeman-thief-ab";
 import { GameBoard, type BoardClientProps } from "../../../strategy-game-factory";
 
@@ -15,29 +14,16 @@ const cubeCoords = [
 ];
 
 export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
-  const handleCircleClick = (vertex: number) => {
-    if (!isClickable(vertex)) return;
-    if (ctx.currentPlayer === 1) {
-      moves.moveThief(board, vertex);
-      return;
-    }
-    if (board.firstPolicemanMoved) {
-      moves.moveSecondPoliceman(board, vertex);
-      return;
-    }
-    moves.moveFirstPoliceman(board, vertex);
+  // Exactly one piece is due to move at any moment; the same move then decides
+  // both what a click does and which intersections are offered.
+  const activeMove = () => {
+    if (ctx.currentPlayer === 1) return moves.moveThief;
+    return board.firstPolicemanMoved ? moves.moveSecondPoliceman : moves.moveFirstPoliceman;
   };
 
-  const isClickable = (vertex: number) => {
-    if (!ctx.isClientMoveAllowed) return false;
-    if (ctx.currentPlayer === 1) {
-      return neighbours[board.thief].includes(vertex);
-    }
-    if (board.firstPolicemanMoved) {
-      return neighbours[board.policemen[1]].includes(vertex)
-    }
-    return neighbours[board.policemen[0]].includes(vertex)
-  }
+  const handleCircleClick = (vertex: number) => activeMove()(board, vertex);
+
+  const isClickable = (vertex: number) => activeMove().isAllowed!(board, vertex);
 
   const getColor = (vertex: number) => {
     if (isClickable(vertex)) {

--- a/src/components/games/policeman-thief/policeman-thief-ab/bot-strategy.ts
+++ b/src/components/games/policeman-thief/policeman-thief-ab/bot-strategy.ts
@@ -1,10 +1,10 @@
 import { random } from "lodash";
-import { neighbours } from "./helpers";
+import { neighbours, POLICE } from "./helpers";
 import type { Board } from "./policeman-thief-ab";
 import type { StrategyArgs, GameMoves } from "../../../strategy-game-factory";
 
 export const smartBotStrategy = ({ board, ctx, moves }: StrategyArgs<Board>) => {
-  if (ctx.chosenRoleIndex === 0) {
+  if (ctx.chosenRoleIndex === POLICE) {
     moveThiefOptimally({ board, moves });
   } else {
     movePolicemenOptimally({ board, moves });

--- a/src/components/games/policeman-thief/policeman-thief-ab/helpers.ts
+++ b/src/components/games/policeman-thief/policeman-thief-ab/helpers.ts
@@ -8,3 +8,14 @@ export const neighbours = {
   6: [2, 4, 7],
   7: [3, 5, 6]
 };
+
+export const VERTEX_COUNT = 8;
+
+export const isVertex = (vertex: number): boolean =>
+  Number.isInteger(vertex) && vertex >= 0 && vertex < VERTEX_COUNT;
+
+// Everyone moves along a single road, and everyone must move every round, so
+// every move in this game boils down to "is the target an intersection
+// adjacent to the one the piece stands on".
+export const isNeighbour = (from: number, to: number): boolean =>
+  isVertex(from) && isVertex(to) && neighbours[from].includes(to);

--- a/src/components/games/policeman-thief/policeman-thief-ab/helpers.ts
+++ b/src/components/games/policeman-thief/policeman-thief-ab/helpers.ts
@@ -19,3 +19,7 @@ export const isVertex = (vertex: number): boolean =>
 // adjacent to the one the piece stands on".
 export const isNeighbour = (from: number, to: number): boolean =>
   isVertex(from) && isVertex(to) && neighbours[from].includes(to);
+
+// Player 0 chases, player 1 runs. Both indices appear in move legality, in the
+// winner handed to endGame and in the board client, so they get names.
+export const [POLICE, THIEF] = [0, 1];

--- a/src/components/games/policeman-thief/policeman-thief-ab/legality.spec.ts
+++ b/src/components/games/policeman-thief/policeman-thief-ab/legality.spec.ts
@@ -1,0 +1,67 @@
+import { isNeighbour, isVertex, neighbours, VERTEX_COUNT } from './helpers';
+import { moves, type Board } from './policeman-thief-ab';
+import { makeCtx } from '../../../../test-utils';
+
+const board = (overrides: Partial<Board> = {}): Board => ({
+  turnCount: 0,
+  policemen: [0, 3],
+  thief: 6,
+  firstPolicemanMoved: false,
+  ...overrides
+});
+
+const asPolice = { ctx: makeCtx({ currentPlayer: 0 }) };
+const asThief = { ctx: makeCtx({ currentPlayer: 1 }) };
+
+describe('graph predicates', () => {
+  it('accepts only the eight intersections', () => {
+    expect(isVertex(0)).toBe(true);
+    expect(isVertex(VERTEX_COUNT - 1)).toBe(true);
+    expect(isVertex(VERTEX_COUNT)).toBe(false);
+    expect(isVertex(-1)).toBe(false);
+    expect(isVertex(1.5)).toBe(false);
+  });
+
+  it('accepts exactly the pairs joined by a road', () => {
+    for (let v = 0; v < VERTEX_COUNT; v++) {
+      for (let u = 0; u < VERTEX_COUNT; u++) {
+        expect(isNeighbour(v, u)).toBe(neighbours[v].includes(u));
+      }
+    }
+  });
+
+  it('never treats an intersection as its own neighbour — staying put is not a move', () => {
+    for (let v = 0; v < VERTEX_COUNT; v++) expect(isNeighbour(v, v)).toBe(false);
+  });
+});
+
+describe('move legality', () => {
+  it('lets the thief step to an adjacent intersection only', () => {
+    expect(moves.moveThief.validate(board(), asThief, 2)).toBe(true); // 6 ~ 2
+    expect(moves.moveThief.validate(board(), asThief, 1)).toBe(false);
+    expect(moves.moveThief.validate(board(), asThief, 6)).toBe(false); // must move
+  });
+
+  it('does not let the police move the thief, nor the thief the police', () => {
+    expect(moves.moveThief.validate(board(), asPolice, 2)).toBe(false);
+    expect(moves.moveFirstPoliceman.validate(board(), asThief, 1)).toBe(false);
+  });
+
+  it('offers the blue policeman first and the green one only afterwards', () => {
+    const beforeSplit = board();
+    expect(moves.moveFirstPoliceman.validate(beforeSplit, asPolice, 1)).toBe(true); // 0 ~ 1
+    expect(moves.moveSecondPoliceman.validate(beforeSplit, asPolice, 1)).toBe(false);
+
+    const afterFirst = board({ firstPolicemanMoved: true });
+    expect(moves.moveFirstPoliceman.validate(afterFirst, asPolice, 1)).toBe(false);
+    expect(moves.moveSecondPoliceman.validate(afterFirst, asPolice, 1)).toBe(true); // 3 ~ 1
+  });
+
+  it('keeps each policeman to its own neighbours', () => {
+    // Vertex 4 is adjacent to the blue policeman on 0, but not to the green on 3.
+    expect(moves.moveFirstPoliceman.validate(board(), asPolice, 4)).toBe(true);
+    expect(moves.moveSecondPoliceman.validate(
+      board({ firstPolicemanMoved: true }), asPolice, 4
+    )).toBe(false);
+  });
+});

--- a/src/components/games/policeman-thief/policeman-thief-ab/legality.spec.ts
+++ b/src/components/games/policeman-thief/policeman-thief-ab/legality.spec.ts
@@ -1,4 +1,4 @@
-import { isNeighbour, isVertex, neighbours, VERTEX_COUNT } from './helpers';
+import { isNeighbour, isVertex, neighbours, POLICE, THIEF, VERTEX_COUNT } from './helpers';
 import { moves, type Board } from './policeman-thief-ab';
 import { makeCtx } from '../../../../test-utils';
 
@@ -10,8 +10,8 @@ const board = (overrides: Partial<Board> = {}): Board => ({
   ...overrides
 });
 
-const asPolice = { ctx: makeCtx({ currentPlayer: 0 }) };
-const asThief = { ctx: makeCtx({ currentPlayer: 1 }) };
+const asPolice = { ctx: makeCtx({ currentPlayer: POLICE }) };
+const asThief = { ctx: makeCtx({ currentPlayer: THIEF }) };
 
 describe('graph predicates', () => {
   it('accepts only the eight intersections', () => {

--- a/src/components/games/policeman-thief/policeman-thief-ab/policeman-thief-ab.tsx
+++ b/src/components/games/policeman-thief/policeman-thief-ab/policeman-thief-ab.tsx
@@ -1,6 +1,6 @@
 import { range, random, sample, difference, cloneDeep } from "lodash";
 import { strategyGameFactory, type Ctx, type Events } from "../../../strategy-game-factory";
-import { neighbours } from "./helpers";
+import { neighbours, isNeighbour } from "./helpers";
 import { smartBotStrategy } from "./bot-strategy";
 import { BoardClient } from "./board-client";
 
@@ -43,31 +43,51 @@ const generateStartBoardB = (): Board => {
   };
 };
 
-const moves = {
-  moveThief: (board: Board, { events }: { events: Events }, vertex: number) => {
-    const overrides: Partial<Board> = { thief: vertex, turnCount: board.turnCount + 1 };
-    const nextBoard = { ...cloneDeep(board), ...overrides };
-    events.endTurn();
-    if (isGameEnd(nextBoard)) {
-      events.endGame(hasFirstPlayerWon(nextBoard) ? 0 : 1);
+export const [POLICE, THIEF] = [0, 1];
+
+// A police round is two half-moves — blue then green — and `firstPolicemanMoved`
+// records which half is due, so no turn state is needed. The thief's move
+// belongs to the other player entirely, hence the currentPlayer checks: they
+// say *which* piece may move, not merely whose turn it is.
+export const moves = {
+  moveThief: {
+    validate: (board: Board, { ctx }: { ctx: Ctx }, vertex: number) =>
+      ctx.currentPlayer === THIEF && isNeighbour(board.thief, vertex),
+    apply: (board: Board, { events }: { events: Events }, vertex: number) => {
+      const overrides: Partial<Board> = { thief: vertex, turnCount: board.turnCount + 1 };
+      const nextBoard = { ...cloneDeep(board), ...overrides };
+      events.endTurn();
+      if (isGameEnd(nextBoard)) {
+        events.endGame(hasFirstPlayerWon(nextBoard) ? 0 : 1);
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   },
-  moveFirstPoliceman: (board: Board, _, vertex: number) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard.policemen[0] = vertex;
-    nextBoard.firstPolicemanMoved = true;
-    return { nextBoard };
-  },
-  moveSecondPoliceman: (board: Board, { events }: { events: Events }, vertex: number) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard.policemen[1] = vertex;
-    nextBoard.firstPolicemanMoved = false;
-    events.endTurn();
-    if (isGameEnd(nextBoard)) {
-      events.endGame(hasFirstPlayerWon(nextBoard) ? 0 : 1);
+  moveFirstPoliceman: {
+    validate: (board: Board, { ctx }: { ctx: Ctx }, vertex: number) =>
+      ctx.currentPlayer === POLICE && !board.firstPolicemanMoved
+        && isNeighbour(board.policemen[0], vertex),
+    apply: (board: Board, _, vertex: number) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard.policemen[0] = vertex;
+      nextBoard.firstPolicemanMoved = true;
+      return { nextBoard };
     }
-    return { nextBoard };
+  },
+  moveSecondPoliceman: {
+    validate: (board: Board, { ctx }: { ctx: Ctx }, vertex: number) =>
+      ctx.currentPlayer === POLICE && board.firstPolicemanMoved
+        && isNeighbour(board.policemen[1], vertex),
+    apply: (board: Board, { events }: { events: Events }, vertex: number) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard.policemen[1] = vertex;
+      nextBoard.firstPolicemanMoved = false;
+      events.endTurn();
+      if (isGameEnd(nextBoard)) {
+        events.endGame(hasFirstPlayerWon(nextBoard) ? 0 : 1);
+      }
+      return { nextBoard };
+    }
   }
 };
 

--- a/src/components/games/policeman-thief/policeman-thief-ab/policeman-thief-ab.tsx
+++ b/src/components/games/policeman-thief/policeman-thief-ab/policeman-thief-ab.tsx
@@ -1,6 +1,6 @@
 import { range, random, sample, difference, cloneDeep } from "lodash";
 import { strategyGameFactory, type Ctx, type Events } from "../../../strategy-game-factory";
-import { neighbours, isNeighbour } from "./helpers";
+import { neighbours, isNeighbour, POLICE, THIEF } from "./helpers";
 import { smartBotStrategy } from "./bot-strategy";
 import { BoardClient } from "./board-client";
 
@@ -43,8 +43,6 @@ const generateStartBoardB = (): Board => {
   };
 };
 
-export const [POLICE, THIEF] = [0, 1];
-
 // A police round is two half-moves — blue then green — and `firstPolicemanMoved`
 // records which half is due, so no turn state is needed. The thief's move
 // belongs to the other player entirely, hence the currentPlayer checks: they
@@ -58,7 +56,7 @@ export const moves = {
       const nextBoard = { ...cloneDeep(board), ...overrides };
       events.endTurn();
       if (isGameEnd(nextBoard)) {
-        events.endGame(hasFirstPlayerWon(nextBoard) ? 0 : 1);
+        events.endGame(hasFirstPlayerWon(nextBoard) ? POLICE : THIEF);
       }
       return { nextBoard };
     }
@@ -84,7 +82,7 @@ export const moves = {
       nextBoard.firstPolicemanMoved = false;
       events.endTurn();
       if (isGameEnd(nextBoard)) {
-        events.endGame(hasFirstPlayerWon(nextBoard) ? 0 : 1);
+        events.endGame(hasFirstPlayerWon(nextBoard) ? POLICE : THIEF);
       }
       return { nextBoard };
     }
@@ -149,7 +147,7 @@ const ruleB = {
 }
 
 const getPlayerStepDescription = ({ board, ctx }: { board: Board; ctx: Ctx }) => {
-  if (ctx.currentPlayer === 0) {
+  if (ctx.currentPlayer === POLICE) {
     return {
       hu: `Kattints arra az útkereszteződésre, ahová a ` +
         `${board.firstPolicemanMoved ? "zöld" : "kék"} rendőrrel lépni szeretnél.`,

--- a/src/components/games/policeman-thief/policeman-thief-c/board-client.tsx
+++ b/src/components/games/policeman-thief/policeman-thief-c/board-client.tsx
@@ -1,5 +1,5 @@
 import { range } from "lodash";
-import { coords, edges, VERTEX_COUNT } from "./helpers";
+import { coords, edges, POLICE, VERTEX_COUNT } from "./helpers";
 import type { Board } from "./policeman-thief-c";
 import { GameBoard, type BoardClientProps } from "../../../strategy-game-factory";
 import { useTranslation } from "../../../../language";
@@ -20,7 +20,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const activeMove = () => {
     if (phase === 'placingCops') return moves.placeCop;
     if (phase === 'placingThief') return moves.placeThief;
-    return ctx.currentPlayer === 0 ? moves.moveCop : moves.moveThief;
+    return ctx.currentPlayer === POLICE ? moves.moveCop : moves.moveThief;
   };
 
   const isClickable = (vertex: number) => activeMove().isAllowed!(board, vertex);
@@ -31,7 +31,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   // as a small cluster rather than overlapping discs.
   const piecesByVertex: Piece[][] = range(VERTEX_COUNT).map(() => []);
   board.policemen.forEach((vertex, i) => {
-    const isActive = phase === 'chasing' && ctx.currentPlayer === 0
+    const isActive = phase === 'chasing' && ctx.currentPlayer === POLICE
       && ctx.isClientMoveAllowed && i === board.copCursor;
     piecesByVertex[vertex].push({ color: COP_COLORS[i], isThief: false, isActive });
   });

--- a/src/components/games/policeman-thief/policeman-thief-c/board-client.tsx
+++ b/src/components/games/policeman-thief/policeman-thief-c/board-client.tsx
@@ -1,5 +1,5 @@
 import { range } from "lodash";
-import { neighbours, coords, edges, VERTEX_COUNT } from "./helpers";
+import { coords, edges, VERTEX_COUNT } from "./helpers";
 import type { Board } from "./policeman-thief-c";
 import { GameBoard, type BoardClientProps } from "../../../strategy-game-factory";
 import { useTranslation } from "../../../../language";
@@ -15,21 +15,17 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
   const { phase } = board;
 
-  const isClickable = (vertex: number) => {
-    if (!ctx.isClientMoveAllowed) return false;
-    if (phase === 'placingCops') return true; // police may occupy any vertex (even a shared one)
-    if (phase === 'placingThief') return !board.policemen.includes(vertex);
-    if (ctx.currentPlayer === 0) return neighbours[board.policemen[board.copCursor]].includes(vertex);
-    return neighbours[board.thief!].includes(vertex);
+  // Exactly one move is on offer at any moment; it decides both what a click
+  // does and which vertices are highlighted.
+  const activeMove = () => {
+    if (phase === 'placingCops') return moves.placeCop;
+    if (phase === 'placingThief') return moves.placeThief;
+    return ctx.currentPlayer === 0 ? moves.moveCop : moves.moveThief;
   };
 
-  const handleClick = (vertex: number) => {
-    if (!isClickable(vertex)) return;
-    if (phase === 'placingCops') moves.placeCop(board, vertex);
-    else if (phase === 'placingThief') moves.placeThief(board, vertex);
-    else if (ctx.currentPlayer === 0) moves.moveCop(board, vertex);
-    else moves.moveThief(board, vertex);
-  };
+  const isClickable = (vertex: number) => activeMove().isAllowed!(board, vertex);
+
+  const handleClick = (vertex: number) => activeMove()(board, vertex);
 
   // Collect the pieces standing on each vertex so shared vertices can be shown
   // as a small cluster rather than overlapping discs.

--- a/src/components/games/policeman-thief/policeman-thief-c/bot-strategy.ts
+++ b/src/components/games/policeman-thief/policeman-thief-c/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { sample, random, range } from "lodash";
-import { neighbours, VERTEX_COUNT, dist, minDistToSet } from "./helpers";
+import { neighbours, VERTEX_COUNT, dist, minDistToSet, THIEF } from "./helpers";
 import type { Board } from "./policeman-thief-c";
 import type { StrategyArgs, GameMoves } from "../../../strategy-game-factory";
 
@@ -170,7 +170,7 @@ const moveThiefOptimally = ({ board, moves }: { board: Board; moves: GameMoves<B
 };
 
 export const smartBotStrategy = ({ board, ctx, moves }: StrategyArgs<Board>) => {
-  const botIsCops = ctx.chosenRoleIndex === 1;
+  const botIsCops = ctx.chosenRoleIndex === THIEF;
   if (botIsCops) {
     if (board.phase === 'placingCops') placeCopsOptimally({ board, moves });
     else moveCopsOptimally({ board, moves });
@@ -221,7 +221,7 @@ const moveThiefRandom = ({ board, moves }: { board: Board; moves: GameMoves<Boar
 };
 
 export const randomBotStrategy = ({ board, ctx, moves }: StrategyArgs<Board>) => {
-  const botIsCops = ctx.chosenRoleIndex === 1;
+  const botIsCops = ctx.chosenRoleIndex === THIEF;
   if (botIsCops) {
     if (board.phase === 'placingCops') placeCopsRandom({ board, moves });
     else moveCopsRandom({ board, moves });

--- a/src/components/games/policeman-thief/policeman-thief-c/helpers.ts
+++ b/src/components/games/policeman-thief/policeman-thief-c/helpers.ts
@@ -85,3 +85,7 @@ export const isVertex = (vertex: number): boolean =>
 // reduces to "is the target adjacent to where the piece stands".
 export const isNeighbour = (from: number, to: number): boolean =>
   isVertex(from) && isVertex(to) && neighbours[from].includes(to);
+
+// Player 0 chases, player 1 runs. Both indices appear in move legality, in the
+// winner handed to endGame and in the board client, so they get names.
+export const [POLICE, THIEF] = [0, 1];

--- a/src/components/games/policeman-thief/policeman-thief-c/helpers.ts
+++ b/src/components/games/policeman-thief/policeman-thief-c/helpers.ts
@@ -77,3 +77,11 @@ export const dist: number[][] = (() => {
 
 export const minDistToSet = (vertex: number, set: number[]): number =>
   Math.min(...set.map((c) => dist[vertex][c]));
+
+export const isVertex = (vertex: number): boolean =>
+  Number.isInteger(vertex) && vertex >= 0 && vertex < VERTEX_COUNT;
+
+// Once the chase is on, everyone moves along a single edge, so every move
+// reduces to "is the target adjacent to where the piece stands".
+export const isNeighbour = (from: number, to: number): boolean =>
+  isVertex(from) && isVertex(to) && neighbours[from].includes(to);

--- a/src/components/games/policeman-thief/policeman-thief-c/policeman-thief-c.spec.ts
+++ b/src/components/games/policeman-thief/policeman-thief-c/policeman-thief-c.spec.ts
@@ -1,6 +1,7 @@
 import { moves, generateStartBoard, pickCopCount, type Board } from './policeman-thief-c';
+import { VERTEX_COUNT } from './helpers';
 import { range } from 'lodash';
-import { makeEvents } from '../../../../test-utils';
+import { makeEvents, makeCtx } from '../../../../test-utils';
 
 const meta = () => ({ events: makeEvents() });
 
@@ -42,7 +43,7 @@ describe('pickCopCount', () => {
 describe('moves.placeCop', () => {
   it('adds a policeman without ending the turn until all are placed', () => {
     const { events } = meta();
-    const { nextBoard } = moves.placeCop(generateStartBoard(), { events }, 7);
+    const { nextBoard } = moves.placeCop.apply(generateStartBoard(), { events }, 7);
     expect(nextBoard.policemen).toEqual([7]);
     expect(nextBoard.phase).toBe('placingCops');
     expect(events.endTurn).not.toHaveBeenCalled();
@@ -53,7 +54,7 @@ describe('moves.placeCop', () => {
     // pin copCount so placing the second cop reliably completes placement
     // (generateStartBoard randomises it to 2 or 3)
     const board = { ...generateStartBoard(), copCount: 2, policemen: [7] };
-    const { nextBoard } = moves.placeCop(board, { events }, 3);
+    const { nextBoard } = moves.placeCop.apply(board, { events }, 3);
     expect(nextBoard.policemen).toEqual([7, 3]);
     expect(nextBoard.phase).toBe('placingThief');
     expect(events.endTurn).toHaveBeenCalledTimes(1);
@@ -64,7 +65,7 @@ describe('moves.placeThief', () => {
   it('places the thief, enters the chasing phase and ends the turn', () => {
     const { events } = meta();
     const board: Board = { ...generateStartBoard(), policemen: [10, 11], phase: 'placingThief' };
-    const { nextBoard } = moves.placeThief(board, { events }, 2);
+    const { nextBoard } = moves.placeThief.apply(board, { events }, 2);
     expect(nextBoard.thief).toBe(2);
     expect(nextBoard.phase).toBe('chasing');
     expect(nextBoard.copCursor).toBe(0);
@@ -75,7 +76,7 @@ describe('moves.placeThief', () => {
 describe('moves.moveCop', () => {
   it('advances the cursor and keeps the turn until every policeman has moved', () => {
     const { events } = meta();
-    const { nextBoard } = moves.moveCop(chasingBoard(), { events }, 12);
+    const { nextBoard } = moves.moveCop.apply(chasingBoard(), { events }, 12);
     expect(nextBoard.policemen).toEqual([12, 11]);
     expect(nextBoard.copCursor).toBe(1);
     expect(events.endTurn).not.toHaveBeenCalled();
@@ -84,7 +85,7 @@ describe('moves.moveCop', () => {
 
   it('ends the turn after the last policeman moves', () => {
     const { events } = meta();
-    const { nextBoard } = moves.moveCop(chasingBoard({ copCursor: 1 }), { events }, 13);
+    const { nextBoard } = moves.moveCop.apply(chasingBoard({ copCursor: 1 }), { events }, 13);
     expect(nextBoard.policemen).toEqual([10, 13]);
     expect(nextBoard.copCursor).toBe(0);
     expect(events.endTurn).toHaveBeenCalledTimes(1);
@@ -93,7 +94,7 @@ describe('moves.moveCop', () => {
   it('ends the game for the police when a policeman steps onto the thief', () => {
     const { events } = meta();
     // thief on vertex 0; blue cop at 10 is adjacent to 0
-    moves.moveCop(chasingBoard({ thief: 0 }), { events }, 0);
+    moves.moveCop.apply(chasingBoard({ thief: 0 }), { events }, 0);
     expect(events.endGame).toHaveBeenCalledWith(0);
     expect(events.endTurn).not.toHaveBeenCalled();
   });
@@ -102,7 +103,7 @@ describe('moves.moveCop', () => {
 describe('moves.moveThief', () => {
   it('records a move and ends the turn when the thief stays free', () => {
     const { events } = meta();
-    const { nextBoard } = moves.moveThief(chasingBoard({ thief: 0 }), { events }, 5);
+    const { nextBoard } = moves.moveThief.apply(chasingBoard({ thief: 0 }), { events }, 5);
     expect(nextBoard.thief).toBe(5);
     expect(nextBoard.thiefMoveCount).toBe(1);
     expect(events.endTurn).toHaveBeenCalledTimes(1);
@@ -113,7 +114,7 @@ describe('moves.moveThief', () => {
     const { events } = meta();
     // thief at 9 (adjacent to 0 and 4); a cop sits on 9's neighbour... use direct overlap
     const board = chasingBoard({ thief: 0, policemen: [5, 11] });
-    moves.moveThief(board, { events }, 5);
+    moves.moveThief.apply(board, { events }, 5);
     expect(events.endGame).toHaveBeenCalledWith(0);
     expect(events.endTurn).not.toHaveBeenCalled();
   });
@@ -121,8 +122,56 @@ describe('moves.moveThief', () => {
   it('ends the game for the thief after a safe third move', () => {
     const { events } = meta();
     const board = chasingBoard({ thief: 0, thiefMoveCount: 2, policemen: [12, 13] });
-    moves.moveThief(board, { events }, 5);
+    moves.moveThief.apply(board, { events }, 5);
     expect(events.endGame).toHaveBeenCalledWith(1);
     expect(events.endTurn).not.toHaveBeenCalled();
+  });
+});
+
+describe('move legality', () => {
+  const asPolice = { ctx: makeCtx({ currentPlayer: 0 }) };
+  const asThief = { ctx: makeCtx({ currentPlayer: 1 }) };
+
+  it('accepts a policeman on any vertex during the placement phase', () => {
+    const board = generateStartBoard();
+    expect(moves.placeCop.validate(board, asPolice, 0)).toBe(true);
+    expect(moves.placeCop.validate(board, asPolice, VERTEX_COUNT - 1)).toBe(true);
+    expect(moves.placeCop.validate(board, asPolice, VERTEX_COUNT)).toBe(false);
+    expect(moves.placeCop.validate(board, asPolice, -1)).toBe(false);
+  });
+
+  it('refuses to place further policemen once the phase has moved on', () => {
+    const board = { ...generateStartBoard(), phase: 'placingThief' as const, policemen: [0, 1] };
+    expect(moves.placeCop.validate(board, asPolice, 5)).toBe(false);
+  });
+
+  it('keeps the thief off a vertex a policeman already occupies', () => {
+    const board = { ...generateStartBoard(), phase: 'placingThief' as const, policemen: [0, 7] };
+    expect(moves.placeThief.validate(board, asThief, 3)).toBe(true);
+    expect(moves.placeThief.validate(board, asThief, 0)).toBe(false);
+    expect(moves.placeThief.validate(board, asThief, 7)).toBe(false);
+  });
+
+  it('moves the policeman the cursor points at, along one edge', () => {
+    const board = chasingBoard({ policemen: [10, 11], copCursor: 0 });
+    expect(moves.moveCop.validate(board, asPolice, 0)).toBe(true); // 10 ~ 0
+    expect(moves.moveCop.validate(board, asPolice, 1)).toBe(false); // 1 is 11's neighbour
+    expect(moves.moveCop.validate(board, asPolice, 10)).toBe(false); // must move
+
+    const second = chasingBoard({ policemen: [10, 11], copCursor: 1 });
+    expect(moves.moveCop.validate(second, asPolice, 1)).toBe(true); // 11 ~ 1
+    expect(moves.moveCop.validate(second, asPolice, 0)).toBe(false);
+  });
+
+  it('never lets one side make the other side\'s move', () => {
+    const board = chasingBoard({ policemen: [10, 11], thief: 0 });
+    expect(moves.moveCop.validate(board, asThief, 0)).toBe(false);
+    expect(moves.moveThief.validate(board, asPolice, 5)).toBe(false);
+  });
+
+  it('refuses a chase move before the chase has started', () => {
+    const board = generateStartBoard();
+    expect(moves.moveCop.validate(board, asPolice, 0)).toBe(false);
+    expect(moves.moveThief.validate(board, asThief, 0)).toBe(false);
   });
 });

--- a/src/components/games/policeman-thief/policeman-thief-c/policeman-thief-c.spec.ts
+++ b/src/components/games/policeman-thief/policeman-thief-c/policeman-thief-c.spec.ts
@@ -1,5 +1,5 @@
 import { moves, generateStartBoard, pickCopCount, type Board } from './policeman-thief-c';
-import { VERTEX_COUNT } from './helpers';
+import { POLICE, THIEF, VERTEX_COUNT } from './helpers';
 import { range } from 'lodash';
 import { makeEvents, makeCtx } from '../../../../test-utils';
 
@@ -129,8 +129,8 @@ describe('moves.moveThief', () => {
 });
 
 describe('move legality', () => {
-  const asPolice = { ctx: makeCtx({ currentPlayer: 0 }) };
-  const asThief = { ctx: makeCtx({ currentPlayer: 1 }) };
+  const asPolice = { ctx: makeCtx({ currentPlayer: POLICE }) };
+  const asThief = { ctx: makeCtx({ currentPlayer: THIEF }) };
 
   it('accepts a policeman on any vertex during the placement phase', () => {
     const board = generateStartBoard();

--- a/src/components/games/policeman-thief/policeman-thief-c/policeman-thief-c.tsx
+++ b/src/components/games/policeman-thief/policeman-thief-c/policeman-thief-c.tsx
@@ -1,7 +1,7 @@
 import { cloneDeep, random } from "lodash";
 import { strategyGameFactory, type Ctx, type Events } from "../../../strategy-game-factory";
 import { smartBotStrategy, randomBotStrategy } from "./bot-strategy";
-import { isNeighbour, isVertex } from "./helpers";
+import { isNeighbour, isVertex, POLICE, THIEF } from "./helpers";
 import { BoardClient } from "./board-client";
 
 export type Phase = 'placingCops' | 'placingThief' | 'chasing';
@@ -29,8 +29,6 @@ export const generateStartBoard = (): Board => ({
   thiefMoveCount: 0,
   copCursor: 0
 });
-
-export const [POLICE, THIEF] = [0, 1];
 
 // `phase` and `copCursor` record how far the setup and the current police round
 // have got, so every validator is a pure function of the board. The
@@ -76,7 +74,7 @@ export const moves = {
       nextBoard.policemen[nextBoard.copCursor] = vertex;
       nextBoard.copCursor += 1;
       if (vertex === nextBoard.thief) {
-        events.endGame(0);
+        events.endGame(POLICE);
         return { nextBoard };
       }
       if (nextBoard.copCursor === nextBoard.copCount) {
@@ -97,11 +95,11 @@ export const moves = {
       nextBoard.thief = vertex;
       nextBoard.thiefMoveCount += 1;
       if (nextBoard.policemen.includes(vertex)) {
-        events.endGame(0);
+        events.endGame(POLICE);
         return { nextBoard };
       }
       if (nextBoard.thiefMoveCount === 3) {
-        events.endGame(1);
+        events.endGame(THIEF);
         return { nextBoard };
       }
       events.endTurn();
@@ -149,7 +147,7 @@ const getPlayerStepDescription = ({ board, ctx }: { board: Board; ctx: Ctx }) =>
     };
   }
   // chasing
-  if (ctx.currentPlayer === 0) {
+  if (ctx.currentPlayer === POLICE) {
     return {
       hu: `Lépj a ${copColorName.hu[board.copCursor]} rendőrrel egy szomszédos csúcsra.`,
       en: `Move the ${copColorName.en[board.copCursor]} policeman to a neighbouring vertex.`

--- a/src/components/games/policeman-thief/policeman-thief-c/policeman-thief-c.tsx
+++ b/src/components/games/policeman-thief/policeman-thief-c/policeman-thief-c.tsx
@@ -1,6 +1,7 @@
 import { cloneDeep, random } from "lodash";
 import { strategyGameFactory, type Ctx, type Events } from "../../../strategy-game-factory";
 import { smartBotStrategy, randomBotStrategy } from "./bot-strategy";
+import { isNeighbour, isVertex } from "./helpers";
 import { BoardClient } from "./board-client";
 
 export type Phase = 'placingCops' | 'placingThief' | 'chasing';
@@ -29,58 +30,83 @@ export const generateStartBoard = (): Board => ({
   copCursor: 0
 });
 
+export const [POLICE, THIEF] = [0, 1];
+
+// `phase` and `copCursor` record how far the setup and the current police round
+// have got, so every validator is a pure function of the board. The
+// currentPlayer checks in the chasing moves say *which* piece may move — during
+// a round the police and the thief both have a legal-looking step available,
+// and only one of them is theirs to make.
 export const moves = {
   // Police placement: one click per policeman; police may share a vertex.
-  placeCop: (board: Board, { events }: { events: Events }, vertex: number) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard.policemen.push(vertex);
-    if (nextBoard.policemen.length === nextBoard.copCount) {
-      nextBoard.phase = 'placingThief';
-      events.endTurn();
+  placeCop: {
+    validate: (board: Board, _, vertex: number) =>
+      board.phase === 'placingCops' && isVertex(vertex),
+    apply: (board: Board, { events }: { events: Events }, vertex: number) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard.policemen.push(vertex);
+      if (nextBoard.policemen.length === nextBoard.copCount) {
+        nextBoard.phase = 'placingThief';
+        events.endTurn();
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   },
-  // Thief picks a starting vertex (guaranteed police-free by the board client).
-  placeThief: (board: Board, { events }: { events: Events }, vertex: number) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard.thief = vertex;
-    nextBoard.phase = 'chasing';
-    nextBoard.copCursor = 0;
-    events.endTurn();
-    return { nextBoard };
+  // Thief picks a starting vertex; it may not be one already holding a policeman.
+  placeThief: {
+    validate: (board: Board, _, vertex: number) =>
+      board.phase === 'placingThief' && isVertex(vertex) && !board.policemen.includes(vertex),
+    apply: (board: Board, { events }: { events: Events }, vertex: number) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard.thief = vertex;
+      nextBoard.phase = 'chasing';
+      nextBoard.copCursor = 0;
+      events.endTurn();
+      return { nextBoard };
+    }
   },
   // Chasing: move the current policeman along one edge. Catching the thief
   // (landing on its vertex) ends the game immediately for the police.
-  moveCop: (board: Board, { events }: { events: Events }, vertex: number) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard.policemen[nextBoard.copCursor] = vertex;
-    nextBoard.copCursor += 1;
-    if (vertex === nextBoard.thief) {
-      events.endGame(0);
+  moveCop: {
+    validate: (board: Board, { ctx }: { ctx: Ctx }, vertex: number) =>
+      board.phase === 'chasing' && ctx.currentPlayer === POLICE
+        && isNeighbour(board.policemen[board.copCursor], vertex),
+    apply: (board: Board, { events }: { events: Events }, vertex: number) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard.policemen[nextBoard.copCursor] = vertex;
+      nextBoard.copCursor += 1;
+      if (vertex === nextBoard.thief) {
+        events.endGame(0);
+        return { nextBoard };
+      }
+      if (nextBoard.copCursor === nextBoard.copCount) {
+        nextBoard.copCursor = 0;
+        events.endTurn();
+      }
       return { nextBoard };
     }
-    if (nextBoard.copCursor === nextBoard.copCount) {
-      nextBoard.copCursor = 0;
-      events.endTurn();
-    }
-    return { nextBoard };
   },
   // Chasing: move the thief along one edge. Stepping onto a policeman loses;
   // completing a third move without being caught wins.
-  moveThief: (board: Board, { events }: { events: Events }, vertex: number) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard.thief = vertex;
-    nextBoard.thiefMoveCount += 1;
-    if (nextBoard.policemen.includes(vertex)) {
-      events.endGame(0);
+  moveThief: {
+    validate: (board: Board, { ctx }: { ctx: Ctx }, vertex: number) =>
+      board.phase === 'chasing' && ctx.currentPlayer === THIEF
+        && isNeighbour(board.thief!, vertex),
+    apply: (board: Board, { events }: { events: Events }, vertex: number) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard.thief = vertex;
+      nextBoard.thiefMoveCount += 1;
+      if (nextBoard.policemen.includes(vertex)) {
+        events.endGame(0);
+        return { nextBoard };
+      }
+      if (nextBoard.thiefMoveCount === 3) {
+        events.endGame(1);
+        return { nextBoard };
+      }
+      events.endTurn();
       return { nextBoard };
     }
-    if (nextBoard.thiefMoveCount === 3) {
-      events.endGame(1);
-      return { nextBoard };
-    }
-    events.endTurn();
-    return { nextBoard };
   }
 };
 


### PR DESCRIPTION
Continues the per-move `validate` migration started in #333. The two sibling chase games.

Each is a pursuit on a fixed graph where every move is a single step along an edge, so each game gets an `isVertex` / `isNeighbour` pair over its own adjacency list. The graphs are different — a cube for A/B, a subdivided Petersen graph for C — so nothing is shared between the two beyond the shape of the idea.

## policeman-thief-ab

- `moveThief` — the thief, to an intersection adjacent to its own.
- `moveFirstPoliceman` — the police, while `firstPolicemanMoved` is false, adjacent to the blue policeman.
- `moveSecondPoliceman` — the police, while `firstPolicemanMoved` is true, adjacent to the green one.

A police round is two half-moves, and `firstPolicemanMoved` already records which half is due, so the two rule each other out with no turn state involved.

## policeman-thief-c

`phase` and `copCursor` do the same job for the longer setup:

- `placeCop` — only during `placingCops`, on any vertex (police may share one).
- `placeThief` — only during `placingThief`, and never onto a vertex a policeman occupies. That rule was previously enforced only by the board client; the comment on the move said "guaranteed police-free by the board client", which is now true by construction instead.
- `moveCop` / `moveThief` — only while chasing, and only for the piece whose turn it is.

## The currentPlayer checks

Both games need them, and for the same reason as #350: during a chase round the police and the thief each have a legal-looking step available, and only one of them is theirs to make. Without the check, a stray `moveCop` during the thief's turn would look legal from the board alone.

## Board clients

Both collapse into an `activeMove()` helper — exactly one move is on offer at any moment, and it now decides both what a click does and which vertices are highlighted, rather than each being spelled out separately. That removes the last copies of the adjacency rules from the UI.

## Tests

A new `legality.spec.ts` for A/B (including an exhaustive cross-check of `isNeighbour` against the adjacency list, and that no intersection is its own neighbour — staying put is not a move), and a `move legality` block appended to `policeman-thief-c.spec.ts`.

Full suite: 96 files, 639 tests, all passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSxP4EAjGt4vDBxsQt32c)_