### PR TITLE
Add outcome-returning move contract (apply) + 3 pilot game migrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ strategyGameFactory({
   },
   BoardClient,                 // React component receiving { board, ctx, events, moves }
   gameplay: {
-    moves,                     // { [name]: moveFn | { legacyApply, validate? } } — see below
+    moves,                     // { [name]: { apply, validate? } | legacyFn | { legacyApply, validate? } } — see below
     endOfTurnMove?,            // optional move name auto-executed after moves with autoEndOfTurn: true
   },
   variants,                    // see below
@@ -94,15 +94,33 @@ omitted on a variant, the default variant's `botStrategy` is used as fallback.
 If multiple variants are provided, exactly one must be `isDefault: true`. A
 single-entry array needs no `isDefault` flag.
 
-**`moves`** — each move is either a plain move function
-`(board, { ctx, events }, ...args) => { nextBoard }` (shorthand), or a long-form
-object `{ legacyApply, validate? }` colocating it with a legality predicate. Always
-pass the current `board` as first arg when chaining moves within a turn. `legacyApply`
-trusts its arguments and applies them blindly; legality is enforced by
-`validate` (below) and/or the `BoardClient`'s `disabled` gating.
+**`moves`** — each move is one of three shapes, all mixable within one game:
+
+- **`{ apply, validate? }` (preferred, use for new games)** — an
+  outcome-returning move `(board, { ctx }, ...args) => MoveOutcome`. It gets no
+  `events`; everything it causes is data in the returned `MoveOutcome`:
+  `{ nextBoard, isTurnEnd?, nextTurnState?, gameEnd?, autoEndOfTurn? }`.
+  `isTurnEnd: true` passes the turn (omitted = further moves follow in the same
+  turn); `gameEnd: { winnerIndex }` ends the game with an always-explicit winner
+  (`ctx.currentPlayer!` when the mover wins) and never flips `currentPlayer` —
+  `isTurnEnd`/`autoEndOfTurn` alongside it are a dev-mode error;
+  `nextTurnState` sets `ctx.turnState` (`null` clears, omitted keeps);
+  `autoEndOfTurn: true` schedules `endOfTurnMove`. Being `events`-free makes the
+  move a pure reducer — the piece a future authoritative competition server
+  and the planned external state store both need (see issue #313).
+- **legacy plain move function** `(board, { ctx, events }, ...args) =>
+  { nextBoard }` (shorthand), or **legacy `{ legacyApply, validate? }`** — the
+  move calls `events.endTurn()` / `events.endGame(winnerIndex?)` imperatively
+  (bare `endGame()` credits the mover). Existing games migrate to the
+  outcome-returning `apply` one by one; don't add new legacy moves.
+
+Always pass the current `board` as first arg when chaining moves within a turn.
+Neither form validates its arguments — they apply them blindly; legality is
+enforced by `validate` (below) and/or the `BoardClient`'s `disabled` gating.
 
 **`validate`** (optional, per move) — a pure, side-effect-free legality predicate
-`(board, { ctx }, ...args) => boolean` sitting right next to its `legacyApply`. When
+`(board, { ctx }, ...args) => boolean` sitting right next to its
+`apply`/`legacyApply`. When
 present, the engine rejects any dispatch whose args fail it (in dev it throws
 loudly to surface the bug; in prod it warns, fires an `illegal-move` analytics
 event, and no-ops so a stray call cannot corrupt the board). The function
@@ -142,6 +160,10 @@ the raw `validate`/helpers instead.
   getPlayerStepDescription
 
 **`events`**: `endTurn()`, `endGame(winnerIndex?)`, `setTurnState(stage)`.
+`endTurn`/`endGame` are for legacy moves only (outcome-returning moves
+express both in their return value); `setTurnState` also remains current for
+`BoardClient` components that keep mid-turn UI state in `ctx.turnState`
+(several games call it from UI code — that usage does not migrate).
 
 ### Known limitation: React state staleness in multi-move turns
 
@@ -157,9 +179,11 @@ Two workarounds exist for two symptoms of this one root cause:
   loudly when violated (visibly wrong moves).
 - **`ctx.turnState`** — shadowed engine-side: move validation reads `ctx`
   through a ref that is re-synced every render *and* patched synchronously by
-  `events.setTurnState`, because a chained dispatch (e.g. a bot's 0-delay
-  `setTimeout`) can fire before React re-renders. See `ctxRef` in
-  `strategy-game-factory.tsx` and the two-phase bot regression tests.
+  `events.setTurnState` (the engine routes an outcome-returning `apply`'s returned
+  `nextTurnState` through the same setter), because a chained dispatch (e.g. a
+  bot's 0-delay `setTimeout`) can fire before React re-renders. See `ctxRef` in
+  `strategy-game-factory.tsx` and the two-phase bot regression tests (legacy
+  and v2 variants).
 
 The asymmetry matters when reviewing new games: a validator that depends on
 some *other* mid-turn-changing `ctx` field (e.g. `moveCount`) would need the
@@ -187,6 +211,8 @@ long-form move shape already does — and build the rest in-repo.
 - Starting positions representative of the game's complexity; each player wins
   with ~50% probability across random starting boards
 - Player cannot win with a non-winning strategy (i.e. AI is truly optimal)
+- Moves use the outcome-returning `apply` form (no `events` in moves; see
+  `five-connected-fields`, `coins-in-3-piles`, `hunyadi-and-the-janissaries`)
 - Moves with non-trivial legality define `validate` (single source of truth for
   the engine, the `BoardClient`'s `disabled` state and the bot)
 - Clear what the player should do next (`getPlayerStepDescription`)

--- a/README.md
+++ b/README.md
@@ -147,13 +147,14 @@ choosing a role, restart game) are extracted to a `strategyGameFactory`.
 type Board = number;
 
 const moves = {
-  addNumber: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, number) => {
-    const nextBoard = board + number;
-    events.endTurn();
-    if (nextBoard >= 20) {
-      events.endGame(1 - ctx.currentPlayer)
+  addNumber: {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, number) => {
+      const nextBoard = board + number;
+      if (nextBoard >= 20) {
+        return { nextBoard, gameEnd: { winnerIndex: 1 - ctx.currentPlayer! } };
+      }
+      return { nextBoard, isTurnEnd: true };
     }
-    return { nextBoard }
   }
 };
 
@@ -202,14 +203,31 @@ Conceptually a `move` is a unit that captures a change in the board initiated by
 a player. Moves help ensure that the game is played according to rules by all
 players.
 
-Technically the `legacyApply` function of a move takes board as first param, `{
-ctx, events }` as second param and may receive any number of additional params.
-The second param is provided by the framework, additional params will be
-provided by the client based on player interaction or by the bot strategy. Each
-move must return an object with `nextBoard`.
+Technically a move function takes board as first param, a framework-provided
+meta object as second param and may receive any number of additional params
+(provided by the client based on player interaction or by the bot strategy).
 
 A move may result in ending the turn of the current player or ending the game or
-allow further moves within the same turn.
+allow further moves within the same turn. In the preferred, outcome-returning
+form (`apply`) the move expresses all of this as data in its return value
+(a `MoveOutcome`):
+
+- `nextBoard` (required): the board after the move
+- `isTurnEnd`: `true` passes the turn; omitted = further moves follow within
+  the same turn. Ignored when `gameEnd` is present.
+- `gameEnd: { winnerIndex }`: the game is over, with an always explicit winner
+  (`ctx.currentPlayer!` when the mover wins)
+- `nextTurnState`: new `ctx.turnState` value (`null` clears it; omitted =
+  unchanged)
+- `autoEndOfTurn`: `true` asks the framework to auto-dispatch
+  `gameplay.endOfTurnMove` after a short delay
+
+`apply` receives `{ ctx }` and no `events` — it is a pure function, which
+is what lets the same move logic run on a possible future authoritative
+competition server. The legacy form (`legacyApply`) instead receives
+`{ ctx, events }` and calls `events.endTurn()` / `events.endGame(winnerIndex?)`
+imperatively; existing games are migrated one by one, new games should use
+`apply`.
 
 You must always pass `board` as a first param to all moves (meaning you must
 pass the updated board to subsequent moves in case of multiple moves within a
@@ -219,25 +237,26 @@ snapshot — see [AGENTS.md § Known limitation: React state staleness in
 multi-move turns](AGENTS.md#known-limitation-react-state-staleness-in-multi-move-turns)
 for the root cause and how `ctx.turnState` is handled.
 
-In `gameplay.moves`, each entry is either the move function itself (shorthand)
-or a long-form object `{ legacyApply, validate? }`:
+In `gameplay.moves`, each entry is either a legacy move function itself
+(shorthand) or a long-form object `{ apply, validate? }` (preferred) /
+`{ legacyApply, validate? }` (legacy):
 
 ```ts
 moves: {
   removeCoin: {
     validate: (board, { ctx }, value) => board[value - 1] > 0,
-    apply: (board, { events }, value) => { /* ... */ return { nextBoard }; }
+    apply: (board, { ctx }, value) => { /* ... */ return { nextBoard, isTurnEnd: true }; }
   }
 }
 ```
 
-`legacyApply` does **not** validate its arguments — it applies them blindly; legality
-lives in `validate`, right next to it.
+Neither `apply` nor `legacyApply` validates its arguments — they apply them
+blindly; legality lives in `validate`, right next to them.
 
 ### validate (optional, per move)
 
 `validate` is a pure predicate `(board, { ctx }, ...args) => boolean` colocated
-with `legacyApply` — the single source of truth for move legality. The framework
+with `apply` — the single source of truth for move legality. The framework
 rejects dispatches that fail it, and exposes it on the wrapped move as
 `moves.<name>.isAllowed(board, ...args)` (turn ownership AND `validate`, `ctx`
 bound) for the `BoardClient`'s `disabled` state. Full contract in
@@ -304,11 +323,14 @@ framework.
   remembered during a turn, i.e. to expose it from BoardClient to
   getPlayerStepDescription
 
-`events` is and objects that will contain the following (extendable):
-- `endTurn`: a function
+`events` is an object that will contain the following (extendable):
+- `endTurn`: a function (legacy `legacyApply`/shorthand moves only — outcome-returning moves
+  return `isTurnEnd: true` instead)
 - `endGame`: a function with optional winnerIndex specified, if not, last player
-  to move is the winner
-- `setTurnState`: a function to set `turnState`
+  to move is the winner (legacy `legacyApply`/shorthand moves only — outcome-returning moves
+  return `gameEnd: { winnerIndex }` with an explicit winner instead)
+- `setTurnState`: a function to set `turnState` — still current for
+  `BoardClient` components that keep mid-turn UI state in `ctx.turnState`
 </details>
 
 ## Things to look out for

--- a/src/components/games/coins-in-3-piles/helpers.spec.ts
+++ b/src/components/games/coins-in-3-piles/helpers.spec.ts
@@ -57,3 +57,37 @@ describe('coins-in-3-piles move validators', () => {
     });
   });
 });
+
+describe('coins-in-3-piles move outcomes', () => {
+  const ctx = makeCtx({ currentPlayer: 0 });
+
+  it('removing a 1-coin ends the turn without a place-back phase', () => {
+    expect(moves.removeCoin.apply([2, 5, 7], { ctx }, 1))
+      .toEqual({ nextBoard: [1, 5, 7], isTurnEnd: true });
+  });
+
+  it('removing the last coin as a 1-coin ends the game, the mover winning', () => {
+    expect(moves.removeCoin.apply([1, 0, 0], { ctx }, 1))
+      .toEqual({ nextBoard: [0, 0, 0], gameEnd: { winnerIndex: 0 } });
+  });
+
+  it('removing a 2- or 3-coin starts the place-back phase instead of ending the turn', () => {
+    expect(moves.removeCoin.apply([3, 5, 7], { ctx }, 3))
+      .toEqual({ nextBoard: [3, 5, 6], nextTurnState: { removedCoinValue: 3 } });
+  });
+
+  it('placing back a coin ends the turn and clears the place-back state', () => {
+    expect(moves.addCoin.apply([3, 5, 6], { ctx }, 2))
+      .toEqual({ nextBoard: [3, 6, 6], nextTurnState: null, isTurnEnd: true });
+  });
+
+  it('passing on the empty board ends the game, the mover winning', () => {
+    expect(moves.passAddition.apply([0, 0, 0], { ctx }))
+      .toEqual({ nextBoard: [0, 0, 0], nextTurnState: null, gameEnd: { winnerIndex: 0 } });
+  });
+
+  it('passing on a non-empty board just ends the turn', () => {
+    expect(moves.passAddition.apply([3, 5, 6], { ctx }))
+      .toEqual({ nextBoard: [3, 5, 6], nextTurnState: null, isTurnEnd: true });
+  });
+});

--- a/src/components/games/coins-in-3-piles/helpers.ts
+++ b/src/components/games/coins-in-3-piles/helpers.ts
@@ -1,5 +1,5 @@
 import { cloneDeep, isEqual } from "lodash";
-import type { Ctx, Events } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
 
 export type Board = number[]
 
@@ -27,18 +27,16 @@ export const moves = {
   removeCoin: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, value: number) =>
       ctx.turnState === null && value >= 1 && value <= 3 && board[value - 1] > 0,
-    legacyApply: (board: Board, { events }: { events: Events }, value) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, value): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard[value - 1] -= 1;
       if (value === 1) {
-        events.endTurn();
         if (isEqual(nextBoard, [0, 0, 0])) {
-          events.endGame();
+          return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
         }
-      } else {
-        events.setTurnState({ removedCoinValue: value });
+        return { nextBoard, isTurnEnd: true };
       }
