### PR TITLE
Move legality layer: latin-square-filling, matches-on-edges, triangle-coloring

### DIFF
--- a/src/components/games/latin-square-filling/helpers.spec.ts
+++ b/src/components/games/latin-square-filling/helpers.spec.ts
@@ -160,3 +160,29 @@ describe('latin-square-filling helpers', () => {
     });
   });
 });
+
+describe('isLegalPlacement argument checks', () => {
+  it('refuses a digit outside 1..3', () => {
+    const board = generateStartBoard();
+    expect(isLegalPlacement(board, 0, 0)).toBe(false);
+    expect(isLegalPlacement(board, 0, 4)).toBe(false);
+    expect(isLegalPlacement(board, 0, 1.5)).toBe(false);
+  });
+
+  it('refuses a cell outside the 3x3 grid', () => {
+    const board = generateStartBoard();
+    expect(isLegalPlacement(board, -1, 1)).toBe(false);
+    expect(isLegalPlacement(board, 9, 1)).toBe(false);
+    expect(isLegalPlacement(board, 0.5, 1)).toBe(false);
+  });
+
+  it('accepts exactly the moves the generator lists', () => {
+    const board = applyMove(applyMove(generateStartBoard(), { cell: 0, digit: 1 }), { cell: 4, digit: 2 });
+    const listed = new Set(legalMoves(board).map(m => `${m.cell},${m.digit}`));
+    for (let cell = 0; cell < 9; cell++) {
+      for (const digit of [1, 2, 3]) {
+        expect(isLegalPlacement(board, cell, digit)).toBe(listed.has(`${cell},${digit}`));
+      }
+    }
+  });
+});

