### PR TITLE
Move legality layer: add-reduce-double, ten-digit-number, polynomial-building

### DIFF
--- a/src/components/games/add-reduce-double/add-reduce-double.tsx
+++ b/src/components/games/add-reduce-double/add-reduce-double.tsx
@@ -20,9 +20,6 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const isDisabled = ({ pileId, pieceId }: Piece) =>
     !moves.moveHalvedPieces.isAllowed!(board, { pileId, pieceCount: board[pileId] - pieceId });
 
-  const clickPiece = ({ pileId, pieceId }: Piece) =>
-    moves.moveHalvedPieces(board, { pileId, pieceCount: board[pileId] - pieceId });
-
   // The pieces removed by clicking the hovered piece: it and everything above it.
   const removedCount = () => (validHoveredPiece ? board[validHoveredPiece.pileId] - validHoveredPiece.pieceId : 0);
 
@@ -83,7 +80,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
                 }
                 ${!nonExistent({ pileId, pieceId }) && !toBeRemoved({ pileId, pieceId }) ? 'bg-blue-800' : ''}
               `}
-              onClick={() => clickPiece({ pileId, pieceId })}
+              onClick={() => moves.moveHalvedPieces(board, { pileId, pieceCount: board[pileId] - pieceId })}
               {...(isDisabled({ pileId, pieceId }) ? {} : hoverProps({ pileId, pieceId }))}
             >
               {!isDisabled({ pileId, pieceId }) &&

--- a/src/components/games/add-reduce-double/add-reduce-double.tsx
+++ b/src/components/games/add-reduce-double/add-reduce-double.tsx
@@ -14,18 +14,14 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     return pieceId >= board[pileId];
   };
 
-  const isDisabled = ({ pileId, pieceId }: Piece) => {
-    if (!ctx.isClientMoveAllowed) return true;
-    // Clicking piece `pieceId` removes it and everything above it (from the top),
-    // i.e. `board[pileId] - pieceId` pieces, which must be even and at least 2.
-    return (board[pileId] - pieceId) % 2 !== 0 || pieceId > board[pileId] - 2;
-  };
+  // Clicking piece `pieceId` removes it and everything above it (from the top),
+  // i.e. `board[pileId] - pieceId` pieces — so the piece is clickable exactly
+  // when that is a legal transfer.
+  const isDisabled = ({ pileId, pieceId }: Piece) =>
+    !moves.moveHalvedPieces.isAllowed!(board, { pileId, pieceCount: board[pileId] - pieceId });
 
-  const clickPiece = ({ pileId, pieceId }: Piece) => {
-    if (isDisabled({ pileId, pieceId })) return;
-
+  const clickPiece = ({ pileId, pieceId }: Piece) =>
     moves.moveHalvedPieces(board, { pileId, pieceCount: board[pileId] - pieceId });
-  };
 
   // The pieces removed by clicking the hovered piece: it and everything above it.
   const removedCount = () => (validHoveredPiece ? board[validHoveredPiece.pileId] - validHoveredPiece.pieceId : 0);
@@ -102,18 +98,30 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   );
 };
 
+// An even number of pieces, at least two, and no more than the pile holds —
+// half of them then go to the other pile. Both players draw on the same two
+// piles, so whose turn it is does not enter into legality.
+export const isTransferAllowed = (board: Board, { pileId, pieceCount }): boolean =>
+  (pileId === 0 || pileId === 1)
+    && Number.isInteger(pieceCount)
+    && pieceCount >= 2
+    && pieceCount % 2 === 0
+    && pieceCount <= board[pileId];
+
 const moves = {
-  moveHalvedPieces: (board: Board, { events }: { events: Events }, { pileId, pieceCount }) => {
-    if (pieceCount % 2 !== 0) console.error('invalid_move');
-    const nextBoard = cloneDeep(board);
-    nextBoard[pileId] -= pieceCount;
-    nextBoard[1 - pileId] += pieceCount / 2;
-    events.endTurn();
-    const isGameEnd = isEqual(nextBoard, [1, 1]) || isEqual(nextBoard, [0, 1]) || isEqual(nextBoard, [1, 0]);
-    if (isGameEnd) {
-      events.endGame();
+  moveHalvedPieces: {
+    validate: (board: Board, _, piece) => isTransferAllowed(board, piece),
+    apply: (board: Board, { events }: { events: Events }, { pileId, pieceCount }) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard[pileId] -= pieceCount;
+      nextBoard[1 - pileId] += pieceCount / 2;
+      events.endTurn();
+      const isGameEnd = isEqual(nextBoard, [1, 1]) || isEqual(nextBoard, [0, 1]) || isEqual(nextBoard, [1, 0]);
+      if (isGameEnd) {
+        events.endGame();
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 };
 

--- a/src/components/games/add-reduce-double/legality.spec.ts
+++ b/src/components/games/add-reduce-double/legality.spec.ts
@@ -1,0 +1,31 @@
+import { isTransferAllowed } from './add-reduce-double';
+
+describe('isTransferAllowed', () => {
+  const board = [6, 3];
+
+  it('accepts an even count from two up to the whole pile', () => {
+    expect(isTransferAllowed(board, { pileId: 0, pieceCount: 2 })).toBe(true);
+    expect(isTransferAllowed(board, { pileId: 0, pieceCount: 4 })).toBe(true);
+    expect(isTransferAllowed(board, { pileId: 0, pieceCount: 6 })).toBe(true);
+    expect(isTransferAllowed(board, { pileId: 1, pieceCount: 2 })).toBe(true);
+  });
+
+  it('refuses an odd count — half of it could not be moved across', () => {
+    expect(isTransferAllowed(board, { pileId: 0, pieceCount: 3 })).toBe(false);
+    expect(isTransferAllowed(board, { pileId: 0, pieceCount: 5 })).toBe(false);
+  });
+
+  it('refuses taking nothing', () => {
+    expect(isTransferAllowed(board, { pileId: 0, pieceCount: 0 })).toBe(false);
+  });
+
+  it('refuses taking more than the pile holds', () => {
+    expect(isTransferAllowed(board, { pileId: 0, pieceCount: 8 })).toBe(false);
+    expect(isTransferAllowed(board, { pileId: 1, pieceCount: 4 })).toBe(false);
+  });
+
+  it('refuses a pile that does not exist', () => {
+    expect(isTransferAllowed(board, { pileId: 2, pieceCount: 2 })).toBe(false);
+    expect(isTransferAllowed(board, { pileId: -1, pieceCount: 2 })).toBe(false);
+  });
+});

--- a/src/components/games/polynomial-building/board-client.tsx
+++ b/src/components/games/polynomial-building/board-client.tsx
@@ -31,8 +31,9 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
   const [inputs, setInputs] = useState<Record<Coef, string>>({ a: '', b: '', c: '' });
 
+  // The text has to parse before there is a value to judge; from there on the
+  // move's own validator decides, and the engine ignores a dispatch it rejects.
   const submit = (coef: Coef) => {
-    if (!ctx.isClientMoveAllowed || board[coef] !== null) return;
     const raw = inputs[coef];
     if (!isValidValue(raw)) return;
     moves.setCoefficient(board, coef, parseInt(raw, 10));
@@ -79,7 +80,8 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
                 placeholder={t({ hu: 'egész szám', en: 'integer' })}
               />
               <button
-                disabled={!ctx.isClientMoveAllowed || !isValidValue(inputs[coef])}
+                disabled={!isValidValue(inputs[coef])
+                  || !moves.setCoefficient.isAllowed!(board, coef, parseInt(inputs[coef], 10))}
                 onClick={() => submit(coef)}
                 className="rounded-md border-2 px-3 py-1.5 font-bold
                   enabled:hocus:bg-blue-100 dark:enabled:hocus:bg-blue-900

--- a/src/components/games/polynomial-building/helpers.spec.ts
+++ b/src/components/games/polynomial-building/helpers.spec.ts
@@ -1,4 +1,7 @@
-import { divisors, integerRoots, hasThreeIntegerRoots, completionValue } from './helpers';
+import {
+  divisors, integerRoots, hasThreeIntegerRoots, completionValue, isCoefficientChoiceAllowed,
+  type Board, type Coef
+} from './helpers';
 
 const sorted = (xs: number[] | null) => (xs === null ? null : [...xs].sort((a, b) => a - b));
 
@@ -66,5 +69,33 @@ describe('completionValue', () => {
     const v = completionValue({ a: null, b: 5000, c: 0 });
     expect(v).toBe(-5001);
     expect(hasThreeIntegerRoots(-5001, 5000, 0)).toBe(true);
+  });
+});
+
+describe('isCoefficientChoiceAllowed', () => {
+  const empty: Board = { a: null, b: null, c: null };
+
+  it('accepts any integer for a coefficient nobody has fixed', () => {
+    expect(isCoefficientChoiceAllowed(empty, 'a', 0)).toBe(true);
+    expect(isCoefficientChoiceAllowed(empty, 'b', -7)).toBe(true);
+    expect(isCoefficientChoiceAllowed(empty, 'c', 1000000)).toBe(true);
+  });
+
+  it('refuses a coefficient that is already set', () => {
+    const board: Board = { a: 2, b: null, c: null };
+    expect(isCoefficientChoiceAllowed(board, 'a', 5)).toBe(false);
+    expect(isCoefficientChoiceAllowed(board, 'b', 5)).toBe(true);
+  });
+
+  it('refuses a value that is not an exact integer', () => {
+    expect(isCoefficientChoiceAllowed(empty, 'a', 1.5)).toBe(false);
+    expect(isCoefficientChoiceAllowed(empty, 'a', NaN)).toBe(false);
+    expect(isCoefficientChoiceAllowed(empty, 'a', Infinity)).toBe(false);
+    // Beyond 2^53 the root arithmetic would stop being exact.
+    expect(isCoefficientChoiceAllowed(empty, 'a', 2 ** 53)).toBe(false);
+  });
+
+  it('refuses a name that is not one of the three coefficients', () => {
+    expect(isCoefficientChoiceAllowed(empty, 'd' as Coef, 1)).toBe(false);
   });
 });

--- a/src/components/games/polynomial-building/helpers.ts
+++ b/src/components/games/polynomial-building/helpers.ts
@@ -3,6 +3,13 @@ export type Board = { a: number | null; b: number | null; c: number | null }
 
 export const COEFS: Coef[] = ['a', 'b', 'c'];
 
+// Any integer may be chosen for any coefficient nobody has fixed yet — the two
+// players pick from the same three slots, so whose turn it is does not enter
+// into legality. The safe-integer bound is what keeps the root arithmetic
+// exact; the board client caps the input at 12 digits for the same reason.
+export const isCoefficientChoiceAllowed = (board: Board, coef: Coef, value: number): boolean =>
+  COEFS.includes(coef) && board[coef] === null && Number.isSafeInteger(value);
+
 // All integer divisors (positive and negative) of a nonzero integer.
 export const divisors = (n: number): number[] => {
   const m = Math.abs(n);

--- a/src/components/games/polynomial-building/polynomial-building.tsx
+++ b/src/components/games/polynomial-building/polynomial-building.tsx
@@ -1,19 +1,25 @@
 import { strategyGameFactory, type Events } from '../../strategy-game-factory';
-import { type Board, type Coef, COEFS, hasThreeIntegerRoots } from './helpers';
+import {
+  type Board, type Coef, COEFS, hasThreeIntegerRoots, isCoefficientChoiceAllowed
+} from './helpers';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { BoardClient } from './board-client';
 
 const moves = {
-  setCoefficient: (board: Board, { events }: { events: Events }, coef: Coef, value: number) => {
-    const nextBoard = { ...board, [coef]: value };
-    const filled = nextBoard.a !== null && nextBoard.b !== null && nextBoard.c !== null;
-    if (filled) {
-      // A (player 0) wins iff all three roots are integers; otherwise B (player 1).
-      events.endGame(hasThreeIntegerRoots(nextBoard.a!, nextBoard.b!, nextBoard.c!) ? 0 : 1);
-    } else {
-      events.endTurn();
+  setCoefficient: {
+    validate: (board: Board, _, coef: Coef, value: number) =>
+      isCoefficientChoiceAllowed(board, coef, value),
+    apply: (board: Board, { events }: { events: Events }, coef: Coef, value: number) => {
+      const nextBoard = { ...board, [coef]: value };
+      const filled = nextBoard.a !== null && nextBoard.b !== null && nextBoard.c !== null;
+      if (filled) {
+        // A (player 0) wins iff all three roots are integers; otherwise B (player 1).
+        events.endGame(hasThreeIntegerRoots(nextBoard.a!, nextBoard.b!, nextBoard.c!) ? 0 : 1);
+      } else {
+        events.endTurn();
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 };
 

--- a/src/components/games/ten-digit-number/legality.spec.ts
+++ b/src/components/games/ten-digit-number/legality.spec.ts
@@ -1,0 +1,27 @@
+import { isDigitChoiceAllowed } from './ten-digit-number';
+
+const board = (digitCount: number) => ({
+  digits: Array.from({ length: digitCount }, () => 1),
+  sumMod9: digitCount % 9
+});
+
+describe('isDigitChoiceAllowed', () => {
+  it('accepts each of the six offered digits', () => {
+    for (const d of [1, 2, 3, 4, 5, 6]) expect(isDigitChoiceAllowed(board(0), d)).toBe(true);
+  });
+
+  it('refuses a digit outside the offered six', () => {
+    expect(isDigitChoiceAllowed(board(0), 0)).toBe(false);
+    expect(isDigitChoiceAllowed(board(0), 7)).toBe(false);
+    expect(isDigitChoiceAllowed(board(0), 9)).toBe(false);
+    expect(isDigitChoiceAllowed(board(0), -1)).toBe(false);
+  });
+
+  it('accepts a digit up to the last free slot', () => {
+    expect(isDigitChoiceAllowed(board(9), 3)).toBe(true);
+  });
+
+  it('refuses any digit once all ten are written', () => {
+    expect(isDigitChoiceAllowed(board(10), 3)).toBe(false);
+  });
+});

--- a/src/components/games/ten-digit-number/ten-digit-number.tsx
+++ b/src/components/games/ten-digit-number/ten-digit-number.tsx
@@ -30,6 +30,12 @@ const winnerFromState = (() => {
   return (sumMod9, turnsLeft) => memo[`${sumMod9},${turnsLeft}`];
 })();
 
+// Only one of the six offered digits may be appended, and only while the number
+// is still short of its ten digits. Both players draw from the same six, so
+// whose turn it is does not enter into legality.
+export const isDigitChoiceAllowed = (board: Board, digit: number): boolean =>
+  board.digits.length < totalDigits && availableDigits.includes(digit);
+
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
   const slots = Array.from({ length: totalDigits }, (_, i) =>
@@ -71,7 +77,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
         {availableDigits.map(d => (
           <button
             key={d}
-            disabled={!ctx.isClientMoveAllowed}
+            disabled={!moves.chooseDigit.isAllowed!(board, d)}
             onClick={(e) => { moves.chooseDigit(board, d); e.currentTarget.blur(); }}
             className="rounded-lg border-2 text-2xl w-12 py-2 font-bold
               enabled:hocus:bg-blue-100 dark:enabled:hocus:bg-blue-900
@@ -86,16 +92,19 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 };
 
 const moves = {
-  chooseDigit: (board: Board, { events }: { events: Events }, digit) => {
-    const newDigits = [...board.digits, digit];
-    const newSumMod9 = (board.sumMod9 + digit) % 9;
-    const nextBoard = { digits: newDigits, sumMod9: newSumMod9 };
-    if (newDigits.length === totalDigits) {
-      events.endGame(newSumMod9 === 0 ? 1 : 0);
-    } else {
-      events.endTurn();
+  chooseDigit: {
+    validate: (board: Board, _, digit) => isDigitChoiceAllowed(board, digit),
+    apply: (board: Board, { events }: { events: Events }, digit) => {
+      const newDigits = [...board.digits, digit];
+      const newSumMod9 = (board.sumMod9 + digit) % 9;
+      const nextBoard = { digits: newDigits, sumMod9: newSumMod9 };
+      if (newDigits.length === totalDigits) {
+        events.endGame(newSumMod9 === 0 ? 1 : 0);
+      } else {
+        events.endTurn();
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 };
 


### PR DESCRIPTION
Continues the per-move `validate` migration started in #333. Three games where the two players build the same thing between them, so none of these validators needs `ctx`.

## add-reduce-double

`moveHalvedPieces` takes an even count, at least two and no more than the pile holds.

`isDisabled` in the board client was the same arithmetic spelled out over the clicked piece index; it now converts the click into a piece count and asks the move. This also removes a dead `console.error('invalid_move')` that logged an odd count and then moved the pieces anyway — the fourth of these the migration has turned up.

## ten-digit-number

`chooseDigit` takes one of the six offered digits, and only while the number is still short of its ten.

## polynomial-building

`setCoefficient` takes any integer for a coefficient nobody has fixed yet. The safe-integer bound is the interesting part: it is what keeps the root arithmetic exact, and it is the same reason the board client caps its input at 12 digits — that cap now has a counterpart the engine can enforce.

The Set button additionally asks the validator about the parsed value, so it greys out for a coefficient that is already taken rather than relying on the input row being hidden.

## pairs-of-numbers

Considered for this batch and deliberately left alone: both its moves (`add1`, `subtract`) take no arguments and are legal in every position, so under the agreed "only non-trivial legality" scope there is nothing to validate. Same reasoning as the two `distinct-squares` games. Say the word if you'd rather they all got no-op validators for uniformity.

## Tests

New `legality.spec.ts` for `add-reduce-double` and `ten-digit-number`; a block appended to `polynomial-building`'s existing helpers spec.

Full suite: 97 files, 639 tests, all passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSxP4EAjGt4vDBxsQt32c)_