### PR TITLE
Move legality layer: chess-ducks, amor-and-cupido, bank-robbers

### DIFF
--- a/src/components/games/amor-and-cupido/amor-and-cupido.tsx
+++ b/src/components/games/amor-and-cupido/amor-and-cupido.tsx
@@ -1,18 +1,21 @@
 import { strategyGameFactory, type Ctx, type Events } from '../../strategy-game-factory';
-import { type Board, completesTriangle, generateStartBoard } from './helpers';
+import { type Board, completesTriangle, generateStartBoard, isClaimAllowed } from './helpers';
 import { smartBotStrategy } from './bot-strategy';
 import { BoardClient } from './board-client';
 
 const moves = {
-  claimEdge: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, edge: number) => {
-    const nextBoard = board.slice();
-    nextBoard[edge] = ctx.currentPlayer;
-    if (completesTriangle(board, ctx.currentPlayer!, edge)) {
-      events.endGame(ctx.currentPlayer);
-    } else {
-      events.endTurn();
+  claimEdge: {
+    validate: (board: Board, _, edge: number) => isClaimAllowed(board, edge),
+    apply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, edge: number) => {
+      const nextBoard = board.slice();
+      nextBoard[edge] = ctx.currentPlayer;
+      if (completesTriangle(board, ctx.currentPlayer!, edge)) {
+        events.endGame(ctx.currentPlayer);
+      } else {
+        events.endTurn();
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 };
 

--- a/src/components/games/amor-and-cupido/board-client.tsx
+++ b/src/components/games/amor-and-cupido/board-client.tsx
@@ -16,8 +16,6 @@ const ownerStroke = (owner: number | null): string => {
 export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const isMoveAllowed = (edge: number) => moves.claimEdge.isAllowed!(board, edge);
 
-  const clickEdge = (edge: number) => moves.claimEdge(board, edge);
-
   const winningEdges =
     ctx.winnerIndex !== null ? findWinningTriangle(board, ctx.winnerIndex) : null;
 
@@ -46,8 +44,8 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
                 }`}
                 strokeWidth={4}
                 strokeLinecap="round"
-                onClick={() => clickEdge(edge)}
-                onKeyUp={event => { if (event.key === 'Enter') clickEdge(edge); }}
+                onClick={() => moves.claimEdge(board, edge)}
+                onKeyUp={event => { if (event.key === 'Enter') moves.claimEdge(board, edge); }}
                 tabIndex={isMoveAllowed(edge) ? 0 : undefined}
                 role={isMoveAllowed(edge) ? 'button' : undefined}
                 aria-label={

--- a/src/components/games/amor-and-cupido/board-client.tsx
+++ b/src/components/games/amor-and-cupido/board-client.tsx
@@ -14,13 +14,9 @@ const ownerStroke = (owner: number | null): string => {
 };
 
 export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
-  const isMoveAllowed = (edge: number) =>
-    ctx.isClientMoveAllowed && board[edge] === null;
+  const isMoveAllowed = (edge: number) => moves.claimEdge.isAllowed!(board, edge);
 
-  const clickEdge = (edge: number) => {
-    if (!isMoveAllowed(edge)) return;
-    moves.claimEdge(board, edge);
-  };
+  const clickEdge = (edge: number) => moves.claimEdge(board, edge);
 
   const winningEdges =
     ctx.winnerIndex !== null ? findWinningTriangle(board, ctx.winnerIndex) : null;

--- a/src/components/games/amor-and-cupido/helpers.spec.ts
+++ b/src/components/games/amor-and-cupido/helpers.spec.ts
@@ -1,6 +1,6 @@
 import {
   EDGES, TRIANGLES, edgeIndex, getAllowedMoves, completesTriangle, findWinningTriangle,
-  generateStartBoard
+  generateStartBoard, isClaimAllowed
 } from './helpers';
 
 describe('helpers geometry', () => {
@@ -54,5 +54,36 @@ describe('findWinningTriangle', () => {
       [edgeIndex[3][4], edgeIndex[3][5], edgeIndex[4][5]].sort((a, b) => a - b)
     );
     expect(findWinningTriangle(board, 1)).toBeNull();
+  });
+});
+
+describe('isClaimAllowed', () => {
+  it('accepts a pair nobody has claimed', () => {
+    expect(isClaimAllowed(generateStartBoard(), 0)).toBe(true);
+    expect(isClaimAllowed(generateStartBoard(), 14)).toBe(true);
+  });
+
+  it('refuses a pair either player already owns', () => {
+    const board = generateStartBoard();
+    board[3] = 0;
+    board[7] = 1;
+    expect(isClaimAllowed(board, 3)).toBe(false);
+    expect(isClaimAllowed(board, 7)).toBe(false);
+  });
+
+  it('refuses a pair that does not exist', () => {
+    expect(isClaimAllowed(generateStartBoard(), -1)).toBe(false);
+    expect(isClaimAllowed(generateStartBoard(), 15)).toBe(false);
+    expect(isClaimAllowed(generateStartBoard(), 1.5)).toBe(false);
+  });
+
+  it('accepts exactly the edges the generator lists', () => {
+    const board = generateStartBoard();
+    board[2] = 0;
+    board[5] = 1;
+    const listed = new Set(getAllowedMoves(board));
+    for (let e = 0; e < EDGES.length; e++) {
+      expect(isClaimAllowed(board, e)).toBe(listed.has(e));
+    }
   });
 });

--- a/src/components/games/amor-and-cupido/helpers.ts
+++ b/src/components/games/amor-and-cupido/helpers.ts
@@ -40,6 +40,11 @@ export const generateStartBoard = (): Board => new Array(EDGES.length).fill(null
 export const getAllowedMoves = (board: Board): number[] =>
   board.flatMap((owner, e) => (owner === null ? [e] : []));
 
+// A pair may be claimed while nobody owns it. Both players claim from the same
+// 15 edges, so whose turn it is does not enter into legality.
+export const isClaimAllowed = (board: Board, edge: number): boolean =>
+  Number.isInteger(edge) && edge >= 0 && edge < EDGES.length && board[edge] === null;
+
 // Would claiming `edge` for `player` complete a triangle entirely in their
 // colour? A move can only ever complete the mover's own triangle (you only add
 // to your own colour), so this is the single win condition. `edge` itself is

--- a/src/components/games/bank-robbers/bank-robbers.tsx
+++ b/src/components/games/bank-robbers/bank-robbers.tsx
@@ -20,8 +20,6 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
 
   const isAllowedBank = index => isRobbable(board, index);
 
-  const clickBank = (index) => moves.rob(board, index);
-
   const getBankColor = index => {
     if (index === board.lastMove) return "fill-red-800 stroke-red-600";
     if (board.circle[index] === false) return "fill-red-800";
@@ -54,9 +52,9 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
               r="4%"
               className={`${getBankColor(index)}`}
               strokeWidth={index === board.lastMove ? "1%" : "0"}
-              onClick={() => clickBank(index)}
+              onClick={() => moves.rob(board, index)}
               onKeyUp={(event) => {
-                if (event.key === 'Enter') clickBank(index);
+                if (event.key === 'Enter') moves.rob(board, index);
               }}
               tabIndex={isAllowedMove(index) ? 0 : undefined}
               role={isAllowedMove(index) ? 'button' : undefined}

--- a/src/components/games/bank-robbers/bank-robbers.tsx
+++ b/src/components/games/bank-robbers/bank-robbers.tsx
@@ -6,26 +6,21 @@ import { smartBotStrategy } from './bot-strategy';
 
 export type Board = { circle: boolean[], lastMove: number | null, firstMove: number | null }
 
-const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
+const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
   const getCoords = (index) => {
     const step = Math.PI * 2/board.circle.length;
     const angle = index * step + (board.firstMove === null ? 0 : board.firstMove * step);
     return { x: 55 + 50 * Math.cos(angle), y: 55 + 50 * Math.sin(angle) };
   };
 
-  const isAllowedMove = index => {
-    if (!ctx.isClientMoveAllowed) return false;
-    return isAllowedBank(index);
-  }
+  // Two different questions: `isAllowedBank` marks the banks that could be
+  // robbed from this position — shown in green whoever is on turn — while
+  // `isAllowedMove` additionally requires that it is this client's move.
+  const isAllowedMove = index => moves.rob.isAllowed!(board, index);
 
-  const isAllowedBank = index => {
-    return getAllowedBanks(board).includes(index);
-  }
+  const isAllowedBank = index => isRobbable(board, index);
 
-  const clickBank = (index) => {
-    if (!isAllowedMove(index)) return;
-    moves.rob(board, index);
-  }
+  const clickBank = (index) => moves.rob(board, index);
 
   const getBankColor = index => {
     if (index === board.lastMove) return "fill-red-800 stroke-red-600";
@@ -75,22 +70,32 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 };
 
 const moves = {
-  rob: (board: Board, { events }: { events: Events }, index) => {
-    const nextBoard = cloneDeep(board);
-    // so that ai strategy can be simpler: first move is always the same
-    const transformedMove = board.firstMove === null ? 0 : index;
-    if (board.firstMove === null) {
-      nextBoard.firstMove = index;
+  rob: {
+    validate: (board: Board, _, index) => isRobbable(board, index),
+    apply: (board: Board, { events }: { events: Events }, index) => {
+      const nextBoard = cloneDeep(board);
+      // so that ai strategy can be simpler: first move is always the same
+      const transformedMove = board.firstMove === null ? 0 : index;
+      if (board.firstMove === null) {
+        nextBoard.firstMove = index;
+      }
+      nextBoard.lastMove = transformedMove;
+      nextBoard.circle[transformedMove] = false;
+      events.endTurn();
+      if (getAllowedBanks(nextBoard).length === 0) {
+        events.endGame();
+      }
+      return { nextBoard };
     }
-    nextBoard.lastMove = transformedMove;
-    nextBoard.circle[transformedMove] = false;
-    events.endTurn();
-    if (getAllowedBanks(nextBoard).length === 0) {
-      events.endGame();
-    }
-    return { nextBoard };
   }
 }
+
+// A bank may be robbed while it still stands and at least one of its two
+// neighbours does too — a bank whose neighbours are both gone has police lying
+// in wait. Both gangs rob from the same circle, so whose turn it is does not
+// enter into legality.
+export const isRobbable = (board: Board, index: number): boolean =>
+  getAllowedBanks(board).includes(index);
 
 const getAllowedBanks = (board: Board) => {
   return range(board.circle.length).filter(i => {

--- a/src/components/games/bank-robbers/legality.spec.ts
+++ b/src/components/games/bank-robbers/legality.spec.ts
@@ -1,0 +1,43 @@
+import { isRobbable, type Board } from './bank-robbers';
+
+const board = (standing: boolean[]): Board => ({
+  circle: standing,
+  lastMove: null,
+  firstMove: 0
+});
+
+describe('isRobbable', () => {
+  it('accepts any standing bank while the circle is untouched', () => {
+    const untouched = board(Array(7).fill(true));
+    for (let i = 0; i < 7; i++) expect(isRobbable(untouched, i)).toBe(true);
+  });
+
+  it('refuses a bank that has already been robbed', () => {
+    const b = board([true, false, true, true, true, true, true]);
+    expect(isRobbable(b, 1)).toBe(false);
+  });
+
+  it('refuses a bank whose two neighbours are both gone — the police wait there', () => {
+    const b = board([false, true, false, true, true, true, true]);
+    expect(isRobbable(b, 1)).toBe(false);
+    // Its own neighbours still standing, so this one is fine.
+    expect(isRobbable(b, 4)).toBe(true);
+  });
+
+  it('accepts a bank with just one neighbour still standing', () => {
+    const b = board([false, true, true, true, true, true, true]);
+    expect(isRobbable(b, 1)).toBe(true);
+  });
+
+  it('treats the circle as a circle — index 0 and the last bank are neighbours', () => {
+    const b = board([true, false, true, true, true, true, false]);
+    // Bank 0's neighbours are 6 and 1, both robbed.
+    expect(isRobbable(b, 0)).toBe(false);
+  });
+
+  it('refuses a bank that is not on the circle', () => {
+    const b = board(Array(7).fill(true));
+    expect(isRobbable(b, -1)).toBe(false);
+    expect(isRobbable(b, 7)).toBe(false);
+  });
+});

--- a/src/components/games/chess-ducks/bot-strategy.ts
+++ b/src/components/games/chess-ducks/bot-strategy.ts
@@ -46,7 +46,7 @@ const getOptimalSmartBotMove = (board: Board): Field => {
     // shuffle + find has the same effect as filter + sample: find a random
     // from the optimal moves
     const optimalPlace = shuffle(allowedMoves).find(({ row, col }) => {
-      const { nextBoard } = moves.placeDuck(board, { events: dummyEvents }, { row, col });
+      const { nextBoard } = moves.placeDuck.apply(board, { events: dummyEvents }, { row, col });
       return isWinningState(nextBoard);
     });
 
@@ -126,7 +126,7 @@ const isWinningState = (board: Board): boolean => {
   const allowedPlacesForOther = getAllowedMoves(board);
 
   const optimalPlaceForOther = allowedPlacesForOther.find(({ row, col }) => {
-    const { nextBoard } = moves.placeDuck(board, { events: dummyEvents }, { row, col });
+    const { nextBoard } = moves.placeDuck.apply(board, { events: dummyEvents }, { row, col });
     return isWinningState(nextBoard);
   });
   return optimalPlaceForOther === undefined;

--- a/src/components/games/chess-ducks/chess-ducks.tsx
+++ b/src/components/games/chess-ducks/chess-ducks.tsx
@@ -16,10 +16,6 @@ const generateStartBoard = (ROWS: number, COLS: number) => (): Board => {
 
 // Board-driven: reads its dimensions from the board, so it renders any size.
 const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
-  const clickField = (field: Field) => moves.placeDuck(board, field);
-
-  const isMoveAllowed = (targetField: Field) => moves.placeDuck.isAllowed!(board, targetField);
-
   const isForbidden = ({ row, col }: Field) => {
     return board[row][col] === FORBIDDEN;
   };
@@ -44,8 +40,8 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
                 >
                   <button
                     className="w-full aspect-square p-[5%]"
-                    disabled={!isMoveAllowed({ row, col })}
-                    onClick={() => clickField({ row, col })}
+                    disabled={!moves.placeDuck.isAllowed!(board, { row, col })}
+                    onClick={() => moves.placeDuck(board, { row, col })}
                   >
                     {isDuck({ row, col }) && (
                       <svg className="w-full aspect-square">

--- a/src/components/games/chess-ducks/chess-ducks.tsx
+++ b/src/components/games/chess-ducks/chess-ducks.tsx
@@ -1,9 +1,8 @@
 import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
-import { some, range, isEqual, sample } from 'lodash';
+import { range, sample } from 'lodash';
 import { DuckSvg } from './rubber-duck-svg';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import {
-  getAllowedMoves,
   DUCK,
   FORBIDDEN,
   moves,
@@ -16,17 +15,10 @@ const generateStartBoard = (ROWS: number, COLS: number) => (): Board => {
 };
 
 // Board-driven: reads its dimensions from the board, so it renders any size.
-const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
-  const clickField = (field: Field) => {
-    if (!isMoveAllowed(field)) return;
+const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
+  const clickField = (field: Field) => moves.placeDuck(board, field);
 
-    moves.placeDuck(board, field);
-  };
-
-  const isMoveAllowed = (targetField: Field) => {
-    if (!ctx.isClientMoveAllowed) return false;
-    return some(getAllowedMoves(board), field => isEqual(field, targetField));
-  };
+  const isMoveAllowed = (targetField: Field) => moves.placeDuck.isAllowed!(board, targetField);
 
   const isForbidden = ({ row, col }: Field) => {
     return board[row][col] === FORBIDDEN;

--- a/src/components/games/chess-ducks/helpers.ts
+++ b/src/components/games/chess-ducks/helpers.ts
@@ -33,15 +33,24 @@ export const markForbiddenFields = (board: Board, { row, col }: Field): void => 
   }
 };
 
+// A duck goes on a field that is still free — neither holding a duck nor
+// attacked by one. Both players place on the same board, so whose turn it is
+// does not enter into legality.
+export const isPlacementAllowed = (board: Board, field: Field): boolean =>
+  !!field && board[field.row]?.[field.col] === null;
+
 export const moves = {
-  placeDuck: (board: Board, { events }: { events: Events }, { row, col }: Field) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard[row][col] = DUCK;
-    markForbiddenFields(nextBoard, { row, col });
-    events.endTurn();
-    if (getAllowedMoves(nextBoard).length === 0) {
-      events.endGame();
+  placeDuck: {
+    validate: (board: Board, _, field: Field) => isPlacementAllowed(board, field),
+    apply: (board: Board, { events }: { events: Events }, { row, col }: Field) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard[row][col] = DUCK;
+      markForbiddenFields(nextBoard, { row, col });
+      events.endTurn();
+      if (getAllowedMoves(nextBoard).length === 0) {
+        events.endGame();
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 };

--- a/src/components/games/chess-ducks/legality.spec.ts
+++ b/src/components/games/chess-ducks/legality.spec.ts
@@ -1,0 +1,43 @@
+import { DUCK, FORBIDDEN, isPlacementAllowed, getAllowedMoves, type Board } from './helpers';
+
+const emptyBoard = (rows: number, cols: number): Board =>
+  Array.from({ length: rows }, () => Array.from({ length: cols }, () => null));
+
+describe('isPlacementAllowed', () => {
+  it('accepts a free field', () => {
+    expect(isPlacementAllowed(emptyBoard(4, 6), { row: 0, col: 0 })).toBe(true);
+    expect(isPlacementAllowed(emptyBoard(4, 6), { row: 3, col: 5 })).toBe(true);
+  });
+
+  it('refuses a field that already holds a duck', () => {
+    const board = emptyBoard(4, 6);
+    board[1][2] = DUCK;
+    expect(isPlacementAllowed(board, { row: 1, col: 2 })).toBe(false);
+  });
+
+  it('refuses a field a duck attacks', () => {
+    const board = emptyBoard(4, 6);
+    board[1][2] = FORBIDDEN;
+    expect(isPlacementAllowed(board, { row: 1, col: 2 })).toBe(false);
+  });
+
+  it('refuses a field off the board', () => {
+    const board = emptyBoard(4, 6);
+    expect(isPlacementAllowed(board, { row: -1, col: 0 })).toBe(false);
+    expect(isPlacementAllowed(board, { row: 4, col: 0 })).toBe(false);
+    expect(isPlacementAllowed(board, { row: 0, col: 6 })).toBe(false);
+  });
+
+  it('accepts exactly the fields the generator lists', () => {
+    const board = emptyBoard(4, 6);
+    board[1][2] = DUCK;
+    board[0][2] = FORBIDDEN;
+    board[1][1] = FORBIDDEN;
+    const listed = new Set(getAllowedMoves(board).map(f => `${f.row},${f.col}`));
+    for (let row = 0; row < 4; row++) {
+      for (let col = 0; col < 6; col++) {
+        expect(isPlacementAllowed(board, { row, col })).toBe(listed.has(`${row},${col}`));
+      }
+    }
+  });
+});


### PR DESCRIPTION
Continues the per-move `validate` migration started in #333. Three games where each claim takes a spot on a shared board and closes off others, so none of these validators needs `ctx`.

| Game | Legality |
|---|---|
| chess-ducks | a field neither holding a duck nor attacked by one |
| amor-and-cupido | a pair nobody has claimed |
| bank-robbers | a standing bank with at least one neighbour still standing |

## chess-ducks

`isMoveAllowed` in the board client was a linear scan of `getAllowedMoves` per cell; it now asks the move, which is also a constant-time lookup on the board. The bot's lookahead reaches the move effect through `.apply`.

## bank-robbers

Its board client keeps two separate questions, same shape as `remove-divisor-multiple` in #354: `isAllowedBank` colours in green what could be robbed from this position, shown whoever is on turn, while the click targets and their `tabIndex`/`role` are gated on `moves.rob.isAllowed`. Collapsing the two would have greyed the hints out during the opponent's turn.

## Tests

New `legality.spec.ts` for `chess-ducks` and `bank-robbers`; a block appended to `amor-and-cupido`'s existing helpers spec. Two things pinned that were previously only implicit: that the bank circle wraps (bank 0's neighbours are the last bank and bank 1), and that each validator accepts exactly the moves its game's own generator lists.

Full suite: 97 files, 641 tests, all passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSxP4EAjGt4vDBxsQt32c)_