### PR TITLE
Move legality layer: the two distinct-squares games

### DIFF
--- a/src/components/games/distinct-squares/five-squares/five-squares.tsx
+++ b/src/components/games/distinct-squares/five-squares/five-squares.tsx
@@ -37,8 +37,6 @@ const moves = {
 }
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
-  const placePiece = (id: number) => moves.addPiece(board, id);
-
   const turnState = ctx.turnState as TurnState;
   const firstPlacedSquareIndex = turnState?.firstPlacedSquareIndex ?? null;
   const showDimmedDisc = ctx.isClientMoveAllowed && firstPlacedSquareIndex !== null;
@@ -50,7 +48,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
         <button
           key={id}
           disabled={!moves.addPiece.isAllowed!(board, id)}
-          onClick={() => placePiece(id)}
+          onClick={() => moves.addPiece(board, id)}
           className="aspect-square border-r-4 border-b-4 p-[3%]"
         >
           {range(board[id]).map((i) =>

--- a/src/components/games/distinct-squares/five-squares/five-squares.tsx
+++ b/src/components/games/distinct-squares/five-squares/five-squares.tsx
@@ -3,6 +3,7 @@ import {
   strategyGameFactory, type Ctx, type Events, type BoardClientProps, GameBoard
 } from '../../../strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
+import { isPlacementAllowed } from '../helpers';
 
 export type Board = number[]
 type TurnState = { firstPlacedSquareIndex: number } | null
@@ -15,28 +16,28 @@ const generateStartBoard = (): Board => {
 };
 
 const moves = {
-  addPiece: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, pileId: number) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard[pileId] += 1;
-    if (ctx.currentPlayer === 1 && [3, 6, 9].includes(sum(nextBoard))) {
-      events.setTurnState({ firstPlacedSquareIndex: pileId });
+  addPiece: {
+    validate: (board: Board, _, pileId: number) => isPlacementAllowed(board, pileId),
+    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, pileId: number) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard[pileId] += 1;
+      if (ctx.currentPlayer === 1 && [3, 6, 9].includes(sum(nextBoard))) {
+        events.setTurnState({ firstPlacedSquareIndex: pileId });
+        return { nextBoard };
+      }
+      events.setTurnState(null);
+      events.endTurn();
+      if (sum(nextBoard) === 10) {
+        const winnerIndex = isEqual(cloneDeep(nextBoard).sort(), [0, 1, 2, 3, 4]) ? 1 : 0;
+        events.endGame(winnerIndex);
+      }
       return { nextBoard };
     }
-    events.setTurnState(null);
-    events.endTurn();
-    if (sum(nextBoard) === 10) {
-      const winnerIndex = isEqual(cloneDeep(nextBoard).sort(), [0, 1, 2, 3, 4]) ? 1 : 0;
-      events.endGame(winnerIndex);
-    }
-    return { nextBoard };
   }
 }
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
-  const placePiece = (id: number) => {
-    if (!ctx.isClientMoveAllowed) return;
-    moves.addPiece(board, id);
-  };
+  const placePiece = (id: number) => moves.addPiece(board, id);
 
   const turnState = ctx.turnState as TurnState;
   const firstPlacedSquareIndex = turnState?.firstPlacedSquareIndex ?? null;