-      return { nextBoard };
+      return { nextBoard, nextTurnState: { removedCoinValue: value } };
     }
   },
   addCoin: {
@@ -46,25 +44,23 @@ export const moves = {
       const removed = (ctx.turnState as { removedCoinValue: number } | null)?.removedCoinValue;
       return removed != null && value >= 1 && value < removed;
     },
-    legacyApply: (board: Board, { events }: { events: Events }, value) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, value) => {
       const nextBoard = cloneDeep(board);
       nextBoard[value - 1] += 1;
-      return finishPlaceBack(nextBoard, events);
+      return finishPlaceBack(nextBoard, ctx);
     }
   },
   passAddition: {
     validate: (board: Board, { ctx }: { ctx: Ctx }) => ctx.turnState !== null,
-    legacyApply: (board: Board, { events }: { events: Events }) => finishPlaceBack(board, events)
+    apply: (board: Board, { ctx }: { ctx: Ctx }) => finishPlaceBack(board, ctx)
   }
 }
 
 // Shared second half of the place-back phase: whether a coin was added or the
 // player passed, the turn ends the same way.
-function finishPlaceBack(nextBoard: Board, events: Events) {
-  events.endTurn();
-  events.setTurnState(null);
+function finishPlaceBack(nextBoard: Board, ctx: Ctx): MoveOutcome<Board> {
   if (isEqual(nextBoard, [0, 0, 0])) {
-    events.endGame();
+    return { nextBoard, nextTurnState: null, gameEnd: { winnerIndex: ctx.currentPlayer! } };
   }
-  return { nextBoard };
+  return { nextBoard, nextTurnState: null, isTurnEnd: true };
 }

--- a/src/components/games/five-connected-fields/five-connected-fields.tsx
+++ b/src/components/games/five-connected-fields/five-connected-fields.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory, type Ctx, type Events } from "../../strategy-game-factory";
+import { strategyGameFactory, type Ctx } from "../../strategy-game-factory";
 import { type Board, hasAnyMove, isNodePlayable } from "./helpers";
 import { smartBotStrategy } from "./bot-strategy";
 import { BoardClient } from "./board-client";
