### PR TITLE
Move legality layer: digit-subtraction, sum-fifteen, two-of-three-takeaway, remove-divisor-multiple

### DIFF
--- a/src/components/games/digit-subtraction/digit-subtraction.tsx
+++ b/src/components/games/digit-subtraction/digit-subtraction.tsx
@@ -13,7 +13,14 @@ const digitsOf = (n: number): number[] =>
 const uniqueNonZeroDigits = (n: number): number[] =>
   [...new Set(digitsOf(n))];
 
-const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
+// Only a non-zero digit that actually appears in the current number may be
+// subtracted. Both players draw from the same number, so whose turn it is does
+// not enter into legality.
+export const isSubtractableDigit = (board: Board, digit: number): boolean =>
+  Number.isInteger(digit) && digit >= 1 && digit <= 9
+    && String(board).includes(String(digit));
+
+const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
   const digits = String(board).split('').map(Number);
 
   return (
@@ -22,7 +29,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
         {digits.map((d, i) => (
           <button
             key={i}
-            disabled={!ctx.isClientMoveAllowed || d === 0}
+            disabled={!moves.subtractDigit.isAllowed!(board, d)}
             onClick={() => moves.subtractDigit(board, d)}
             className="secondary-button border-2 text-3xl sm:text-5xl w-12 sm:w-16 py-2 sm:py-3 font-bold"
           >
@@ -35,14 +42,17 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 };
 
 const moves = {
-  subtractDigit: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, digit: number) => {
-    const nextBoard = board - digit;
-    if (nextBoard === 0) {
-      events.endGame(ctx.currentPlayer!);
-    } else {
-      events.endTurn();
+  subtractDigit: {
+    validate: (board: Board, _, digit: number) => isSubtractableDigit(board, digit),
+    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, digit: number) => {
+      const nextBoard = board - digit;
+      if (nextBoard === 0) {
+        events.endGame(ctx.currentPlayer!);
+      } else {
+        events.endTurn();
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 };
 

--- a/src/components/games/digit-subtraction/legality.spec.ts
+++ b/src/components/games/digit-subtraction/legality.spec.ts
@@ -1,0 +1,28 @@
+import { isSubtractableDigit } from './digit-subtraction';
+
+describe('isSubtractableDigit', () => {
+  it('accepts a digit that appears in the current number', () => {
+    expect(isSubtractableDigit(147, 1)).toBe(true);
+    expect(isSubtractableDigit(147, 4)).toBe(true);
+    expect(isSubtractableDigit(147, 7)).toBe(true);
+  });
+
+  it('refuses a digit the number does not contain', () => {
+    expect(isSubtractableDigit(147, 2)).toBe(false);
+    expect(isSubtractableDigit(147, 9)).toBe(false);
+  });
+
+  it('refuses zero — subtracting it would never end the game', () => {
+    expect(isSubtractableDigit(105, 0)).toBe(false);
+  });
+
+  it('refuses anything that is not a single digit', () => {
+    expect(isSubtractableDigit(147, 14)).toBe(false);
+    expect(isSubtractableDigit(147, -1)).toBe(false);
+    expect(isSubtractableDigit(147, 1.5)).toBe(false);
+  });
+
+  it('counts a repeated digit once, and accepts it', () => {
+    expect(isSubtractableDigit(11, 1)).toBe(true);
+  });
+});

--- a/src/components/games/remove-divisor-multiple/legality.spec.ts
+++ b/src/components/games/remove-divisor-multiple/legality.spec.ts
@@ -1,0 +1,35 @@
+import { range } from 'lodash';
+import { isAllowed } from './remove-divisor-multiple';
+
+const board = (previousMove: number | null, removed: number[] = [], size = 10) => ({
+  numbersOnTable: range(1, size + 1).map(n => !removed.includes(n)),
+  previousMove
+});
+
+describe('isAllowed', () => {
+  it('accepts any number on the table as the opening move', () => {
+    expect(isAllowed(board(null), 1)).toBe(true);
+    expect(isAllowed(board(null), 10)).toBe(true);
+  });
+
+  it('accepts divisors and multiples of the number just removed', () => {
+    const after6 = board(6, [6]);
+    expect(isAllowed(after6, 2)).toBe(true); // divisor
+    expect(isAllowed(after6, 3)).toBe(true); // divisor
+    expect(isAllowed(after6, 1)).toBe(true); // divisor
+    expect(isAllowed(after6, 4)).toBe(false); // neither
+    expect(isAllowed(after6, 5)).toBe(false); // neither
+  });
+
+  it('refuses a number that has already been removed', () => {
+    expect(isAllowed(board(6, [6, 3]), 3)).toBe(false);
+    expect(isAllowed(board(null, [4]), 4)).toBe(false);
+  });
+
+  it('refuses a number that is not on the board at all', () => {
+    expect(isAllowed(board(null), 0)).toBe(false);
+    expect(isAllowed(board(null), 11)).toBe(false);
+    expect(isAllowed(board(null), 2.5)).toBe(false);
+    expect(isAllowed(board(6, [6]), 12)).toBe(false);
+  });
+});

--- a/src/components/games/remove-divisor-multiple/remove-divisor-multiple.tsx
+++ b/src/components/games/remove-divisor-multiple/remove-divisor-multiple.tsx
@@ -7,11 +7,17 @@ import { useTranslation } from '../../../language';
 
 type Board = { numbersOnTable: boolean[], previousMove: number | null }
 
-const isAllowed = (board: Board, n) => {
+// The number must still be on the table, and — from the second move on — be a
+// divisor or a multiple of the number the other player just removed. The
+// on-the-table check used to be skipped for the opening move, where every
+// number is still there anyway; hoisting it above the previousMove branch
+// changes nothing for a real opening move but keeps a bogus argument out.
+export const isAllowed = (board: Board, n) => {
+  if (!Number.isInteger(n) || n < 1 || n > board.numbersOnTable.length) return false;
+  if (board.numbersOnTable[n - 1] === false) return false;
   if (board.previousMove === null) {
     return true;
   }
-  if (board.numbersOnTable[n - 1] === false) return false;
   if (board.previousMove > n && board.previousMove % n === 0) {
     return true;
   } else if (board.previousMove < n && n % board.previousMove === 0) {
@@ -20,15 +26,14 @@ const isAllowed = (board: Board, n) => {
   return false;
 }
 
-const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
+const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
-  const isMoveAllowed = n => isAllowed(board, n);
+  // Two different questions: `isLegal` marks the numbers that could be removed
+  // from this position — shown in blue whoever is on turn — while `isAllowed`
+  // additionally requires that it is this client's move, and gates the buttons.
+  const isLegal = n => isAllowed(board, n);
 
-  const removeNumber = n => {
-    if (!ctx.isClientMoveAllowed) return;
-    if (!isMoveAllowed(n)) return;
-    moves.removeNumber(board, n);
-  }
+  const removeNumber = n => moves.removeNumber(board, n);
 
   return (
     <GameBoard>
@@ -36,12 +41,12 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
         {range(1, board.numbersOnTable.length + 1).map(num =>
           <button
             key={num}
-            disabled={!isMoveAllowed(num) || !ctx.isClientMoveAllowed}
+            disabled={!moves.removeNumber.isAllowed!(board, num)}
             onClick={() => removeNumber(num)}
             className={`
               m-1 min-h-28 w-18 border-4 rounded-lg shadow-md text-4xl font-bold
               ${board.numbersOnTable[num - 1] ? '' : 'opacity-50 border-dashed'}
-              ${board.numbersOnTable[num - 1] ? (isMoveAllowed(num) ? 'border-blue-600' : 'border-red-600') : ''}
+              ${board.numbersOnTable[num - 1] ? (isLegal(num) ? 'border-blue-600' : 'border-red-600') : ''}
               enabled:hocus:opacity-50 enabled:hocus:border-dashed
               `}
           >
@@ -57,15 +62,18 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 };
 
 const moves = {
-  removeNumber: (board: Board, { events }: { events: Events }, n) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard.numbersOnTable[n - 1] = false;
-    nextBoard.previousMove = n;
-    events.endTurn();
-    if (isGameEnd(nextBoard)) {
-      events.endGame();
+  removeNumber: {
+    validate: (board: Board, _, n) => isAllowed(board, n),
+    apply: (board: Board, { events }: { events: Events }, n) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard.numbersOnTable[n - 1] = false;
+      nextBoard.previousMove = n;
+      events.endTurn();
+      if (isGameEnd(nextBoard)) {
+        events.endGame();
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 };
 

--- a/src/components/games/sum-fifteen/helpers.spec.ts
+++ b/src/components/games/sum-fifteen/helpers.spec.ts
@@ -1,7 +1,7 @@
 import { range } from 'lodash';
 import {
   hasSum15, findWinningTriple, winnerOptimal, chooseSmartMove,
-  numbersOwnedBy, freeNumbers, currentPlayerFromOwner, generateStartBoard,
+  numbersOwnedBy, freeNumbers, currentPlayerFromOwner, generateStartBoard, isChoiceAllowed,
   type Owner
 } from './helpers';
 
@@ -86,5 +86,30 @@ describe('chooseSmartMove', () => {
     const owner: Owner = [0, 1, 0, null, null, 1, null, null, null];
     expect(currentPlayerFromOwner(owner)).toBe(0);
     expect(chooseSmartMove(owner, 0)).toBe(7);
+  });
+});
+
+describe('isChoiceAllowed', () => {
+  const owner: Owner = [0, null, 1, null, null, null, null, null, null];
+
+  it('accepts a number nobody has claimed', () => {
+    expect(isChoiceAllowed(owner, 2)).toBe(true);
+    expect(isChoiceAllowed(owner, 9)).toBe(true);
+  });
+
+  it('refuses a number either player already owns', () => {
+    expect(isChoiceAllowed(owner, 1)).toBe(false);
+    expect(isChoiceAllowed(owner, 3)).toBe(false);
+  });
+
+  it('refuses anything outside 1..9', () => {
+    expect(isChoiceAllowed(owner, 0)).toBe(false);
+    expect(isChoiceAllowed(owner, 10)).toBe(false);
+    expect(isChoiceAllowed(owner, 2.5)).toBe(false);
+  });
+
+  it('accepts exactly the free numbers', () => {
+    const free = new Set(freeNumbers(owner));
+    for (let n = 1; n <= 9; n++) expect(isChoiceAllowed(owner, n)).toBe(free.has(n));
   });
 });

--- a/src/components/games/sum-fifteen/helpers.ts
+++ b/src/components/games/sum-fifteen/helpers.ts
@@ -15,6 +15,11 @@ export const numbersOwnedBy = (owner: Owner, player: 0 | 1): number[] =>
 export const freeNumbers = (owner: Owner): number[] =>
   allNumbers.filter(n => owner[n - 1] === null);
 
+// A player may claim any of 1..9 that nobody has claimed yet. Both players draw
+// from the same nine numbers, so whose turn it is does not enter into legality.
+export const isChoiceAllowed = (owner: Owner, n: number): boolean =>
+  Number.isInteger(n) && n >= 1 && n <= allNumbers.length && owner[n - 1] === null;
+
 // The first player owns numbers on even move counts, so the player to move is
 // simply the parity of how many numbers have been claimed.
 export const currentPlayerFromOwner = (owner: Owner): 0 | 1 =>

--- a/src/components/games/sum-fifteen/sum-fifteen.tsx
+++ b/src/components/games/sum-fifteen/sum-fifteen.tsx
@@ -20,8 +20,6 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     ? (findWinningTriple(numbersOwnedBy(owner, ctx.winnerIndex as 0 | 1)) ?? [])
     : [];
 
-  const clickNumber = (n: number) => moves.chooseNumber(board, n);
-
   const ownerLabel = (player: 0 | 1) => {
     const colorClass = player === 0
       ? 'font-bold text-red-700 dark:text-red-400'
@@ -61,7 +59,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
           <button
             key={n}
             disabled={!moves.chooseNumber.isAllowed!(board, n)}
-            onClick={(e) => { clickNumber(n); e.currentTarget.blur(); }}
+            onClick={(e) => { moves.chooseNumber(board, n); e.currentTarget.blur(); }}
             className={numberClass(n)}
           >
             {n}

--- a/src/components/games/sum-fifteen/sum-fifteen.tsx
+++ b/src/components/games/sum-fifteen/sum-fifteen.tsx
@@ -4,7 +4,7 @@ import {
 import { useTranslation } from '../../../language';
 import {
   allNumbers, generateStartBoard, numbersOwnedBy, currentPlayerFromOwner,
-  hasSum15, findWinningTriple, chooseSmartMove, chooseTestMove, type Board
+  hasSum15, findWinningTriple, chooseSmartMove, chooseTestMove, isChoiceAllowed, type Board
 } from './helpers';
 
 const ownedLabel = (owner: Board['owner'], player: 0 | 1): string => {
@@ -20,10 +20,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     ? (findWinningTriple(numbersOwnedBy(owner, ctx.winnerIndex as 0 | 1)) ?? [])
     : [];
 
-  const clickNumber = (n: number) => {
-    if (!ctx.isClientMoveAllowed || owner[n - 1] !== null) return;
-    moves.chooseNumber(board, n);
-  };
+  const clickNumber = (n: number) => moves.chooseNumber(board, n);
 
   const ownerLabel = (player: 0 | 1) => {
     const colorClass = player === 0
@@ -63,7 +60,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
         {allNumbers.map(n => (
           <button
             key={n}
-            disabled={!ctx.isClientMoveAllowed || owner[n - 1] !== null}
+            disabled={!moves.chooseNumber.isAllowed!(board, n)}
             onClick={(e) => { clickNumber(n); e.currentTarget.blur(); }}
             className={numberClass(n)}
           >
@@ -82,21 +79,24 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 };
 
 const moves = {
-  chooseNumber: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, n: number) => {
-    const player = ctx.currentPlayer as 0 | 1;
-    const owner = board.owner.slice() as Board['owner'];
-    owner[n - 1] = player;
-    const nextBoard = { owner };
+  chooseNumber: {
+    validate: (board: Board, _, n: number) => isChoiceAllowed(board.owner, n),
+    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, n: number) => {
+      const player = ctx.currentPlayer as 0 | 1;
+      const owner = board.owner.slice() as Board['owner'];
+      owner[n - 1] = player;
+      const nextBoard = { owner };
 
-    if (hasSum15(numbersOwnedBy(owner, player))) {
-      events.endGame(player);
-    } else if (owner.every(o => o !== null)) {
-      // All nine numbers claimed, nobody reached a triple summing to 15.
-      events.endGame(1);
-    } else {
-      events.endTurn();
+      if (hasSum15(numbersOwnedBy(owner, player))) {
+        events.endGame(player);
+      } else if (owner.every(o => o !== null)) {
+        // All nine numbers claimed, nobody reached a triple summing to 15.
+        events.endGame(1);
+      } else {
+        events.endTurn();
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 };
 

--- a/src/components/games/two-of-three-takeaway/helpers.spec.ts
+++ b/src/components/games/two-of-three-takeaway/helpers.spec.ts
@@ -2,6 +2,7 @@ import {
   type Board,
   applyMove,
   canMove,
+  isTakeAllowed,
   isTerminal,
   getLegalMoves,
   isWinningInOneMove,
@@ -137,5 +138,30 @@ describe('two-of-three-takeaway helpers', () => {
       for (let i = 0; i < 500; i++) results.add(isWinningBoard(generateStartBoard()));
       expect(results).toEqual(new Set([true, false]));
     });
+  });
+});
+
+describe('isTakeAllowed', () => {
+  const board: Board = [3, 1, 0];
+
+  it('accepts two distinct non-empty piles, in either order', () => {
+    expect(isTakeAllowed(board, 0, 1)).toBe(true);
+    expect(isTakeAllowed(board, 1, 0)).toBe(true);
+  });
+
+  it('refuses an empty pile, the same pile twice, and indices off the board', () => {
+    expect(isTakeAllowed(board, 0, 2)).toBe(false); // pile 2 is empty
+    expect(isTakeAllowed(board, 0, 0)).toBe(false);
+    expect(isTakeAllowed(board, 0, 3)).toBe(false);
+    expect(isTakeAllowed(board, -1, 0)).toBe(false);
+  });
+
+  it('accepts every move the generator lists, and nothing else', () => {
+    const listed = new Set(getLegalMoves(board).map(([i, j]) => `${i},${j}`));
+    for (let i = 0; i < 3; i++) {
+      for (let j = i + 1; j < 3; j++) {
+        expect(isTakeAllowed(board, i, j)).toBe(listed.has(`${i},${j}`));
+      }
+    }
   });
 });

--- a/src/components/games/two-of-three-takeaway/helpers.ts
+++ b/src/components/games/two-of-three-takeaway/helpers.ts
@@ -17,6 +17,12 @@ export const isTerminal = (board: Board): boolean => !canMove(board);
 export const applyMove = (board: Board, [i, j]: Move): Board =>
   board.map((v, idx) => (idx === i || idx === j ? v - 1 : v));
 
+export const isPile = (i: number): boolean => Number.isInteger(i) && i >= 0 && i < 3;
+
+// A move takes one chip from each of two *distinct* non-empty piles.
+export const isTakeAllowed = (board: Board, i: number, j: number): boolean =>
+  isPile(i) && isPile(j) && i !== j && board[i] > 0 && board[j] > 0;
+
 export const getLegalMoves = (board: Board): Move[] => {
   const nonEmpty = board.map((v, i) => i).filter(i => board[i] > 0);
   const moves: Move[] = [];

--- a/src/components/games/two-of-three-takeaway/two-of-three-takeaway.tsx
+++ b/src/components/games/two-of-three-takeaway/two-of-three-takeaway.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from '../../../language';
 import {
   type Board,
   applyMove,
+  isTakeAllowed,
   isTerminal,
   getSmartBotMove,
   getRandomBotMove,
@@ -102,15 +103,18 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 };
 
 const moves = {
-  takeChips: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, i: number, j: number) => {
-    const nextBoard = applyMove(board, [i, j]);
-    if (isTerminal(nextBoard)) {
-      // The opponent cannot move, so the player who just moved wins.
-      events.endGame(ctx.currentPlayer!);
-    } else {
-      events.endTurn();
+  takeChips: {
+    validate: (board: Board, _, i: number, j: number) => isTakeAllowed(board, i, j),
+    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, i: number, j: number) => {
+      const nextBoard = applyMove(board, [i, j]);
+      if (isTerminal(nextBoard)) {
+        // The opponent cannot move, so the player who just moved wins.
+        events.endGame(ctx.currentPlayer!);
+      } else {
+        events.endTurn();
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 };
 


### PR DESCRIPTION
Continues the per-move `validate` migration started in #333. Four small number games, all symmetric — both players draw from the same number, board or pool — so none of these validators needs `ctx`.

| Game | Legality |
|---|---|
| digit-subtraction | a non-zero digit that appears in the current number |
| sum-fifteen | one of 1..9 that nobody has claimed yet |
| two-of-three-takeaway | two distinct non-empty piles, in either order |
| remove-divisor-multiple | on the table, and a divisor or multiple of the number just removed |

## remove-divisor-multiple

`isAllowed` already *was* the rule; it is now exported and wired up as `removeNumber`'s `validate`. It also gains a bounds and on-the-table check ahead of the `previousMove` branch — for the opening move it used to return `true` for **any** argument, since every number is still on the table then anyway. That changes nothing for a real opening move but keeps a bogus argument out, which is exactly what the engine wants from a validator.

Its board client keeps two separate questions, which is worth a look when reviewing: `isLegal` marks in blue the numbers that could be removed from this position, shown whoever is on turn, while the buttons are gated on `moves.removeNumber.isAllowed`, which additionally requires that it is this client's move. Collapsing the two would have greyed the hints out during the opponent's turn.

## Tests

New specs for `digit-subtraction` and `remove-divisor-multiple`, which had none. Blocks appended to the other two, each including a check that the validator agrees exactly with the game's own move generator (`getLegalMoves` / `freeNumbers`).

Full suite: 97 files, 642 tests, all passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSxP4EAjGt4vDBxsQt32c)_