### PR TITLE
Move legality layer: ten-coins, pile-union, stones-remove-one-not-twice-from-left

### DIFF
--- a/src/components/games/pile-union/legality.spec.ts
+++ b/src/components/games/pile-union/legality.spec.ts
@@ -1,0 +1,48 @@
+import { isPile, isMergeAllowed } from './pile-union';
+
+describe('isPile', () => {
+  const board = [3, 2, 5];
+
+  it('accepts every pile on the table', () => {
+    expect(isPile(board, 0)).toBe(true);
+    expect(isPile(board, 2)).toBe(true);
+  });
+
+  it('refuses an index off the table', () => {
+    expect(isPile(board, 3)).toBe(false);
+    expect(isPile(board, -1)).toBe(false);
+    expect(isPile(board, 1.5)).toBe(false);
+  });
+
+  it('refuses everything once the table is empty', () => {
+    expect(isPile([], 0)).toBe(false);
+  });
+});
+
+describe('isMergeAllowed', () => {
+  const board = [3, 2, 5];
+
+  it('accepts two different piles, in either order', () => {
+    expect(isMergeAllowed(board, [0, 1])).toBe(true);
+    expect(isMergeAllowed(board, [1, 0])).toBe(true);
+    expect(isMergeAllowed(board, [0, 2])).toBe(true);
+  });
+
+  it('refuses merging a pile with itself', () => {
+    expect(isMergeAllowed(board, [1, 1])).toBe(false);
+  });
+
+  it('refuses a pile that is not on the table', () => {
+    expect(isMergeAllowed(board, [0, 3])).toBe(false);
+    expect(isMergeAllowed(board, [-1, 0])).toBe(false);
+  });
+
+  it('refuses anything that is not a pair of piles', () => {
+    expect(isMergeAllowed(board, [0])).toBe(false);
+    expect(isMergeAllowed(board, [0, 1, 2])).toBe(false);
+  });
+
+  it('refuses a merge on a single-pile table — there is nothing to merge with', () => {
+    expect(isMergeAllowed([4], [0, 1])).toBe(false);
+  });
+});

--- a/src/components/games/pile-union/pile-union.tsx
+++ b/src/components/games/pile-union/pile-union.tsx
@@ -15,6 +15,9 @@ const BoardClient = ({ board, ctx, events, moves }: BoardClientProps<Board>) => 
   const { value: hoveredPile, hoverProps } = useHoverPreview<number>(ctx.moveCount);
   const turnState = ctx.turnState as TurnState;
 