@@ -48,7 +49,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
       {range(board.length).map(id =>
         <button
           key={id}
-          disabled={!ctx.isClientMoveAllowed}
+          disabled={!moves.addPiece.isAllowed!(board, id)}
           onClick={() => placePiece(id)}
           className="aspect-square border-r-4 border-b-4 p-[3%]"
         >

--- a/src/components/games/distinct-squares/helpers.spec.ts
+++ b/src/components/games/distinct-squares/helpers.spec.ts
@@ -1,0 +1,24 @@
+import { isPlacementAllowed } from './helpers';
+
+describe('isPlacementAllowed', () => {
+  it('accepts every square of the board, however many pieces it already holds', () => {
+    const board = [3, 0, 1, 0, 2];
+    for (let i = 0; i < board.length; i++) expect(isPlacementAllowed(board, i)).toBe(true);
+  });
+
+  it('refuses an index past the last square', () => {
+    expect(isPlacementAllowed([0, 0, 0, 0], 4)).toBe(false);
+    expect(isPlacementAllowed([0, 0, 0, 0, 0], 5)).toBe(false);
+  });
+
+  it('reads the square count off the board, so the two games differ only in size', () => {
+    expect(isPlacementAllowed([0, 0, 0, 0], 4)).toBe(false); // two-times-two
+    expect(isPlacementAllowed([0, 0, 0, 0, 0], 4)).toBe(true); // five-squares
+  });
+
+  it('refuses a negative or non-integer index', () => {
+    expect(isPlacementAllowed([0, 0, 0, 0], -1)).toBe(false);
+    expect(isPlacementAllowed([0, 0, 0, 0], 1.5)).toBe(false);
+    expect(isPlacementAllowed([0, 0, 0, 0], NaN)).toBe(false);
+  });
+});

--- a/src/components/games/distinct-squares/helpers.ts
+++ b/src/components/games/distinct-squares/helpers.ts
@@ -1,0 +1,10 @@
+// Both distinct-squares games place a piece on any square, at any time — there
+// is no notion of a square being full or blocked. So the only thing legality
+// has to say is that the square exists.
+//
+// That is worth saying: `apply` does `nextBoard[squareId] += 1`, and on an
+// out-of-range index that writes NaN and grows the array rather than doing
+// nothing. The two games differ only in how many squares they have, which the
+// predicate reads off the board.
+export const isPlacementAllowed = (board: number[], squareId: number): boolean =>
+  Number.isInteger(squareId) && squareId >= 0 && squareId < board.length;

--- a/src/components/games/distinct-squares/two-times-two/two-times-two.tsx
+++ b/src/components/games/distinct-squares/two-times-two/two-times-two.tsx
@@ -23,17 +23,14 @@ const moves = {
   }
 }
 
-const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
-  const placePiece = id => moves.addPiece(board, id);
-
-  return (
+const BoardClient = ({ board, moves }: BoardClientProps<Board>) => (
   <GameBoard>
     <div className="grid grid-cols-2 border-t-2 border-l-2">
       {range(board.length).map(id =>
         <button
           key={id}
           disabled={!moves.addPiece.isAllowed!(board, id)}
-          onClick={() => placePiece(id)}
+          onClick={() => moves.addPiece(board, id)}
           className="aspect-square border-r-2 border-b-2 p-[4%]"
         >
           {range(board[id]).map((i) =>
@@ -50,8 +47,7 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
       )}
     </div>
   </GameBoard>
-  );
-};
+);
 
 const getPlayerStepDescription = () => ({
   hu: 'Kattints arra a mezőre, ahova korongot szeretnél lerakni.',

--- a/src/components/games/distinct-squares/two-times-two/two-times-two.tsx
+++ b/src/components/games/distinct-squares/two-times-two/two-times-two.tsx
@@ -1,29 +1,30 @@
 import { range, sum, isEqual, cloneDeep } from 'lodash';
 import { strategyGameFactory, type Events, type BoardClientProps, GameBoard } from '../../../strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
+import { isPlacementAllowed } from '../helpers';
 
 export type Board = number[]
 
 const generateStartBoard = (): Board => [0, 0, 0, 0];
 
 const moves = {
-  addPiece: (board: Board, { events }: { events: Events }, pileId) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard[pileId] += 1;
-    events.endTurn();
-    if (sum(nextBoard) === 6) {
-      const winnerIndex = isEqual(cloneDeep(nextBoard).sort(), [0, 1, 2, 3]) ? 1 : 0;
-      events.endGame(winnerIndex);
+  addPiece: {
+    validate: (board: Board, _, pileId) => isPlacementAllowed(board, pileId),
+    apply: (board: Board, { events }: { events: Events }, pileId) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard[pileId] += 1;
+      events.endTurn();
+      if (sum(nextBoard) === 6) {
+        const winnerIndex = isEqual(cloneDeep(nextBoard).sort(), [0, 1, 2, 3]) ? 1 : 0;
+        events.endGame(winnerIndex);
+      }
+      return { nextBoard };
     }
-    return { nextBoard };
   }
 }
 
-const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
-  const placePiece = id => {
-    if (!ctx.isClientMoveAllowed) return;
-    moves.addPiece(board, id);
-  };
+const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
+  const placePiece = id => moves.addPiece(board, id);
 
   return (
   <GameBoard>
@@ -31,7 +32,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
       {range(board.length).map(id =>
         <button
           key={id}
-          disabled={!ctx.isClientMoveAllowed}
+          disabled={!moves.addPiece.isAllowed!(board, id)}
           onClick={() => placePiece(id)}
           className="aspect-square border-r-2 border-b-2 p-[4%]"
         >


### PR DESCRIPTION
a piece may go on any square at any time, so there was "no non-trivial legality". But the square still has to exist, and an out-of-range index is not harmless here:

```js
nextBoard[pileId] += 1;   // pileId = 9 on a 5-square board
```

`undefined + 1` is `NaN`, so that writes `NaN` at index 9 and grows the array — the board is corrupted rather than the move being ignored. That is exactly what the engine's check exists to stop, and exactly the case a future server-side check would have to reject.

`isPlacementAllowed` is identical in both games and reads the square count off the board, so it lives in a shared `helpers.ts` for the sibling pair (four squares for `two-times-two`, five for `five-squares`).


## Tests

A `helpers.spec.ts` for the pair, including that the same predicate gives different answers for the two board sizes (index 4 is a square in `five-squares`, not in `two-times-two`).

Full suite: 96 files, 630 tests, all passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSxP4EAjGt4vDBxsQt32c)_