--- a/src/components/games/latin-square-filling/helpers.ts
+++ b/src/components/games/latin-square-filling/helpers.ts
@@ -14,6 +14,8 @@ export const isFull = (board: Board): boolean => board.every(v => v !== 0);
 // Writing `digit` into empty `cell` is legal iff that digit is not already
 // present in the cell's row or column (no row/column may hold two equal digits).
 export const isLegalPlacement = (board: Board, cell: number, digit: number): boolean => {
+  if (!Number.isInteger(cell) || cell < 0 || cell >= 9) return false;
+  if (![1, 2, 3].includes(digit)) return false;
   if (board[cell] !== 0) return false;
   const r = rowOf(cell), c = colOf(cell);
   for (let k = 0; k < 3; k++) {

--- a/src/components/games/latin-square-filling/latin-square-filling.tsx
+++ b/src/components/games/latin-square-filling/latin-square-filling.tsx
@@ -12,7 +12,7 @@ import {
   type Board,
   generateStartBoard,
   isFull,
-  legalDigits,
+  isLegalPlacement,
   legalMoves,
   getSmartBotStep,
   getRandomBotStep
@@ -32,12 +32,13 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     setSelectedCell(prev => (prev === cell ? null : cell));
   };
 
-  const placeDigit = (digit: number) => {
-    if (!ctx.isClientMoveAllowed || selectedCell === null) return;
-    moves.placeDigit(board, selectedCell, digit);
-  };
+  const placeDigit = (digit: number) => moves.placeDigit(board, selectedCell, digit);
 
-  const allowed = selectedCell === null ? [] : legalDigits(board, selectedCell);
+  // Which digits the selected cell will accept — asked of the move itself, so
+  // the keypad and the engine cannot disagree.
+  const allowed = [1, 2, 3].filter(
+    digit => selectedCell !== null && moves.placeDigit.isAllowed!(board, selectedCell, digit)
+  );
 
   return (
     <GameBoard>
@@ -109,18 +110,21 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 };
 
 const moves = {
-  placeDigit: (board: Board, { events }: { ctx: Ctx; events: Events }, cell: number, digit: number) => {
-    const nextBoard = board.map((v, i) => (i === cell ? digit : v));
-    events.endTurn();
-    // The next player now faces nextBoard: a full grid means the first player
-    // won; an empty grid with no legal move means that player is stuck and the
-    // second player won.
-    if (isFull(nextBoard)) {
-      events.endGame(0);
-    } else if (legalMoves(nextBoard).length === 0) {
-      events.endGame(1);
+  placeDigit: {
+    validate: (board: Board, _, cell: number, digit: number) => isLegalPlacement(board, cell, digit),
+    apply: (board: Board, { events }: { ctx: Ctx; events: Events }, cell: number, digit: number) => {
+      const nextBoard = board.map((v, i) => (i === cell ? digit : v));
+      events.endTurn();
+      // The next player now faces nextBoard: a full grid means the first player
+      // won; an empty grid with no legal move means that player is stuck and the
+      // second player won.
+      if (isFull(nextBoard)) {
+        events.endGame(0);
+      } else if (legalMoves(nextBoard).length === 0) {
+        events.endGame(1);
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 };
 

--- a/src/components/games/matches-on-edges/board-client.tsx
+++ b/src/components/games/matches-on-edges/board-client.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { range } from 'lodash';
 import { useTranslation } from '../../../language';
 import { GameBoard, type BoardClientProps, useHoverPreview } from '../../strategy-game-factory';
-import { type Board, boundaryEdgesToPlace, currentWindowSize, legalMoves } from './helpers';
+import { type Board, boundaryEdgesToPlace, currentWindowSize } from './helpers';
 
 const Matchstick = ({ ghost = false }: { ghost?: boolean }) => (
   <div
@@ -30,7 +30,10 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
   const { n, edges } = board;
   const k = currentWindowSize(board);
-  const validStarts = new Set(legalMoves(board).map(m => m.a));
+  // A cell is a valid start exactly when the window it would open is a legal
+  // move — asked of the move itself rather than of the generator directly.
+  const isValidStart = (a: number) =>
+    k !== null && moves.placeWindow.isAllowed!(board, a, a + k - 1);
 
   const [selectedStart, setSelectedStart] = useState<number | null>(null);
   const { value: hoverStart, hoverProps } = useHoverPreview<number>(ctx.moveCount);
@@ -54,12 +57,12 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   );
 
   const selectStart = (a: number) => {
-    if (!canInteract || !validStarts.has(a)) return;
+    if (!isValidStart(a)) return;
     setSelectedStart(prev => (prev === a ? null : a));
   };
 
   const submit = () => {
-    if (!canInteract || selectedStart === null || k === null) return;
+    if (selectedStart === null || k === null) return;
     moves.placeWindow(board, selectedStart, selectedStart + k - 1);
   };
 
@@ -70,7 +73,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     <GameBoard className="min-w-0">
       <div className="flex items-center justify-center w-full">
         {range(n).flatMap(i => {
-          const selectable = canInteract && validStarts.has(i);
+          const selectable = isValidStart(i);
           const cell = (
             <button
               key={`cell-${i}`}

--- a/src/components/games/matches-on-edges/helpers.spec.ts
+++ b/src/components/games/matches-on-edges/helpers.spec.ts
@@ -5,6 +5,7 @@ import {
   blockMultiset,
   currentWindowSize,
   emptyBoard,
+  isWindowAllowed,
   legalMoves,
   moverWins,
   secondPlayerWins
@@ -127,5 +128,37 @@ describe('move mechanics', () => {
     const after = applyMove(board, 0, 0);
     expect(blockMultiset(after)).toEqual([]);
     expect(currentWindowSize(after)).toBeNull();
+  });
+});
+
+describe('isWindowAllowed', () => {
+  it('accepts exactly the windows the generator lists', () => {
+    const board = emptyBoard(10);
+    const listed = new Set(legalMoves(board).map(m => `${m.a},${m.b}`));
+    for (let a = 0; a < board.n; a++) {
+      for (let b = a; b < board.n; b++) {
+        expect(isWindowAllowed(board, a, b)).toBe(listed.has(`${a},${b}`));
+      }
+    }
+  });
+
+  it('refuses a window of the wrong size — the largest legal size is forced', () => {
+    const board = emptyBoard(10); // largest allowed window here is 8
+    expect(currentWindowSize(board)).toBe(8);
+    expect(isWindowAllowed(board, 0, 7)).toBe(true);
+    expect(isWindowAllowed(board, 0, 0)).toBe(false); // k = 1 is legal in general, but not largest
+    expect(isWindowAllowed(board, 0, 3)).toBe(false); // k = 4 likewise
+  });
+
+  it('refuses a window that runs off the board', () => {
+    const board = emptyBoard(10);
+    expect(isWindowAllowed(board, 3, 10)).toBe(false);
+    expect(isWindowAllowed(board, -1, 6)).toBe(false);
+  });
+
+  it('refuses every window once the game is over', () => {
+    const board = { n: 3, edges: [true, true] };
+    expect(currentWindowSize(board)).toBe(null);
+    expect(isWindowAllowed(board, 0, 0)).toBe(false);
   });
 });

--- a/src/components/games/matches-on-edges/helpers.ts
+++ b/src/components/games/matches-on-edges/helpers.ts
@@ -63,6 +63,14 @@ export const legalMoves = (board: Board): Move[] => {
   return moves;
 };
 
+// Is [a, b] one of the windows the player to move may play? The size is forced
+// (always the largest legal one), and the window must sit strictly inside a
+// single match-free block — so this is not a bounds check but the game's whole
+// move rule. Matching against the generated list keeps the two definitions from
+// drifting; there are only O(n) legal moves.
+export const isWindowAllowed = (board: Board, a: number, b: number): boolean =>
+  legalMoves(board).some(m => m.a === a && m.b === b);
+
 // The bounding edges of window [a, b] that are still free and would receive a
 // match. Used both to apply a move and to preview it in the UI.
 export const boundaryEdgesToPlace = (board: Board, a: number, b: number): number[] => {

--- a/src/components/games/matches-on-edges/matches-on-edges.tsx
+++ b/src/components/games/matches-on-edges/matches-on-edges.tsx
@@ -1,20 +1,25 @@
 import { strategyGameFactory, type Ctx, type Events } from '../../strategy-game-factory';
 import { BoardClient } from './board-client';
-import { type Board, applyMove, currentWindowSize, generateStartBoard, isTerminal } from './helpers';
+import {
+  type Board, applyMove, currentWindowSize, generateStartBoard, isTerminal, isWindowAllowed
+} from './helpers';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 
 const moves = {
   // Place the length-k subtable [a, b]: matches go on its free bounding edges.
   // If that leaves the other player with no legal move, they lose; otherwise the
   // turn passes.
-  placeWindow: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, a: number, b: number) => {
-    const nextBoard = applyMove(board, a, b);
-    if (isTerminal(nextBoard)) {
-      events.endGame(ctx.currentPlayer!);
-    } else {
-      events.endTurn();
+  placeWindow: {
+    validate: (board: Board, _, a: number, b: number) => isWindowAllowed(board, a, b),
+    apply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, a: number, b: number) => {
+      const nextBoard = applyMove(board, a, b);
+      if (isTerminal(nextBoard)) {
+        events.endGame(ctx.currentPlayer!);
+      } else {
+        events.endTurn();
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 };
 

--- a/src/components/games/triangle-coloring/legality.spec.ts
+++ b/src/components/games/triangle-coloring/legality.spec.ts
@@ -1,0 +1,32 @@
+import { isColoringAllowed } from './triangle-coloring';
+
+const [ALLOWED, COLORED, FORBIDDEN] = [1, 2, 3] as const;
+const board = (overrides: Record<number, 1 | 2 | 3> = {}) =>
+  Array.from({ length: 16 }, (_, i) => overrides[i] ?? ALLOWED);
+
+describe('isColoringAllowed', () => {
+  it('accepts a triangle that is still free', () => {
+    expect(isColoringAllowed(board(), 0)).toBe(true);
+    expect(isColoringAllowed(board(), 15)).toBe(true);
+  });
+
+  it('refuses a triangle someone has already coloured', () => {
+    expect(isColoringAllowed(board({ 5: COLORED }), 5)).toBe(false);
+  });
+
+  it('refuses a triangle forbidden by a coloured neighbour', () => {
+    // Colouring 5 forbids its side neighbours 1, 4 and 6.
+    const afterColouring5 = board({ 5: COLORED, 1: FORBIDDEN, 4: FORBIDDEN, 6: FORBIDDEN });
+    expect(isColoringAllowed(afterColouring5, 1)).toBe(false);
+    expect(isColoringAllowed(afterColouring5, 4)).toBe(false);
+    expect(isColoringAllowed(afterColouring5, 6)).toBe(false);
+    // A triangle that is not a neighbour stays free.
+    expect(isColoringAllowed(afterColouring5, 15)).toBe(true);
+  });
+
+  it('refuses a triangle that is not on the board', () => {
+    expect(isColoringAllowed(board(), -1)).toBe(false);
+    expect(isColoringAllowed(board(), 16)).toBe(false);
+    expect(isColoringAllowed(board(), 1.5)).toBe(false);
+  });
+});

--- a/src/components/games/triangle-coloring/triangle-coloring.tsx
+++ b/src/components/games/triangle-coloring/triangle-coloring.tsx
@@ -59,19 +59,16 @@ const triangles = [
   { id: 15, v: [9, 13, 14], neighbors: [14] }
 ];
 
-const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
+const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
   const getTrianglePoints = i => {
     const v = triangles[i].v;
     const [v0, v1, v2] = [vertices[v[0]], vertices[v[1]], vertices[v[2]]];
     return `${v0.cx},${v0.cy} ${v1.cx},${v1.cy} ${v2.cx},${v2.cy}`
   }
 
-  const isClickable = i => ctx.isClientMoveAllowed && board[i] === ALLOWED;
+  const isClickable = i => moves.colorTriangle.isAllowed!(board, i);
 
-  const colorTriangle = i => {
-    if (!isClickable(i)) return;
-    moves.colorTriangle(board, i);
-  }
+  const colorTriangle = i => moves.colorTriangle(board, i);
 
   const getColor = i => {
     if (board[i] === COLORED) return 'fill-blue-800';
@@ -113,18 +110,27 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   );
 };
 
+// A triangle may be coloured while it is still ALLOWED — neither coloured
+// already nor forbidden by a neighbour someone coloured earlier. Both players
+// colour from the same board, so whose turn it is does not enter into legality.
+export const isColoringAllowed = (board: Board, id: number): boolean =>
+  Number.isInteger(id) && id >= 0 && id < triangles.length && board[id] === ALLOWED;
+
 const moves = {
-  colorTriangle: (board: Board, { events }: { events: Events }, id: number) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard[id] = COLORED;
-    triangles[id].neighbors.forEach(n => {
-      nextBoard[n] = FORBIDDEN;
-    });
-    events.endTurn();
-    if (getAllowedMoves(nextBoard).length === 0) {
-      events.endGame();
+  colorTriangle: {
+    validate: (board: Board, _, id: number) => isColoringAllowed(board, id),
+    apply: (board: Board, { events }: { events: Events }, id: number) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard[id] = COLORED;
+      triangles[id].neighbors.forEach(n => {
+        nextBoard[n] = FORBIDDEN;
+      });
+      events.endTurn();
+      if (getAllowedMoves(nextBoard).length === 0) {
+        events.endGame();
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 };
 
@@ -142,7 +148,7 @@ const smartBotStrategy = ({ board, moves }: StrategyArgs<Board>) => {
 const getOptimalSmartBotMove = (board: Board) => {
   const allowedMoves = getAllowedMoves(board);
   const optimalPlace = shuffle(allowedMoves).find(i => {
-    const { nextBoard } = moves.colorTriangle(board, { events: dummyEvents }, i);
+    const { nextBoard } = moves.colorTriangle.apply(board, { events: dummyEvents }, i);
     return isWinningState(nextBoard);
   });
 
@@ -160,7 +166,7 @@ const isWinningState = (board: Board) => {
   }
 
   const optimalPlaceForOther = allowedPlacesForOther.find(i => {
-    const { nextBoard } = moves.colorTriangle(board, { events: dummyEvents }, i);
+    const { nextBoard } = moves.colorTriangle.apply(board, { events: dummyEvents }, i);
     return isWinningState(nextBoard);
   });
   return optimalPlaceForOther === undefined;


### PR DESCRIPTION
Continues the per-move `validate` migration started in #333. Three games where both players fill the same board, so none of these validators needs `ctx`.

## latin-square-filling

`isLegalPlacement` already was the rule — an empty cell, and a digit not already in its row or column. It is now wired up as `placeDigit`'s validator, and gains cell-bounds and digit-range checks first.

That second part is a real gap rather than defensive padding: a digit outside 1..3 used to pass the row/column scan, because no cell ever holds one. `isLegalPlacement(board, 0, 7)` returned `true`.

The board client's keypad derives its allowed digits from the move now instead of calling `legalDigits` directly.

## matches-on-edges

The window size is forced — always the largest legal one — and the window must sit strictly inside a match-free block. `isWindowAllowed` matches against the generated move list, which is the whole rule rather than a bounds check, and the list is only O(n) long. The board client's set of valid start cells now comes from the same place.

## triangle-coloring

`colorTriangle` accepts a triangle that is still `ALLOWED` — neither coloured already nor forbidden by a neighbour someone coloured earlier. The bot's lookahead reaches the move effect through `.apply`.

## Tests

New `legality.spec.ts` for `triangle-coloring`; blocks appended to the other two. Both appended blocks include an exhaustive cross-check that the validator accepts exactly the moves the game's own generator lists, and nothing else — which is what pins the `matches-on-edges` "largest size is forced" rule (`k = 1` and `k = 4` are legal sizes in general but rejected when 8 is available).

Full suite: 96 files, 637 tests, all passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSxP4EAjGt4vDBxsQt32c)_