+  // The merge branch is a two-click sequence held in turn state, so this one
+  // keeps its guard: without it a click during the bot's turn would still move
+  // the selection around.
   const handlePileClick = (pileIndex) => {
     if (!ctx.isClientMoveAllowed) return;
     if (moveType === 'remove') {
@@ -174,25 +177,41 @@ const Matchstick = ({ dimmed }: { dimmed: boolean }) => (
   </div>
 );
 
+// Empty piles never survive a move (removeOne drops a pile it empties), so any
+// pile still on the table has a match to take.
+export const isPile = (board: Board, pileIndex: number): boolean =>
+  Number.isInteger(pileIndex) && pileIndex >= 0 && pileIndex < board.length;
+
+// Merging needs two piles, and they have to be different ones.
+export const isMergeAllowed = (board: Board, piles: number[]): boolean =>
+  Array.isArray(piles) && piles.length === 2
+    && isPile(board, piles[0]) && isPile(board, piles[1]) && piles[0] !== piles[1];
+
 const moves = {
-  removeOne: (board: Board, { events }: { events: Events }, pileIndex) => {
-    const newSize = board[pileIndex] - 1;
-    const nextBoard = [
-      ...board.slice(0, pileIndex),
-      ...(newSize > 0 ? [newSize] : []),
-      ...board.slice(pileIndex + 1)
-    ];
-    events.endTurn();
-    if (nextBoard.length === 0) events.endGame();
-    return { nextBoard };
+  removeOne: {
+    validate: (board: Board, _, pileIndex) => isPile(board, pileIndex),
+    apply: (board: Board, { events }: { events: Events }, pileIndex) => {
+      const newSize = board[pileIndex] - 1;
+      const nextBoard = [
+        ...board.slice(0, pileIndex),
+        ...(newSize > 0 ? [newSize] : []),
+        ...board.slice(pileIndex + 1)
+      ];
+      events.endTurn();
+      if (nextBoard.length === 0) events.endGame();
+      return { nextBoard };
+    }
   },
-  mergePiles: (board: Board, { events }: { events: Events }, [pileIndex1, pileIndex2]) => {
-    const [firstIdx, secondIdx] = [pileIndex1, pileIndex2].sort((a, b) => a - b);
-    const merged = board[firstIdx] + board[secondIdx];
-    const nextBoard = board.filter((_, i) => i !== firstIdx && i !== secondIdx);
-    nextBoard.splice(firstIdx, 0, merged);
-    events.endTurn();
-    return { nextBoard };
+  mergePiles: {
+    validate: (board: Board, _, piles: number[]) => isMergeAllowed(board, piles),
+    apply: (board: Board, { events }: { events: Events }, [pileIndex1, pileIndex2]) => {
+      const [firstIdx, secondIdx] = [pileIndex1, pileIndex2].sort((a, b) => a - b);
+      const merged = board[firstIdx] + board[secondIdx];
+      const nextBoard = board.filter((_, i) => i !== firstIdx && i !== secondIdx);
+      nextBoard.splice(firstIdx, 0, merged);
+      events.endTurn();
+      return { nextBoard };
+    }
   }
 };
 

--- a/src/components/games/stones-remove-one-not-twice-from-left/legality.spec.ts
+++ b/src/components/games/stones-remove-one-not-twice-from-left/legality.spec.ts
@@ -1,0 +1,40 @@
+import { isRemovalAllowed } from './stones-remove-one-not-twice-from-left';
+
+const board = (piles: [number, number], leftRestriction: [boolean, boolean] = [false, false]) =>
+  ({ piles, leftRestriction });
+
+describe('isRemovalAllowed', () => {
+  it('accepts either pile when nobody is restricted', () => {
+    const b = board([3, 4]);
+    expect(isRemovalAllowed(b, 0, 0)).toBe(true);
+    expect(isRemovalAllowed(b, 0, 1)).toBe(true);
+  });
+
+  it('refuses an empty pile', () => {
+    expect(isRemovalAllowed(board([0, 4]), 0, 0)).toBe(false);
+    expect(isRemovalAllowed(board([3, 0]), 0, 1)).toBe(false);
+  });
+
+  it('closes the left pile to a player who took from it last turn', () => {
+    const b = board([3, 4], [true, false]);
+    expect(isRemovalAllowed(b, 0, 0)).toBe(false);
+    expect(isRemovalAllowed(b, 0, 1)).toBe(true);
+  });
+
+  it('restricts only the player who took from the left, not the other one', () => {
+    const b = board([3, 4], [true, false]);
+    expect(isRemovalAllowed(b, 1, 0)).toBe(true);
+  });
+
+  it('never restricts the right pile', () => {
+    const b = board([3, 4], [true, true]);
+    expect(isRemovalAllowed(b, 0, 1)).toBe(true);
+    expect(isRemovalAllowed(b, 1, 1)).toBe(true);
+  });
+
+  it('refuses a pile that does not exist', () => {
+    const b = board([3, 4]);
+    expect(isRemovalAllowed(b, 0, 2)).toBe(false);
+    expect(isRemovalAllowed(b, 0, -1)).toBe(false);
+  });
+});

--- a/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
+++ b/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
@@ -30,16 +30,20 @@ const StonePile = ({ count, onClick, disabled, restricted, hovered, hoverProps }
   );
 };
 
+// The pile must have a stone left, and the left pile is closed to a player who
+// took from it on their previous turn. The restriction is recorded per player,
+// so this is one of the games where whose move it is genuinely decides what is
+// legal — not merely whose turn it is.
+export const isRemovalAllowed = (board: Board, player: number, pileId: number): boolean =>
+  (pileId === 0 || pileId === 1)
+    && board.piles[pileId] > 0
+    && !(pileId === 0 && board.leftRestriction[player]);
+
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
   const { value: hoveredPile, hoverProps } = useHoverPreview<number>(ctx.moveCount);
 
-  const isMoveAllowed = pileId => {
-    if (!ctx.isClientMoveAllowed) return false;
-    if (board.piles[pileId] === 0) return false;
-    if (pileId === 0 && board.leftRestriction[ctx.currentPlayer!]) return false;
-    return true;
-  }
+  const isMoveAllowed = pileId => moves.removeStone.isAllowed!(board, pileId);
 
   return (
     <GameBoard>
@@ -66,15 +70,19 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 };
 
 const moves = {
-  removeStone: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, pileId) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard.piles[pileId] = board.piles[pileId] - 1;
-    nextBoard.leftRestriction[ctx.currentPlayer!] = (pileId === 0);
-    events.endTurn();
-    if (isGameEnd(nextBoard, ctx)) {
-      events.endGame();
+  removeStone: {
+    validate: (board: Board, { ctx }: { ctx: Ctx }, pileId) =>
+      isRemovalAllowed(board, ctx.currentPlayer!, pileId),
+    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, pileId) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard.piles[pileId] = board.piles[pileId] - 1;
+      nextBoard.leftRestriction[ctx.currentPlayer!] = (pileId === 0);
+      events.endTurn();
+      if (isGameEnd(nextBoard, ctx)) {
+        events.endGame();
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 };
 

--- a/src/components/games/ten-coins/legality.spec.ts
+++ b/src/components/games/ten-coins/legality.spec.ts
@@ -1,0 +1,32 @@
+import { isConversionAllowed } from './ten-coins';
+
+describe('isConversionAllowed', () => {
+  // Four 3s and six 1s: the values 1 and 3 are on the table, 2 and 4 are not.
+  const board = [1, 1, 1, 1, 1, 1, 3, 3, 3, 3];
+
+  it('accepts a value on the table turned into any smaller one', () => {
+    expect(isConversionAllowed(board, 3, 1)).toBe(true);
+    expect(isConversionAllowed(board, 3, 2)).toBe(true);
+  });
+
+  it('refuses a value that is not on the table', () => {
+    expect(isConversionAllowed(board, 2, 1)).toBe(false);
+    expect(isConversionAllowed(board, 4, 1)).toBe(false);
+  });
+
+  it('refuses a target that is not strictly smaller', () => {
+    expect(isConversionAllowed(board, 3, 3)).toBe(false);
+    expect(isConversionAllowed(board, 3, 4)).toBe(false);
+  });
+
+  it('refuses value-1 coins, which have no smaller value to become', () => {
+    expect(isConversionAllowed(board, 1, 1)).toBe(false);
+    expect(isConversionAllowed(board, 1, 0)).toBe(false);
+  });
+
+  it('refuses non-integer or non-positive arguments', () => {
+    expect(isConversionAllowed(board, 3, 0)).toBe(false);
+    expect(isConversionAllowed(board, 3, -1)).toBe(false);
+    expect(isConversionAllowed(board, 3, 1.5)).toBe(false);
+  });
+});

--- a/src/components/games/ten-coins/optimality.spec.ts
+++ b/src/components/games/ten-coins/optimality.spec.ts
@@ -40,8 +40,9 @@ const driveBot = (set: Vals): Vals => {
   const board = [...set];
   let captured = board;
   const ctx = makeCtx();
-  const wrapped = mapValues(gameMoves, fn => (b: number[], ...args: unknown[]) => {
-    const res = (fn as (...a: unknown[]) => { nextBoard: number[] })(b, { ctx, events: dummyEvents }, ...args);
+  // Long-form moves ({ validate, apply }) expose their effect as `apply`.
+  const wrapped = mapValues(gameMoves, ({ apply }) => (b: number[], ...args: unknown[]) => {
+    const res = (apply as (...a: unknown[]) => { nextBoard: number[] })(b, { ctx, events: dummyEvents }, ...args);
     captured = res.nextBoard;
     return res;
   }) as unknown as GameMoves<number[]>;

--- a/src/components/games/ten-coins/ten-coins.tsx
+++ b/src/components/games/ten-coins/ten-coins.tsx
@@ -60,12 +60,10 @@ const BoardClient = ({ board, ctx, events, moves }: BoardClientProps<Board>) => 
   const selectedValue = ctx.turnState as number | null;
   const presentValues = distinctValues(board);
 
-  // Value-1 coins can't be selected: there is no smaller value to change them
-  // to, so not even the most generous target (L = 1) makes a legal move.
-  const isSelectable = (v: number) => moves.convert.isAllowed!(board, v, 1);
-
+  // Asking about L = 1 asks whether these coins can be changed at all: it is the
+  // most generous target, so value-1 coins fall out as unselectable.
   const selectValue = (v: number) => {
-    if (!isSelectable(v)) return;
+    if (!moves.convert.isAllowed!(board, v, 1)) return;
     events.setTurnState(selectedValue === v ? null : v);
   };
 
@@ -83,7 +81,7 @@ const BoardClient = ({ board, ctx, events, moves }: BoardClientProps<Board>) => 
           return (
             <button
               key={v}
-              disabled={!isSelectable(v)}
+              disabled={!moves.convert.isAllowed!(board, v, 1)}
               onClick={() => selectValue(v)}
               aria-pressed={isSelected}
               aria-label={t({

--- a/src/components/games/ten-coins/ten-coins.tsx
+++ b/src/components/games/ten-coins/ten-coins.tsx
@@ -60,16 +60,16 @@ const BoardClient = ({ board, ctx, events, moves }: BoardClientProps<Board>) => 
   const selectedValue = ctx.turnState as number | null;
   const presentValues = distinctValues(board);
 
-  // Value-1 coins can't be selected: there is no smaller value to change them to.
-  const isSelectable = (v: number) => v > 1;
+  // Value-1 coins can't be selected: there is no smaller value to change them
+  // to, so not even the most generous target (L = 1) makes a legal move.
+  const isSelectable = (v: number) => moves.convert.isAllowed!(board, v, 1);
 
   const selectValue = (v: number) => {
-    if (!ctx.isClientMoveAllowed || !isSelectable(v)) return;
+    if (!isSelectable(v)) return;
     events.setTurnState(selectedValue === v ? null : v);
   };
 
   const chooseTarget = (l: number) => {
-    if (!ctx.isClientMoveAllowed || selectedValue === null) return;
     moves.convert(board, selectedValue, l);
     events.setTurnState(null);
   };
@@ -83,7 +83,7 @@ const BoardClient = ({ board, ctx, events, moves }: BoardClientProps<Board>) => 
           return (
             <button
               key={v}
-              disabled={!ctx.isClientMoveAllowed || !isSelectable(v)}
+              disabled={!isSelectable(v)}
               onClick={() => selectValue(v)}
               aria-pressed={isSelected}
               aria-label={t({
@@ -125,7 +125,7 @@ const BoardClient = ({ board, ctx, events, moves }: BoardClientProps<Board>) => 
           {range(1, selectedValue).map(l => (
             <button
               key={l}
-              disabled={!ctx.isClientMoveAllowed}
+              disabled={!moves.convert.isAllowed!(board, selectedValue, l)}
               onClick={() => chooseTarget(l)}
               aria-label={t({ hu: `${l} értékű érme`, en: `value ${l} coin` })}
               className="rounded-full transition-transform enabled:hocus:scale-110
@@ -156,15 +156,24 @@ const Coin = ({ value }: { value: number }) => (
   </div>
 );
 
+// A move needs a value K that is actually on the table, and a strictly smaller
+// positive L to turn those coins into. Both players draw on the same table, so
+// whose turn it is does not enter into legality.
+export const isConversionAllowed = (board: Board, k: number, l: number): boolean =>
+  Number.isInteger(k) && Number.isInteger(l) && l >= 1 && l < k && board.includes(k);
+
 export const moves = {
-  convert: (board: Board, { events }: { events: Events }, k, l) => {
-    const nextBoard = board.map(v => (v === k ? l : v)).sort((a, b) => a - b);
-    if (uniq(nextBoard).length === 1) {
-      events.endGame(); // whoever equalises the coins wins → current player
-    } else {
-      events.endTurn();
+  convert: {
+    validate: (board: Board, _, k, l) => isConversionAllowed(board, k, l),
+    apply: (board: Board, { events }: { events: Events }, k, l) => {
+      const nextBoard = board.map(v => (v === k ? l : v)).sort((a, b) => a - b);
+      if (uniq(nextBoard).length === 1) {
+        events.endGame(); // whoever equalises the coins wins → current player
+      } else {
+        events.endTurn();
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 };
 


### PR DESCRIPTION
Continues the per-move `validate` migration started in #333. Three games about taking from a shared table of coins, matches or stones.

## ten-coins

`convert(k, l)` needs a value `k` that is actually on the table and a strictly smaller positive `l` to turn those coins into.

The board client's `isSelectable` — "can these coins be changed at all?" — is now that same question asked of the most generous target: `moves.convert.isAllowed(board, v, 1)`. Value-1 coins fall out as unselectable for the right reason rather than by a separate `v > 1` rule. The target buttons ask about their own value.

## pile-union

- `removeOne(pileIndex)` — a pile that is on the table. Any pile still there has a match to take: `removeOne` drops a pile it empties, so the board never holds a zero.
- `mergePiles([i, j])` — two piles on the table, and different ones.

The merge branch of the click handler keeps its `isClientMoveAllowed` guard. That one is not redundant: it moves a selection held in turn state, which the engine's per-move check does not cover.

## stones-remove-one-not-twice-from-left

The pile must have a stone left, and the left pile is closed to a player who took from it on their previous turn.

This is one of the games where `ctx.currentPlayer` in `validate` is load-bearing in a new way: the restriction is stored per player (`leftRestriction[player]`), so the same board position is legal for one player and not the other. Not turn ownership — a genuine difference in what each side may do.

## Tests

A `legality.spec.ts` for each, including that the left-pile restriction binds only the player who earned it and never touches the right pile. `ten-coins`'s existing optimality spec reaches the move effect through `.apply` now that `convert` is long-form.

Full suite: 98 files, 645 tests, all passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSxP4EAjGt4vDBxsQt32c)_