@@ -8,16 +8,15 @@ export type { Board };
 const moves = {
   placeCoin: {
     validate: (board: Board, _, node: number) => isNodePlayable(board, node),
-    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, node: number) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, node: number) => {
       const nextBoard = board.slice();
       nextBoard[node] += 1;
-      events.endTurn();
       // The player who places the last coin wins: the game ends when no line has
       // equal endpoints, i.e. when the mover just made all further moves impossible.
       if (!hasAnyMove(nextBoard)) {
-        events.endGame(ctx.currentPlayer);
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/hunyadi-and-the-janissaries/bot-strategy.spec.ts
+++ b/src/components/games/hunyadi-and-the-janissaries/bot-strategy.spec.ts
@@ -18,7 +18,7 @@ describe('HunyadiAndTheJanissaries strategy', () => {
     it('should split first row evenly if there are more soldiers', () => {
       const board = [[], ['blue', 'blue']] as Board;
       const soldiers = getOptimalSoldierGroups(board);
-      const { nextBoard } = moves.setGroupOfSoldiers.legacyApply(board, {}, soldiers);
+      const { nextBoard } = moves.setGroupOfSoldiers.apply(board, {}, soldiers);
       expect([[[], ['red', 'blue']], [[], ['blue', 'red']]]).toContainEqual(nextBoard);
     });
 
@@ -31,7 +31,7 @@ describe('HunyadiAndTheJanissaries strategy', () => {
         ['blue', 'blue', 'blue', 'blue']
       ] as Board;
       const soldiers = getOptimalSoldierGroups(board);
-      const { nextBoard } = moves.setGroupOfSoldiers.legacyApply(board, {}, soldiers);
+      const { nextBoard } = moves.setGroupOfSoldiers.apply(board, {}, soldiers);
       expect([
         [[], ['blue'], ['red'], [], ['red', 'red', 'red', 'red']],
         [[], ['red'], ['blue'], [], ['blue', 'blue', 'blue', 'blue']]
@@ -47,7 +47,7 @@ describe('HunyadiAndTheJanissaries strategy', () => {
         ['blue', 'blue']
       ] as Board;
       const soldiers = getOptimalSoldierGroups(board);
-      const { nextBoard } = moves.setGroupOfSoldiers.legacyApply(board, {}, soldiers);
+      const { nextBoard } = moves.setGroupOfSoldiers.apply(board, {}, soldiers);
       expect([
         [[], ['blue'], ['red', 'red', 'blue'], ['red'], ['red', 'red']],
         [[], ['red'], ['blue', 'blue', 'red'], ['blue'], ['blue', 'blue']]

--- a/src/components/games/hunyadi-and-the-janissaries/helpers.spec.ts
+++ b/src/components/games/hunyadi-and-the-janissaries/helpers.spec.ts
@@ -1,33 +1,34 @@
 import {
-  moves, generateStartBoard, isColor, isSoldierAssignmentAllowed, type Board
+  moves, generateStartBoard, isColor, isSoldierAssignmentAllowed, HUNYADI, SULTAN, type Board
 } from './helpers';
 import { uniq, flatten } from 'lodash';
-import { makeEvents } from '../../../test-utils';
+import { makeCtx } from '../../../test-utils';
 
 describe('HunyadiAndTheJanissaries helpers', () => {
   describe('moves', () => {
+    const meta = { ctx: makeCtx() };
+
     it('should claim victory for Hunyadi if all soldiers are killed', () => {
-      const events = makeEvents();
-      moves.killGroup.legacyApply([[], ['red', 'red']] as Board, { events }, 'red')
-      expect(events.endGame).toHaveBeenCalledWith(1);
+      const { gameEnd } = moves.killGroup.apply([[], ['red', 'red']] as Board, meta, 'red');
+      expect(gameEnd).toEqual({ winnerIndex: HUNYADI });
     });
 
     it('should claim loss for Hunyadi if a soldier reaches the castle', () => {
-      const events = makeEvents();
-      const { nextBoard } = moves.killGroup.legacyApply(
-        [[], ['red', 'blue'], ['blue']] as Board, { events }, 'red'
+      const { nextBoard, autoEndOfTurn } = moves.killGroup.apply(
+        [[], ['red', 'blue'], ['blue']] as Board, meta, 'red'
       );
-      moves.stepUp(nextBoard, { events });
-      expect(events.endGame).toHaveBeenCalledWith(0);
+      expect(autoEndOfTurn).toBe(true);
+      const { gameEnd } = moves.stepUp.apply(nextBoard);
+      expect(gameEnd).toEqual({ winnerIndex: SULTAN });
     });
 
     it('should report game as still in progress and advance remaining soldiers otherwise', () => {
-      const events = makeEvents();
       const board = [[], ['red'], ['blue', 'red'], [], ['blue', 'blue']] as Board;
-      const { nextBoard } = moves.killGroup.legacyApply(board, { events }, 'red');
-      const state = moves.stepUp(nextBoard, { events });
-      expect(state.nextBoard).toEqual([[], ['blue'], [], ['blue', 'blue'], []])
-      expect(events.endGame).not.toHaveBeenCalled();
+      const { nextBoard } = moves.killGroup.apply(board, meta, 'red');
+      const outcome = moves.stepUp.apply(nextBoard);
+      expect(outcome.nextBoard).toEqual([[], ['blue'], [], ['blue', 'blue'], []])
+      expect(outcome.gameEnd).toBeUndefined();
+      expect(outcome.isTurnEnd).toBe(true);
     });
   });
 

--- a/src/components/games/hunyadi-and-the-janissaries/helpers.ts
+++ b/src/components/games/hunyadi-and-the-janissaries/helpers.ts
@@ -1,5 +1,4 @@
 import { random, flatten, cloneDeep, sum, tail } from 'lodash';
-import type { Events } from '../../strategy-game-factory';
 
 export type SoldierColor = 'blue' | 'red';
 export type Board = SoldierColor[][];
@@ -65,29 +64,23 @@ export const moves = {
   killGroup: {
     validate: (board: Board, { ctx }, group: SoldierColor) =>
       ctx.currentPlayer === HUNYADI && isColor(group),
-    legacyApply: (board: Board, { events }: { events: Events }, group: SoldierColor) => {
+    apply: (board: Board, _, group: SoldierColor) => {
       const nextBoard = board.map(row => row.filter(soldier => soldier !== group));
 
-      const isGameEnd = flatten(nextBoard).length === 0;
-      if (isGameEnd) {
-        events.endTurn();
-        events.endGame(1);
-        return { nextBoard, isGameEnd };
+      if (flatten(nextBoard).length === 0) {
+        return { nextBoard, gameEnd: { winnerIndex: HUNYADI } };
       }
-      return { nextBoard, isGameEnd, autoEndOfTurn: true };
+      return { nextBoard, autoEndOfTurn: true };
     }
   },
   finalizeSeparation: {
     validate: (board: Board, { ctx }) => ctx.currentPlayer === SULTAN,
-    legacyApply: (board: Board, { events }: { events: Events }) => {
-      events.endTurn();
-      return { nextBoard: board };
-    }
+    apply: (board: Board) => ({ nextBoard: board, isTurnEnd: true })
   },
   setGroupOfSoldiers: {
     validate: (board: Board, { ctx }, soldiers: Soldier[]) =>
       ctx.currentPlayer === SULTAN && isSoldierAssignmentAllowed(board, soldiers),
-    legacyApply: (board: Board, _, soldiers: Soldier[]) => {
+    apply: (board: Board, _, soldiers: Soldier[]) => {
       const nextBoard = cloneDeep(board);
       for (const soldier of soldiers) {
         nextBoard[soldier.rowIndex][soldier.pieceIndex] = soldier.group;
@@ -96,12 +89,13 @@ export const moves = {
     }
   },
   // endOfTurn move automatically initiated by game engine
-  stepUp: (board: Board, { events }: { events: Events }) => {
-    const nextBoard = [...tail(board), []];
-    events.endTurn();
-    if (nextBoard[0].length > 0) {
-      events.endGame(0);
+  stepUp: {
+    apply: (board: Board) => {
+      const nextBoard = [...tail(board), []];
+      if (nextBoard[0].length > 0) {
+        return { nextBoard, gameEnd: { winnerIndex: SULTAN } };
+      }
+      return { nextBoard, isTurnEnd: true };
     }
-    return { nextBoard };
   }
 };

--- a/src/components/strategy-game-factory/index.ts
+++ b/src/components/strategy-game-factory/index.ts
@@ -2,7 +2,7 @@ export { strategyGameFactory, dummyEvents } from './strategy-game-factory';
 export type { Presentation, StrategyGameConfig } from './strategy-game-factory';
 export type {
   Phase, Mode, Ctx, Events,
-  MoveResult, MoveFunction, MoveDefinition, Gameplay, GameMoves,
+  MoveResult, MoveOutcome, MoveFunction, PureMoveFunction, MoveDefinition, Gameplay, GameMoves,
   StrategyArgs, BoardClientProps,
   Variant, VariantInput
 } from './types';

--- a/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
@@ -2,7 +2,9 @@
 import { render, fireEvent, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { strategyGameFactory, type StrategyGameConfig } from './strategy-game-factory';
-import type { BoardClientProps, Ctx, Events, Gameplay, GameMoves, StrategyArgs } from './types';
+import type {
+  BoardClientProps, Ctx, Events, Gameplay, GameMoves, MoveDefinition, StrategyArgs
+} from './types';
 
 type Board = string[];
 
@@ -678,6 +680,350 @@ describe('move validate enforcement', () => {
       expect(track).toHaveBeenCalledWith('illegal-move', expect.objectContaining({ move: 'guarded' }));
       delete window.umami;
       vi.restoreAllMocks();
+    });
+  });
+});
+
+describe('outcome-returning moves (apply)', () => {
+  const v2Config = () => makeConfig({
+    BoardClient: ({ board, ctx, moves }: BoardClientProps<Board>) => (
+      <>
+        <button
+          data-testid="pass-btn"
+          disabled={!ctx.isClientMoveAllowed}
+          onClick={() => moves.passTurn(board)}
+        >pass</button>
+        <button data-testid="mid-btn" onClick={() => moves.midMove(board)}>mid</button>
+        <button data-testid="win-btn" onClick={() => moves.winNow(board)}>win</button>
+        <button data-testid="lose-btn" onClick={() => moves.loseNow(board)}>lose</button>
+        <span data-testid="board">{board.join(',')}</span>
+        <span data-testid="player">{String(ctx.currentPlayer)}</span>
+        <span data-testid="phase">{ctx.phase}</span>
+      </>
+    ),
+    gameplay: {
+      moves: {
+        passTurn: {
+          apply: (board: Board) => ({ nextBoard: [...board, 'pass'], isTurnEnd: true })
+        },
+        midMove: {
+          apply: (board: Board) => ({ nextBoard: [...board, 'mid'] })
+        },
+        winNow: {
+          apply: (board: Board, { ctx }: { ctx: Ctx }) =>
+            ({ nextBoard: board, gameEnd: { winnerIndex: ctx.currentPlayer! } })
+        },
+        loseNow: {
+          apply: (board: Board, { ctx }: { ctx: Ctx }) =>
+            ({ nextBoard: board, gameEnd: { winnerIndex: 1 - ctx.currentPlayer! } })
+        }
+      }
+    }
+  });
+
+  it('isTurnEnd: true passes the turn', () => {
+    const { getByTestId } = renderGame(v2Config());
+    fireEvent.click(getByTestId('role-btn-0'));
+    fireEvent.click(getByTestId('pass-btn'));
+    expect(getByTestId('board').textContent).toBe('initial,pass');
+    expect(getByTestId('player').textContent).toBe('1');
+    expect((getByTestId('pass-btn') as HTMLButtonElement).disabled).toBe(true); // bot's turn
+  });
+
+  it('a result with no outcome fields keeps the turn (mid-turn move)', () => {
+    const { getByTestId } = renderGame(v2Config());
+    fireEvent.click(getByTestId('role-btn-0'));
+    fireEvent.click(getByTestId('mid-btn'));
+    expect(getByTestId('board').textContent).toBe('initial,mid');
+    expect(getByTestId('player').textContent).toBe('0');
+    expect((getByTestId('pass-btn') as HTMLButtonElement).disabled).toBe(false); // still my turn
+  });
+
+  it('gameEnd ends the game with the explicit winner and does not flip currentPlayer', () => {
+    localStorage.clear();
+    const track = vi.fn();
+    window.umami = { track: track as NonNullable<Window['umami']>['track'] };
+    const { getByTestId } = renderGame(v2Config());
+    fireEvent.click(getByTestId('role-btn-0'));
+    fireEvent.click(getByTestId('win-btn'));
+    expect(getByTestId('phase').textContent).toBe('gameEnd');
+    // The v2 contract never flips the player at game end (legacy games often
+    // called endTurn before endGame; nothing user-visible read the flip).
+    expect(getByTestId('player').textContent).toBe('0');
+    expect(JSON.parse(localStorage.getItem('stats__0')!)).toEqual({ win: 1, loss: 0 });
+    expect(track).toHaveBeenCalledWith('game-finished', expect.objectContaining({ result: 'win' }));
+    delete window.umami;
+  });
+
+  it('gameEnd records a loss when the opponent is the explicit winner', () => {
+    localStorage.clear();
+    const { getByTestId } = renderGame(v2Config());
+    fireEvent.click(getByTestId('role-btn-0'));
+    fireEvent.click(getByTestId('lose-btn'));
+    expect(JSON.parse(localStorage.getItem('stats__0')!)).toEqual({ win: 0, loss: 1 });
+  });
+
+  it('throws at factory time when a move defines both legacyApply and apply, or neither', () => {
+    // deliberately malformed configs, cast past the compile-time guard
+    const asMove = (def: object) => def as MoveDefinition<Board>;
+    const both = asMove({
+      legacyApply: (board: Board) => ({ nextBoard: board }),
+      apply: (board: Board) => ({ nextBoard: board })
+    });
+    expect(() => strategyGameFactory(minimalConfig({ moves: { broken: both } })))
+      .toThrow(/exactly one of apply\/legacyApply/);
+    expect(() => strategyGameFactory(minimalConfig({ moves: { broken: asMove({}) } })))
+      .toThrow(/exactly one of apply\/legacyApply/);
+  });
+
+  it('throws in dev when a move returns gameEnd together with isTurnEnd', () => {
+    vi.useFakeTimers();
+    try {
+      const config = makeConfig({
+        gameplay: {
+          moves: {
+            contradiction: {
+              apply: (board: Board) =>
+                ({ nextBoard: board, isTurnEnd: true, gameEnd: { winnerIndex: 0 } })
+            },
+            handOver: { apply: (board: Board) => ({ nextBoard: board, isTurnEnd: true }) }
+          }
+        },
+        BoardClient: ({ board, moves }: BoardClientProps<Board>) => (
+          <button data-testid="hand-over-btn" onClick={() => moves.handOver(board)}>go</button>
+        ),
+        botStrategy: (({ board, moves }: StrategyArgs<Board>) => {
+          moves.contradiction(board);
+        }) as () => void
+      });
+      const { getByTestId } = renderGame(config);
+      fireEvent.click(getByTestId('role-btn-0'));
+      fireEvent.click(getByTestId('hand-over-btn')); // → bot's turn
+      expect(() => act(() => { vi.advanceTimersByTime(1500); }))
+        .toThrow(/gameEnd together with isTurnEnd\/autoEndOfTurn/);
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it('legacy and outcome-returning moves coexist within one game', () => {
+    const gameplay: Gameplay<Board> = {
+      moves: {
+        legacyMove: (board: Board, { events }: { events: Events }) => {
+          events.endTurn();
+          return { nextBoard: [...board, 'legacy'] };
+        },
+        v2Move: { apply: (board: Board) => ({ nextBoard: [...board, 'v2'], isTurnEnd: true }) }
+      }
+    };
+    const BoardClient = ({ board, moves }: BoardClientProps<Board>) => (
+      <>
+        <button data-testid="legacy-btn" onClick={() => moves.legacyMove(board)}>legacy</button>
+        <button data-testid="v2-btn" onClick={() => moves.v2Move(board)}>v2</button>
+        <span data-testid="board">{board.join(',')}</span>
+      </>
+    );
+    const { getByTestId } = renderGame(makeConfig({ BoardClient, gameplay }));
+    fireEvent.click(getByTestId('mode-vsHuman'));
+    fireEvent.click(getByTestId('start-hh-game-0'));
+    fireEvent.click(getByTestId('v2-btn')); // player 0, v2 contract
+    fireEvent.click(getByTestId('legacy-btn')); // player 1, legacy contract
+    expect(getByTestId('board').textContent).toBe('initial,v2,legacy');
+  });
+
+  it('extra outcome-shaped fields returned by a legacy move stay inert', () => {
+    // A legacy (events-based) game may return stray extra fields (hunyadi's
+    // old isGameEnd did) — the engine must not interpret them as v2 outcomes.
+    const gameplay: Gameplay<Board> = {
+      moves: {
+        mainMove: (board: Board) => {
+          // a non-fresh object dodges the excess-property check, like real
+          // legacy code returning ad-hoc extra fields did
+          const strayOutcome = {
+            nextBoard: [...board, 'x'], isTurnEnd: true, gameEnd: { winnerIndex: 0 }
+          };
+          return strayOutcome;
+        }
+      }
+    };
+    const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => (
+      <>
+        <button data-testid="move-btn" onClick={() => moves.mainMove(board)}>move</button>
+        <span data-testid="player">{String(ctx.currentPlayer)}</span>
+        <span data-testid="phase">{ctx.phase}</span>
+      </>
+    );
+    const { getByTestId } = renderGame(makeConfig({ BoardClient, gameplay }));
+    fireEvent.click(getByTestId('role-btn-0'));
+    fireEvent.click(getByTestId('move-btn'));
+    expect(getByTestId('phase').textContent).toBe('play'); // gameEnd field ignored
+    expect(getByTestId('player').textContent).toBe('0'); // isTurnEnd field ignored
+  });
+
+  it('autoEndOfTurn schedules an outcome-returning endOfTurnMove after 750ms', () => {
+    vi.useFakeTimers();
+    try {
+      const autoMove = vi.fn((board: Board) => ({ nextBoard: board, isTurnEnd: true }));
+      const gameplay: Gameplay<Board> = {
+        moves: {
+          mainMove: { apply: (board: Board) => ({ nextBoard: board, autoEndOfTurn: true }) },
+          autoMove: { apply: autoMove }
+        },
+        endOfTurnMove: 'autoMove'
+      };
+      const { getByTestId } = renderGame(makeConfig({ BoardClient: CtxAwareBoardClient, gameplay }));
+      fireEvent.click(getByTestId('role-btn-0'));
+      fireEvent.click(getByTestId('move-btn'));
+      expect(autoMove).not.toHaveBeenCalled();
+      act(() => { vi.advanceTimersByTime(750); });
+      expect(autoMove).toHaveBeenCalledOnce();
+      expect((getByTestId('move-btn') as HTMLButtonElement).disabled).toBe(true); // its isTurnEnd applied
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  describe('nextTurnState', () => {
+    const turnStateConfig = () => makeConfig({
+      BoardClient: ({ board, ctx, moves }: BoardClientProps<Board>) => (
+        <>
+          <button data-testid="set-btn" onClick={() => moves.setTs(board)}>set</button>
+          <button data-testid="keep-btn" onClick={() => moves.keepTs(board)}>keep</button>
+          <button data-testid="clear-btn" onClick={() => moves.clearTs(board)}>clear</button>
+          <span data-testid="board">{board.join(',')}</span>
+          <span data-testid="ts">{JSON.stringify(ctx.turnState)}</span>
+        </>
+      ),
+      gameplay: {
+        moves: {
+          setTs: { apply: (board: Board) => ({ nextBoard: [...board, 's'], nextTurnState: 'stage2' }) },
+          keepTs: { apply: (board: Board) => ({ nextBoard: [...board, 'k'] }) },
+          clearTs: { apply: (board: Board) => ({ nextBoard: [...board, 'c'], nextTurnState: null }) }
+        }
+      }
+    });
+
+    it('sets, preserves (undefined) and clears (null) turnState', () => {
+      const { getByTestId } = renderGame(turnStateConfig());
+      fireEvent.click(getByTestId('role-btn-0'));
+      expect(getByTestId('ts').textContent).toBe('null');
+      fireEvent.click(getByTestId('set-btn'));
+      expect(getByTestId('ts').textContent).toBe('"stage2"');
+      fireEvent.click(getByTestId('keep-btn')); // omitted nextTurnState → unchanged
+      expect(getByTestId('ts').textContent).toBe('"stage2"');
+      fireEvent.click(getByTestId('clear-btn')); // null → cleared
+      expect(getByTestId('ts').textContent).toBe('null');
+    });
+
+    it('undo mid-turn restores the board and clears turnState', () => {
+      const { getByTestId } = renderGame(turnStateConfig());
+      fireEvent.click(getByTestId('mode-vsHuman'));
+      fireEvent.click(getByTestId('start-hh-game-0'));
+      fireEvent.click(getByTestId('set-btn')); // mid-turn, turnState = 'stage2'
+      fireEvent.click(getByTestId('undo-btn'));
+      expect(getByTestId('board').textContent).toBe('initial');
+      expect(getByTestId('ts').textContent).toBe('null');
+    });
+  });
+
+  // The v2 twin of the legacy two-phase regression tests: nextTurnState must be
+  // patched onto ctxRef synchronously while processing the outcome, or a bot's
+  // 0-delay chained dispatch would be validated against a stale turnState.
+  const twoPhaseV2BotConfig = (chainDelayMs: number) => makeConfig({
+    BoardClient: ({ board }: BoardClientProps<Board>) => (
+      <span data-testid="board">{board.join(',')}</span>
+    ),
+    gameplay: {
+      moves: {
+        phase1: {
+          validate: (_board: Board, { ctx }: { ctx: Ctx }) => ctx.turnState === null,
+          apply: (board: Board) =>
+            ({ nextBoard: [...board, 'p1'], nextTurnState: { removedCoinValue: 3 } })
+        },
+        phase2: {
+          validate: (_board: Board, { ctx }: { ctx: Ctx }) => ctx.turnState !== null,
+          apply: (board: Board) =>
+            ({ nextBoard: [...board, 'p2'], isTurnEnd: true, nextTurnState: null })
+        }
+      }
+    },
+    botStrategy: ({ board, moves }) => {
+      const { nextBoard } = moves.phase1(board);
+      setTimeout(() => { moves.phase2(nextBoard); }, chainDelayMs);
+    }
+  });
+
+  const playTwoPhaseV2BotTurn = (chainDelayMs: number) => {
+    vi.useFakeTimers();
+    try {
+      const { getByTestId } = renderGame(twoPhaseV2BotConfig(chainDelayMs));
+      fireEvent.click(getByTestId('role-btn-1')); // human is 2nd player → bot moves first
+      act(() => { vi.advanceTimersByTime(1500); }); // bot "thinking" delay → phase1
+      act(() => { vi.advanceTimersByTime(750); }); // the chained phase2 — must not be rejected
+      return getByTestId('board').textContent;
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  };
+
+  it('validates a bot-chained second move against the returned nextTurnState', () => {
+    expect(playTwoPhaseV2BotTurn(750)).toBe('initial,p1,p2');
+  });
+
+  it('validates a 0-delay chained second move dispatched before React re-renders', () => {
+    expect(playTwoPhaseV2BotTurn(0)).toBe('initial,p1,p2');
+  });
+
+  describe('validate on outcome-returning moves', () => {
+    const guardedV2Config = (botStrategy: () => void = () => {}) => makeConfig({
+      BoardClient: ({ board, moves }: BoardClientProps<Board>) => (
+        <>
+          <button data-testid="legal-btn" onClick={() => moves.guarded(board, 'ok')}>legal</button>
+          <button data-testid="illegal-btn" onClick={() => moves.guarded(board, 'bad')}>illegal</button>
+          <button data-testid="hand-over-btn" onClick={() => moves.handOver(board)}>hand over</button>
+          <span data-testid="board">{board.join(',')}</span>
+        </>
+      ),
+      gameplay: {
+        moves: {
+          guarded: {
+            validate: (_board: Board, _meta: { ctx: Ctx }, arg: string) => arg === 'ok',
+            apply: (board: Board, _meta: { ctx: Ctx }, arg: string) =>
+              ({ nextBoard: [...board, arg] })
+          },
+          handOver: { apply: (board: Board) => ({ nextBoard: board, isTurnEnd: true }) }
+        }
+      },
+      botStrategy
+    });
+
+    it('silently ignores an illegal client dispatch', () => {
+      const { getByTestId } = renderGame(guardedV2Config());
+      fireEvent.click(getByTestId('role-btn-0'));
+      fireEvent.click(getByTestId('illegal-btn')); // must not throw
+      expect(getByTestId('board').textContent).toBe('initial');
+      fireEvent.click(getByTestId('legal-btn'));
+      expect(getByTestId('board').textContent).toBe('initial,ok');
+    });
+
+    it('throws loudly in dev on an illegal bot dispatch', () => {
+      vi.useFakeTimers();
+      try {
+        const botStrategy = vi.fn().mockImplementation((args: any) => {
+          args.moves.guarded(args.board, 'bad');
+        });
+        const { getByTestId } = renderGame(guardedV2Config(botStrategy));
+        fireEvent.click(getByTestId('role-btn-0'));
+        fireEvent.click(getByTestId('hand-over-btn')); // → bot's turn
+        expect(() => act(() => { vi.advanceTimersByTime(1500); })).toThrow(/illegal move/);
+        expect(getByTestId('board').textContent).toBe('initial');
+      } finally {
+        vi.clearAllTimers();
+        vi.useRealTimers();
+      }
     });
   });
 });

--- a/src/components/strategy-game-factory/strategy-game-factory.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.tsx
@@ -10,7 +10,7 @@ import { useLocation } from 'react-router';
 import { useGameStats } from './hooks/use-game-stats';
 import { trackEvent } from '../../tracking';
 import type {
-  Phase, Mode, Ctx, Events, MoveResult, Gameplay, GameMoves,
+  Phase, Mode, Ctx, Events, MoveOutcome, NormalizedMove, Gameplay, GameMoves,
   BoardClientProps, Variant as DisplayVariant, VariantInput
 } from './types';
 import { resolveVariants } from './helpers/resolve-variants';
@@ -42,9 +42,19 @@ export const strategyGameFactory = <TBoard,>({
   const { rule, roleLabels, getPlayerStepDescription } = presentation;
   const { moves, endOfTurnMove } = gameplay;
   const { defaultVariantIndex, defaultVariant, resolvedVariants } = resolveVariants(variants);
-  // Normalize the shorthand (plain function = legacyApply with no validator) so the
-  // rest of the engine deals with a single long-form shape.
-  const normalizedMoves = mapValues(moves, (m) => typeof m === 'function' ? { legacyApply: m } : m);
+  // Normalize the shorthand (plain function = legacy move with no validator)
+  // so the rest of the engine deals with a single long-form shape.
+  const normalizedMoves: Record<string, NormalizedMove<TBoard>> =
+    mapValues(moves, (m) => typeof m === 'function' ? { legacyApply: m } : m);
+  Object.entries(normalizedMoves).forEach(([name, def]) => {
+    if (!!def.legacyApply === !!def.apply) {
+      const message = `strategyGameFactory: move ${name} must define exactly one of apply/legacyApply`;
+      if (import.meta.env.DEV) {
+        throw new Error(message);
+      }
+      console.warn(message);
+    }
+  });
 
   return () => {
     const { t } = useTranslation();
@@ -110,10 +120,10 @@ export const strategyGameFactory = <TBoard,>({
       name: string,
       moveBoard: TBoard,
       args: unknown[],
-      doMove: () => MoveResult<TBoard>
-    ): MoveResult<TBoard> => {
-      const validator = normalizedMoves[name]!.validate;
-      if (validator && !validator(moveBoard, { ctx: ctxRef.current }, ...args)) {
+      doMove: () => MoveOutcome<TBoard>
+    ): MoveOutcome<TBoard> => {
+      const { validate, apply } = normalizedMoves[name]!;
+      if (validate && !validate(moveBoard, { ctx: ctxRef.current }, ...args)) {
         reportIllegalMove(name, moveBoard, args);
         return { nextBoard: moveBoard };
       }
@@ -124,6 +134,27 @@ export const strategyGameFactory = <TBoard,>({
       const moveResult = doMove();
       setBoard(moveResult.nextBoard);
       setMoveCount(c => c + 1);
+      // The returned outcome is interpreted only for outcome-returning `apply`
+      // moves: a legacy move causes turn/game transitions through `events`
+      // instead, and any extra fields it happens to return must stay inert.
+      if (apply) {
+        // Through `events.setTurnState` so ctxRef is patched synchronously — a
+        // chained dispatch can validate before React re-renders.
+        if (moveResult.nextTurnState !== undefined) {
+          events.setTurnState(moveResult.nextTurnState);
+        }
+        if (moveResult.gameEnd) {
+          if (import.meta.env.DEV && (moveResult.isTurnEnd || moveResult.autoEndOfTurn)) {
+            throw new Error(`strategyGameFactory: move ${name} returned gameEnd `
+              + 'together with isTurnEnd/autoEndOfTurn');
+          }
+          endGame(moveResult.gameEnd.winnerIndex);
+          return moveResult;
+        }
+        if (moveResult.isTurnEnd) {
+          endTurn();
+        }
+      }
       if (endOfTurnMove && moveResult.autoEndOfTurn) {
         botTimeoutRef.current = setTimeout(() => {
           botTimeoutRef.current = null;
@@ -252,9 +283,11 @@ export const strategyGameFactory = <TBoard,>({
       }
     };
 
-    wrappedGameMoves = mapValues(normalizedMoves, ({ legacyApply }, name) => {
+    wrappedGameMoves = mapValues(normalizedMoves, ({ legacyApply, apply }, name) => {
       const wrapped: GameMoves<TBoard>[string] = (board: TBoard, ...args: unknown[]) =>
-        moveWrapper(name, board, args, () => legacyApply(board, { ctx, events }, ...args));
+        moveWrapper(name, board, args, () => apply
+          ? apply(board, { ctx }, ...args)
+          : legacyApply!(board, { ctx, events }, ...args));
       return wrapped;
     });
 

--- a/src/components/strategy-game-factory/types.ts
+++ b/src/components/strategy-game-factory/types.ts
@@ -21,26 +21,59 @@ export interface Events {
   setTurnState: (state: unknown) => void
 }
 
-export type MoveResult<TBoard> = { nextBoard: TBoard; autoEndOfTurn?: boolean }
+// Everything a move can cause, expressed as data. Returned by outcome-returning
+// (`apply`) moves and interpreted by the engine; legacy (`legacyApply`) moves
+// return only `nextBoard`/`autoEndOfTurn` and cause the rest through `events`.
+export type MoveOutcome<TBoard> = {
+  nextBoard: TBoard
+  // Turn passes to the other player. Omitted/false = turn continues (mid-turn
+  // move of a multi-phase turn). Ignored when `gameEnd` is present.
+  isTurnEnd?: boolean
+  // undefined = turnState unchanged; null = cleared; anything else = new value.
+  nextTurnState?: unknown
+  // Terminal: the game is over. The winner is always explicit — there is no
+  // "omitted = mover wins" shorthand in this contract.
+  gameEnd?: { winnerIndex: number }
+  // Schedule gameplay.endOfTurnMove after a delay. Ignored when `gameEnd` is
+  // present (contradiction; throws in dev).
+  autoEndOfTurn?: boolean
+}
+export type MoveResult<TBoard> = Pick<MoveOutcome<TBoard>, 'nextBoard' | 'autoEndOfTurn'>
 export type MoveFunction<TBoard> = (
   board: TBoard, meta: { ctx: Ctx; events: Events }, ...args: any[]
 ) => MoveResult<TBoard>
+// Outcome-returning apply: no `events` param, so purity is enforced by the
+// type system — everything the move causes is in the returned MoveOutcome.
+export type PureMoveFunction<TBoard> = (
+  board: TBoard, meta: { ctx: Ctx }, ...args: any[]
+) => MoveOutcome<TBoard>
 // Pure, side-effect-free legality predicate for a single move, colocated with
-// its `legacyApply` in the long-form move definition. Because it depends only on
+// its `apply`/`legacyApply` in the long-form move definition. Because it depends only on
 // `board` + `ctx` (no React, no `events`), the same function drives the UI
 // (button `disabled`), the engine (illegal-move enforcement) and, in the
 // future, an authoritative server-side check.
 type MoveValidator<TBoard> = (
   board: TBoard, meta: { ctx: Ctx }, ...args: any[]
 ) => boolean
-// A move is either a plain move function (shorthand — always accepted by the
-// engine) or a long-form object pairing it with an optional legality validator.
-// The key is named `legacyApply` because this events-based contract is on its
-// way out: an outcome-returning replacement lands next, and every remaining
-// `legacyApply` is one game still to migrate.
+// A move is either a legacy plain function (shorthand — always accepted by the
+// engine), a long-form `legacyApply` object pairing it with an optional
+// legality validator, or — the preferred contract for new games — an
+// outcome-returning `apply` that gets no `events` and instead returns
+// turn/game consequences as data. The distinct key is the contract marker: the
+// engine interprets the returned MoveOutcome only for `apply` moves, and a
+// migrated move that still touches `events` fails to compile.
 export type MoveDefinition<TBoard> =
   | MoveFunction<TBoard>
   | { legacyApply: MoveFunction<TBoard>; validate?: MoveValidator<TBoard> }
+  | { apply: PureMoveFunction<TBoard>; validate?: MoveValidator<TBoard> }
+// Engine-internal normalized move shape (not re-exported from the barrel):
+// the shorthand folded into long form, carrying exactly one of
+// apply/legacyApply (enforced at factory time).
+export type NormalizedMove<TBoard> = {
+  legacyApply?: MoveFunction<TBoard>
+  apply?: PureMoveFunction<TBoard>
+  validate?: MoveValidator<TBoard>
+}
 export interface Gameplay<TBoard> {
   moves: Record<string, MoveDefinition<TBoard>>
   // move name auto-executed (after a delay) following moves returning autoEndOfTurn: true
@@ -56,7 +89,7 @@ export interface Gameplay<TBoard> {
 // use the raw `validate`/helpers to enumerate legal moves.
 export type GameMoves<TBoard> = Record<
   string,
-  ((board: TBoard, ...args: any[]) => MoveResult<TBoard>)
+  ((board: TBoard, ...args: any[]) => MoveOutcome<TBoard>)
     & { isAllowed?: (board: TBoard, ...args: any[]) => boolean }
 >
 export type StrategyArgs<TBoard> = { board: TBoard; ctx: Ctx; moves: GameMoves<TBoard> }


### PR DESCRIPTION
## Summary

**Stacked on #365** (the `apply` → `legacyApply` rename). First step toward server-authoritative competition mode (#313): moves no longer need to call `events.endTurn()` / `events.endGame()` imperatively — the new, preferred contract expresses everything a move causes as data in its return value.

With the mechanical rename split out into #365, this PR is back to **12 files**, all substantive.

### Engine (`strategy-game-factory`)

- New move shape `{ apply, validate? }`: a pure `(board, { ctx }, ...args) => MoveOutcome` with **no `events` param** (purity is compile-enforced by the distinct key).
- `MoveOutcome`: `{ nextBoard, isTurnEnd?, nextTurnState?, gameEnd?: { winnerIndex }, autoEndOfTurn? }`
  - `gameEnd` always carries an explicit winner (no "bare = mover wins" shorthand) and never flips `currentPlayer` — the one deliberate semantic change; verified nothing in the engine UI reads `currentPlayer` at game end (cta-text and the player panel use `winnerIndex`, step description only renders during `play`).
  - `nextTurnState` is routed through the existing synchronous `ctxRef` patch, so a bot's 0-delay chained dispatch validates against the fresh turnState (pinned by new twins of the two-phase regression tests).
  - `gameEnd` + `isTurnEnd`/`autoEndOfTurn` together is a dev-mode error; a move defining both or neither of `apply`/`legacyApply` throws at factory time in dev.
- Legacy `legacyApply`/shorthand moves are behaviorally untouched; both contracts mix freely within one game, so the remaining ~73 games can migrate one by one (like the #333 validate rollout). Stray extra fields returned by legacy moves stay inert (covered by a test).
- 15 new engine spec tests (56 total, all green).

### Pilot migrations (one per pattern family, each a migration recipe)

- **five-connected-fields** — the dominant single-move pattern (~55 games): `endTurn` + conditional `endGame(mover)` → `{ isTurnEnd: true }` / `{ gameEnd: { winnerIndex: ctx.currentPlayer! } }`.
- **coins-in-3-piles** — two-phase turn: `nextTurnState` replaces `events.setTurnState`; `finishPlaceBack` becomes a pure `(board, ctx) => MoveOutcome`; bare `endGame()` gains the explicit mover winner. Bots unchanged.
- **hunyadi-and-the-janissaries** — `endOfTurnMove`/`autoEndOfTurn` recipe; drops the ad-hoc `isGameEnd` result field (verified unused); the auto-dispatched `stepUp` converts from shorthand to the outcome-returning form.

### Docs

AGENTS.md and README now document `apply` as the contract for new games and mark `events.endTurn`/`endGame` in moves as legacy; `events.setTurnState` remains current for BoardClients.

## Test plan

- `npm test` green at every commit: the contract commit alone is 935 tests, and the full branch is 941 unit tests in 130 files (all 41 pre-existing engine tests pass unchanged).
- Manual: played all three pilots in vsComputer + vsHuman, including the 0 ms bot chain (coins) and auto `stepUp` (hunyadi), undo mid-turn, end-of-game dialog.

Next (stacked, separate PR): #362 — Phase 2, external synchronous game-state store (`engine/` reducer + `useSyncExternalStore`), removing the `ctxRef` shadow and board-threading staleness by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cECth7yywjvuhpXHuTgkS

---
_Generated by [Claude Code](https://claude.ai/code/session_015cECth7yywjvuhpXHuTgkS)_