### PR TITLE
Rename the long-form move key apply -> legacyApply

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ strategyGameFactory({
   },
   BoardClient,                 // React component receiving { board, ctx, events, moves }
   gameplay: {
-    moves,                     // { [name]: apply | { apply, validate? } } — see below
+    moves,                     // { [name]: moveFn | { legacyApply, validate? } } — see below
     endOfTurnMove?,            // optional move name auto-executed after moves with autoEndOfTurn: true
   },
   variants,                    // see below
@@ -94,15 +94,15 @@ omitted on a variant, the default variant's `botStrategy` is used as fallback.
 If multiple variants are provided, exactly one must be `isDefault: true`. A
 single-entry array needs no `isDefault` flag.
 
-**`moves`** — each move is either a plain apply function
+**`moves`** — each move is either a plain move function
 `(board, { ctx, events }, ...args) => { nextBoard }` (shorthand), or a long-form
-object `{ apply, validate? }` colocating it with a legality predicate. Always
-pass the current `board` as first arg when chaining moves within a turn. `apply`
+object `{ legacyApply, validate? }` colocating it with a legality predicate. Always
+pass the current `board` as first arg when chaining moves within a turn. `legacyApply`
 trusts its arguments and applies them blindly; legality is enforced by
 `validate` (below) and/or the `BoardClient`'s `disabled` gating.
 
 **`validate`** (optional, per move) — a pure, side-effect-free legality predicate
-`(board, { ctx }, ...args) => boolean` sitting right next to its `apply`. When
+`(board, { ctx }, ...args) => boolean` sitting right next to its `legacyApply`. When
 present, the engine rejects any dispatch whose args fail it (in dev it throws
 loudly to surface the bug; in prod it warns, fires an `illegal-move` analytics
 event, and no-ops so a stray call cannot corrupt the board). The function

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Conceptually a `move` is a unit that captures a change in the board initiated by
 a player. Moves help ensure that the game is played according to rules by all
 players.
 
-Technically the apply function of a move takes board as first param, `{
+Technically the `legacyApply` function of a move takes board as first param, `{
 ctx, events }` as second param and may receive any number of additional params.
 The second param is provided by the framework, additional params will be
 provided by the client based on player interaction or by the bot strategy. Each
@@ -219,8 +219,8 @@ snapshot — see [AGENTS.md § Known limitation: React state staleness in
 multi-move turns](AGENTS.md#known-limitation-react-state-staleness-in-multi-move-turns)
 for the root cause and how `ctx.turnState` is handled.
 
-In `gameplay.moves`, each entry is either the apply function itself (shorthand)
-or a long-form object `{ apply, validate? }`:
+In `gameplay.moves`, each entry is either the move function itself (shorthand)
+or a long-form object `{ legacyApply, validate? }`:
 
 ```ts
 moves: {
@@ -231,13 +231,13 @@ moves: {
 }
 ```
 
-`apply` does **not** validate its arguments — it applies them blindly; legality
+`legacyApply` does **not** validate its arguments — it applies them blindly; legality
 lives in `validate`, right next to it.
 
 ### validate (optional, per move)
 
 `validate` is a pure predicate `(board, { ctx }, ...args) => boolean` colocated
-with `apply` — the single source of truth for move legality. The framework
+with `legacyApply` — the single source of truth for move legality. The framework
 rejects dispatches that fail it, and exposes it on the wrapped move as
 `moves.<name>.isAllowed(board, ...args)` (turn ownership AND `validate`, `ctx`
 bound) for the `BoardClient`'s `disabled` state. Full contract in

--- a/src/components/games/add-reduce-double/add-reduce-double.tsx
+++ b/src/components/games/add-reduce-double/add-reduce-double.tsx
@@ -108,7 +108,7 @@ export const isTransferAllowed = (board: Board, { pileId, pieceCount }): boolean
 const moves = {
   moveHalvedPieces: {
     validate: (board: Board, _, piece) => isTransferAllowed(board, piece),
-    apply: (board: Board, { events }: { events: Events }, { pileId, pieceCount }) => {
+    legacyApply: (board: Board, { events }: { events: Events }, { pileId, pieceCount }) => {
       const nextBoard = cloneDeep(board);
       nextBoard[pileId] -= pieceCount;
       nextBoard[1 - pileId] += pieceCount / 2;

--- a/src/components/games/amor-and-cupido/amor-and-cupido.tsx
+++ b/src/components/games/amor-and-cupido/amor-and-cupido.tsx
@@ -6,7 +6,7 @@ import { BoardClient } from './board-client';
 const moves = {
   claimEdge: {
     validate: (board: Board, _, edge: number) => isClaimAllowed(board, edge),
-    apply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, edge: number) => {
+    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, edge: number) => {
       const nextBoard = board.slice();
       nextBoard[edge] = ctx.currentPlayer;
       if (completesTriangle(board, ctx.currentPlayer!, edge)) {

--- a/src/components/games/architect-and-bandits/architect-and-bandits-a/architect-and-bandits-a.tsx
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-a/architect-and-bandits-a.tsx
@@ -30,7 +30,7 @@ const moves = {
   moveArchitect: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, targetVertex: number) =>
       ctx.currentPlayer === ARCHITECT && isArchitectStepAllowed(board, targetVertex, KM_PER_DAY),
-    apply: (board: Board, _, targetVertex) => {
+    legacyApply: (board: Board, _, targetVertex) => {
       const nextBoard = cloneDeep(board);
       nextBoard.architectPosition = targetVertex;
       nextBoard.towers[targetVertex] = true;
@@ -41,7 +41,7 @@ const moves = {
 
   endDay: {
     validate: (_board: Board, { ctx }: { ctx: Ctx }) => ctx.currentPlayer === ARCHITECT,
-    apply: (board: Board, { events }: { events: Events }) => {
+    legacyApply: (board: Board, { events }: { events: Events }) => {
       const nextBoard = cloneDeep(board);
       nextBoard.kmUsedToday = 0;
       if (board.day === 4) {
@@ -56,7 +56,7 @@ const moves = {
   destroyTower: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, vertex: number) =>
       ctx.currentPlayer === BANDITS && isDestructionAllowed(board, vertex),
-    apply: (board: Board, _, vertex) => {
+    legacyApply: (board: Board, _, vertex) => {
       const nextBoard = cloneDeep(board);
       nextBoard.towers[vertex] = false;
       return { nextBoard, autoEndOfTurn: true };

--- a/src/components/games/architect-and-bandits/architect-and-bandits-b/architect-and-bandits-b.tsx
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-b/architect-and-bandits-b.tsx
@@ -26,7 +26,7 @@ const moves = {
   moveArchitect: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, targetVertex: number) =>
       ctx.currentPlayer === ARCHITECT && isArchitectStepAllowed(board, targetVertex, KM_PER_DAY),
-    apply: (board: Board, _, targetVertex) => {
+    legacyApply: (board: Board, _, targetVertex) => {
       const nextBoard = cloneDeep(board);
       nextBoard.architectPosition = targetVertex;
       nextBoard.towers[targetVertex] = true;
@@ -37,7 +37,7 @@ const moves = {
 
   endDay: {
     validate: (_board: Board, { ctx }: { ctx: Ctx }) => ctx.currentPlayer === ARCHITECT,
-    apply: (board: Board, { events }: { events: Events }) => {
+    legacyApply: (board: Board, { events }: { events: Events }) => {
       const nextBoard = cloneDeep(board);
       nextBoard.kmUsedToday = 0;
       if (board.day === 4) {
@@ -53,7 +53,7 @@ const moves = {
   destroyTower: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, vertex: number) =>
       ctx.currentPlayer === BANDITS && isDestructionAllowed(board, vertex),
-    apply: (board: Board, _, vertex) => {
+    legacyApply: (board: Board, _, vertex) => {
       const nextBoard = cloneDeep(board);
       nextBoard.towers[vertex] = false;
       return { nextBoard, autoEndOfTurn: true };

--- a/src/components/games/bank-robbers/bank-robbers.tsx
+++ b/src/components/games/bank-robbers/bank-robbers.tsx
@@ -70,7 +70,7 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
 const moves = {
   rob: {
     validate: (board: Board, _, index) => isRobbable(board, index),
-    apply: (board: Board, { events }: { events: Events }, index) => {
+    legacyApply: (board: Board, { events }: { events: Events }, index) => {
       const nextBoard = cloneDeep(board);
       // so that ai strategy can be simpler: first move is always the same
       const transformedMove = board.firstMove === null ? 0 : index;

--- a/src/components/games/chess-bishops/chess-bishops.tsx
+++ b/src/components/games/chess-bishops/chess-bishops.tsx
@@ -79,7 +79,7 @@ const moves = {
   placeBishop: {
     validate: (board: Board, _, target: Field) =>
       some(getAllowedMoves(board), field => isEqual(field, target)),
-    apply: (board: Board, { events }: { events: Events }, { row, col }: Field) => {
+    legacyApply: (board: Board, { events }: { events: Events }, { row, col }: Field) => {
       const nextBoard = cloneDeep(board);
       markForbiddenFields(nextBoard, { row, col });
       nextBoard[row][col] = BISHOP;

--- a/src/components/games/chess-ducks/bot-strategy.ts
+++ b/src/components/games/chess-ducks/bot-strategy.ts
@@ -46,7 +46,7 @@ const getOptimalSmartBotMove = (board: Board): Field => {
     // shuffle + find has the same effect as filter + sample: find a random
     // from the optimal moves
     const optimalPlace = shuffle(allowedMoves).find(({ row, col }) => {
-      const { nextBoard } = moves.placeDuck.apply(board, { events: dummyEvents }, { row, col });
+      const { nextBoard } = moves.placeDuck.legacyApply(board, { events: dummyEvents }, { row, col });
       return isWinningState(nextBoard);
     });
 
@@ -126,7 +126,7 @@ const isWinningState = (board: Board): boolean => {
   const allowedPlacesForOther = getAllowedMoves(board);
 
   const optimalPlaceForOther = allowedPlacesForOther.find(({ row, col }) => {
-    const { nextBoard } = moves.placeDuck.apply(board, { events: dummyEvents }, { row, col });
+    const { nextBoard } = moves.placeDuck.legacyApply(board, { events: dummyEvents }, { row, col });
     return isWinningState(nextBoard);
   });
   return optimalPlaceForOther === undefined;

--- a/src/components/games/chess-ducks/helpers.ts
+++ b/src/components/games/chess-ducks/helpers.ts
@@ -42,7 +42,7 @@ export const isPlacementAllowed = (board: Board, field: Field): boolean =>
 export const moves = {
   placeDuck: {
     validate: (board: Board, _, field: Field) => isPlacementAllowed(board, field),
-    apply: (board: Board, { events }: { events: Events }, { row, col }: Field) => {
+    legacyApply: (board: Board, { events }: { events: Events }, { row, col }: Field) => {
       const nextBoard = cloneDeep(board);
       nextBoard[row][col] = DUCK;
       markForbiddenFields(nextBoard, { row, col });

--- a/src/components/games/chess-knight/chess-knight.tsx
+++ b/src/components/games/chess-knight/chess-knight.tsx
@@ -51,7 +51,7 @@ const moves = {
   moveKnight: {
     validate: (board: Board, _, target: Field) =>
       some(getAllowedMoves(board), field => isEqual(field, target)),
-    apply: (board: Board, { events }: { events: Events }, { row, col }: Field) => {
+    legacyApply: (board: Board, { events }: { events: Events }, { row, col }: Field) => {
       const nextBoard = cloneDeep(board);
       markVisitedFields(nextBoard, nextBoard.knightPosition);
 

--- a/src/components/games/chess-rook/chess-rook.tsx
+++ b/src/components/games/chess-rook/chess-rook.tsx
@@ -51,7 +51,7 @@ const moves = {
   moveRook: {
     validate: (board: Board, _, target: Field) =>
       some(getAllowedMoves(board), field => isEqual(field, target)),
-    apply: (board: Board, { events }: { events: Events }, { row, col }: Field) => {
+    legacyApply: (board: Board, { events }: { events: Events }, { row, col }: Field) => {
       const nextBoard = cloneDeep(board);
       markVisitedFields(nextBoard, nextBoard.rookPosition, { row, col });
 

--- a/src/components/games/chocolate-breaking/chocolate-breaking.tsx
+++ b/src/components/games/chocolate-breaking/chocolate-breaking.tsx
@@ -117,7 +117,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 const moves = {
   breakPiece: {
     validate: (board: Board, _, move: Move) => isBreakAllowed(board, move),
-    apply: (board: Board, { events }: { events: Events }, move: Move) => {
+    legacyApply: (board: Board, { events }: { events: Events }, move: Move) => {
       const nextBoard = applyBreak(board, move);
       events.endTurn();
       if (!hasSafeBreak(nextBoard.pieces)) {

--- a/src/components/games/coins-in-3-piles/helpers.ts
+++ b/src/components/games/coins-in-3-piles/helpers.ts
@@ -27,7 +27,7 @@ export const moves = {
   removeCoin: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, value: number) =>
       ctx.turnState === null && value >= 1 && value <= 3 && board[value - 1] > 0,
-    apply: (board: Board, { events }: { events: Events }, value) => {
+    legacyApply: (board: Board, { events }: { events: Events }, value) => {
       const nextBoard = cloneDeep(board);
       nextBoard[value - 1] -= 1;
       if (value === 1) {
@@ -46,7 +46,7 @@ export const moves = {
       const removed = (ctx.turnState as { removedCoinValue: number } | null)?.removedCoinValue;
       return removed != null && value >= 1 && value < removed;
     },
-    apply: (board: Board, { events }: { events: Events }, value) => {
+    legacyApply: (board: Board, { events }: { events: Events }, value) => {
       const nextBoard = cloneDeep(board);
       nextBoard[value - 1] += 1;
       return finishPlaceBack(nextBoard, events);
@@ -54,7 +54,7 @@ export const moves = {
   },
   passAddition: {
     validate: (board: Board, { ctx }: { ctx: Ctx }) => ctx.turnState !== null,
-    apply: (board: Board, { events }: { events: Events }) => finishPlaceBack(board, events)
+    legacyApply: (board: Board, { events }: { events: Events }) => finishPlaceBack(board, events)
   }
 }
 

--- a/src/components/games/cube-coloring/cube-coloring.tsx
+++ b/src/components/games/cube-coloring/cube-coloring.tsx
@@ -140,7 +140,7 @@ const moves = {
   colorVertex: {
     validate: (board: Board, _, { vertex, color }: { vertex: number; color: string | null }) =>
       isAllowedStep(board, vertex, color),
-    apply: (board: Board, { events }: { events: Events }, { vertex, color }) => {
+    legacyApply: (board: Board, { events }: { events: Events }, { vertex, color }) => {
       const nextBoard = cloneDeep(board);
       nextBoard[vertex] = color;
       events.endTurn();

--- a/src/components/games/digit-subtraction/digit-subtraction.tsx
+++ b/src/components/games/digit-subtraction/digit-subtraction.tsx
@@ -44,7 +44,7 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
 const moves = {
   subtractDigit: {
     validate: (board: Board, _, digit: number) => isSubtractableDigit(board, digit),
-    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, digit: number) => {
+    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, digit: number) => {
       const nextBoard = board - digit;
       if (nextBoard === 0) {
         events.endGame(ctx.currentPlayer!);

--- a/src/components/games/discs-flip-or-remove/discs-flip-or-remove.tsx
+++ b/src/components/games/discs-flip-or-remove/discs-flip-or-remove.tsx
@@ -110,7 +110,7 @@ export const isFlipAllowed = (board: Board, count: number): boolean =>
 export const moves = {
   removeDiscs: {
     validate: (board: Board, _, count) => isRemovalAllowed(board, count),
-    apply: (board: Board, { events }: { events: Events }, count) => {
+    legacyApply: (board: Board, { events }: { events: Events }, count) => {
       const nextBoard = cloneDeep(board);
       nextBoard[0] -= count;
       events.endTurn();
@@ -122,7 +122,7 @@ export const moves = {
   },
   turnDiscs: {
     validate: (board: Board, _, count) => isFlipAllowed(board, count),
-    apply: (board: Board, { events }: { events: Events }, count) => {
+    legacyApply: (board: Board, { events }: { events: Events }, count) => {
       const nextBoard = cloneDeep(board);
       nextBoard[1] -= count;
       nextBoard[0] += count;

--- a/src/components/games/discs-flip-or-remove/optimality.spec.ts
+++ b/src/components/games/discs-flip-or-remove/optimality.spec.ts
@@ -37,9 +37,9 @@ const moverWins = (board: Board): boolean => {
 const driveBot = (board: Board): Board => {
   let captured: Board = board;
   const ctx = makeCtx();
-  // Long-form moves ({ validate, apply }) expose their effect as `apply`.
-  const wrapped = mapValues(gameMoves, ({ apply }) => (b: Board, ...args: unknown[]) => {
-    const res = (apply as (...a: unknown[]) => { nextBoard: Board })(b, { ctx, events: dummyEvents }, ...args);
+  // Long-form moves ({ validate, legacyApply }) expose their effect as `legacyApply`.
+  const wrapped = mapValues(gameMoves, ({ legacyApply }) => (b: Board, ...args: unknown[]) => {
+    const res = (legacyApply as (...a: unknown[]) => { nextBoard: Board })(b, { ctx, events: dummyEvents }, ...args);
     captured = res.nextBoard;
     return res;
   }) as unknown as GameMoves<Board>;

--- a/src/components/games/distinct-squares/five-squares/five-squares.tsx
+++ b/src/components/games/distinct-squares/five-squares/five-squares.tsx
@@ -18,7 +18,7 @@ const generateStartBoard = (): Board => {
 const moves = {
   addPiece: {
     validate: (board: Board, _, pileId: number) => isPlacementAllowed(board, pileId),
-    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, pileId: number) => {
+    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, pileId: number) => {
       const nextBoard = cloneDeep(board);
       nextBoard[pileId] += 1;
       if (ctx.currentPlayer === 1 && [3, 6, 9].includes(sum(nextBoard))) {

--- a/src/components/games/distinct-squares/helpers.ts
+++ b/src/components/games/distinct-squares/helpers.ts
@@ -2,7 +2,7 @@
 // is no notion of a square being full or blocked. So the only thing legality
 // has to say is that the square exists.
 //
-// That is worth saying: `apply` does `nextBoard[squareId] += 1`, and on an
+// That is worth saying: `legacyApply` does `nextBoard[squareId] += 1`, and on an
 // out-of-range index that writes NaN and grows the array rather than doing
 // nothing. The two games differ only in how many squares they have, which the
 // predicate reads off the board.

--- a/src/components/games/distinct-squares/two-times-two/two-times-two.tsx
+++ b/src/components/games/distinct-squares/two-times-two/two-times-two.tsx
@@ -10,7 +10,7 @@ const generateStartBoard = (): Board => [0, 0, 0, 0];
 const moves = {
   addPiece: {
     validate: (board: Board, _, pileId) => isPlacementAllowed(board, pileId),
-    apply: (board: Board, { events }: { events: Events }, pileId) => {
+    legacyApply: (board: Board, { events }: { events: Events }, pileId) => {
       const nextBoard = cloneDeep(board);
       nextBoard[pileId] += 1;
       events.endTurn();

--- a/src/components/games/dominoes-4x4/dominoes-4x4.tsx
+++ b/src/components/games/dominoes-4x4/dominoes-4x4.tsx
@@ -164,7 +164,7 @@ const moves = {
   placeDomino: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, domino: Domino) =>
       isDominoAllowed(board, ctx.currentPlayer!, domino),
-    apply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, domino: Domino) => {
+    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, domino: Domino) => {
       const nextBoard = cloneDeep(board);
       nextBoard.push(domino);
       const nextPlayer = 1 - ctx.currentPlayer!;

--- a/src/components/games/dominoes-on-chessboard/dominoes-on-chessboard.tsx
+++ b/src/components/games/dominoes-on-chessboard/dominoes-on-chessboard.tsx
@@ -162,7 +162,7 @@ export const isDominoAllowed = (board: Board, domino: Domino): boolean =>
 const moves = {
   placeDomino: {
     validate: (board: Board, _, domino: Domino) => isDominoAllowed(board, domino),
-    apply: (board: Board, { events }: { events: Events }, domino: Domino) => {
+    legacyApply: (board: Board, { events }: { events: Events }, domino: Domino) => {
       const nextBoard = cloneDeep(board);
       nextBoard.push(domino);
       events.endTurn();

--- a/src/components/games/five-connected-fields/five-connected-fields.tsx
+++ b/src/components/games/five-connected-fields/five-connected-fields.tsx
@@ -8,7 +8,7 @@ export type { Board };
 const moves = {
   placeCoin: {
     validate: (board: Board, _, node: number) => isNodePlayable(board, node),
-    apply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, node: number) => {
+    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, node: number) => {
       const nextBoard = board.slice();
       nextBoard[node] += 1;
       events.endTurn();

--- a/src/components/games/five-five-card/five-five-card.tsx
+++ b/src/components/games/five-five-card/five-five-card.tsx
@@ -72,7 +72,7 @@ const moves = {
   removeCard: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, id: number) =>
       isRemovalAllowed(board, 1 - ctx.currentPlayer!, id),
-    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, id: number) => {
+    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, id: number) => {
       const nextBoard = cloneDeep(board);
       nextBoard[1 - ctx.currentPlayer!][id - 1] = null;
       events.endTurn();

--- a/src/components/games/four-connected-fields/four-connected-fields.tsx
+++ b/src/components/games/four-connected-fields/four-connected-fields.tsx
@@ -8,7 +8,7 @@ export type { Board };
 const moves = {
   placeCoin: {
     validate: (board: Board, _, node: number) => isNodePlayable(board, node),
-    apply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, node: number) => {
+    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, node: number) => {
       const nextBoard = board.slice();
       nextBoard[node] += 1;
       events.endTurn();

--- a/src/components/games/four-piles-spread-ahead/four-piles-spread-ahead.tsx
+++ b/src/components/games/four-piles-spread-ahead/four-piles-spread-ahead.tsx
@@ -139,7 +139,7 @@ const moves = {
   spreadPieces: {
     validate: (board: Board, _, { pileId, pieceCount }: { pileId: number; pieceCount: number }) =>
       isSpreadAllowed(board, pileId, pieceCount),
-    apply: (board: Board, { events }: { events: Events }, { pileId, pieceCount }) => {
+    legacyApply: (board: Board, { events }: { events: Events }, { pileId, pieceCount }) => {
       const nextBoard = cloneDeep(board);
       nextBoard[pileId] = board[pileId] - pieceCount;
       for (let i = pileId - pieceCount; i < pileId; i++) {

--- a/src/components/games/four-piles-two-grabs/four-piles-two-grabs.tsx
+++ b/src/components/games/four-piles-two-grabs/four-piles-two-grabs.tsx
@@ -139,7 +139,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 const moves = {
   takeStones: {
     validate: (board: Board, _, move: Move) => isMoveLegal(board, move),
-    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, move: Move) => {
+    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, move: Move) => {
       const nextBoard = applyMove(board, move);
       if (isTerminal(nextBoard)) {
         // The opponent cannot move, so the player who just moved wins.

--- a/src/components/games/hunyadi-and-the-janissaries/bot-strategy.spec.ts
+++ b/src/components/games/hunyadi-and-the-janissaries/bot-strategy.spec.ts
@@ -18,7 +18,7 @@ describe('HunyadiAndTheJanissaries strategy', () => {
     it('should split first row evenly if there are more soldiers', () => {
       const board = [[], ['blue', 'blue']] as Board;
       const soldiers = getOptimalSoldierGroups(board);
-      const { nextBoard } = moves.setGroupOfSoldiers.apply(board, {}, soldiers);
+      const { nextBoard } = moves.setGroupOfSoldiers.legacyApply(board, {}, soldiers);
       expect([[[], ['red', 'blue']], [[], ['blue', 'red']]]).toContainEqual(nextBoard);
     });
 
@@ -31,7 +31,7 @@ describe('HunyadiAndTheJanissaries strategy', () => {
         ['blue', 'blue', 'blue', 'blue']
       ] as Board;
       const soldiers = getOptimalSoldierGroups(board);
-      const { nextBoard } = moves.setGroupOfSoldiers.apply(board, {}, soldiers);
+      const { nextBoard } = moves.setGroupOfSoldiers.legacyApply(board, {}, soldiers);
       expect([
         [[], ['blue'], ['red'], [], ['red', 'red', 'red', 'red']],
         [[], ['red'], ['blue'], [], ['blue', 'blue', 'blue', 'blue']]
@@ -47,7 +47,7 @@ describe('HunyadiAndTheJanissaries strategy', () => {
         ['blue', 'blue']
       ] as Board;
       const soldiers = getOptimalSoldierGroups(board);
-      const { nextBoard } = moves.setGroupOfSoldiers.apply(board, {}, soldiers);
+      const { nextBoard } = moves.setGroupOfSoldiers.legacyApply(board, {}, soldiers);
       expect([
         [[], ['blue'], ['red', 'red', 'blue'], ['red'], ['red', 'red']],
         [[], ['red'], ['blue', 'blue', 'red'], ['blue'], ['blue', 'blue']]

--- a/src/components/games/hunyadi-and-the-janissaries/helpers.spec.ts
+++ b/src/components/games/hunyadi-and-the-janissaries/helpers.spec.ts
@@ -8,13 +8,13 @@ describe('HunyadiAndTheJanissaries helpers', () => {
   describe('moves', () => {
     it('should claim victory for Hunyadi if all soldiers are killed', () => {
       const events = makeEvents();
-      moves.killGroup.apply([[], ['red', 'red']] as Board, { events }, 'red')
+      moves.killGroup.legacyApply([[], ['red', 'red']] as Board, { events }, 'red')
       expect(events.endGame).toHaveBeenCalledWith(1);
     });
 
     it('should claim loss for Hunyadi if a soldier reaches the castle', () => {
       const events = makeEvents();
-      const { nextBoard } = moves.killGroup.apply(
+      const { nextBoard } = moves.killGroup.legacyApply(
         [[], ['red', 'blue'], ['blue']] as Board, { events }, 'red'
       );
       moves.stepUp(nextBoard, { events });
@@ -24,7 +24,7 @@ describe('HunyadiAndTheJanissaries helpers', () => {
     it('should report game as still in progress and advance remaining soldiers otherwise', () => {
       const events = makeEvents();
       const board = [[], ['red'], ['blue', 'red'], [], ['blue', 'blue']] as Board;
-      const { nextBoard } = moves.killGroup.apply(board, { events }, 'red');
+      const { nextBoard } = moves.killGroup.legacyApply(board, { events }, 'red');
       const state = moves.stepUp(nextBoard, { events });
       expect(state.nextBoard).toEqual([[], ['blue'], [], ['blue', 'blue'], []])
       expect(events.endGame).not.toHaveBeenCalled();

--- a/src/components/games/hunyadi-and-the-janissaries/helpers.ts
+++ b/src/components/games/hunyadi-and-the-janissaries/helpers.ts
@@ -65,7 +65,7 @@ export const moves = {
   killGroup: {
     validate: (board: Board, { ctx }, group: SoldierColor) =>
       ctx.currentPlayer === HUNYADI && isColor(group),
-    apply: (board: Board, { events }: { events: Events }, group: SoldierColor) => {
+    legacyApply: (board: Board, { events }: { events: Events }, group: SoldierColor) => {
       const nextBoard = board.map(row => row.filter(soldier => soldier !== group));
 
       const isGameEnd = flatten(nextBoard).length === 0;
@@ -79,7 +79,7 @@ export const moves = {
   },
   finalizeSeparation: {
     validate: (board: Board, { ctx }) => ctx.currentPlayer === SULTAN,
-    apply: (board: Board, { events }: { events: Events }) => {
+    legacyApply: (board: Board, { events }: { events: Events }) => {
       events.endTurn();
       return { nextBoard: board };
     }
@@ -87,7 +87,7 @@ export const moves = {
   setGroupOfSoldiers: {
     validate: (board: Board, { ctx }, soldiers: Soldier[]) =>
       ctx.currentPlayer === SULTAN && isSoldierAssignmentAllowed(board, soldiers),
-    apply: (board: Board, _, soldiers: Soldier[]) => {
+    legacyApply: (board: Board, _, soldiers: Soldier[]) => {
       const nextBoard = cloneDeep(board);
       for (const soldier of soldiers) {
         nextBoard[soldier.rowIndex][soldier.pieceIndex] = soldier.group;

--- a/src/components/games/latin-square-filling/latin-square-filling.tsx
+++ b/src/components/games/latin-square-filling/latin-square-filling.tsx
@@ -112,7 +112,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 const moves = {
   placeDigit: {
     validate: (board: Board, _, cell: number, digit: number) => isLegalPlacement(board, cell, digit),
-    apply: (board: Board, { events }: { ctx: Ctx; events: Events }, cell: number, digit: number) => {
+    legacyApply: (board: Board, { events }: { ctx: Ctx; events: Events }, cell: number, digit: number) => {
       const nextBoard = board.map((v, i) => (i === cell ? digit : v));
       events.endTurn();
       // The next player now faces nextBoard: a full grid means the first player

--- a/src/components/games/magic-box/magic-box-a/magic-box-a.tsx
+++ b/src/components/games/magic-box/magic-box-a/magic-box-a.tsx
@@ -27,7 +27,7 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => (
 const moves = {
   placeStone: {
     validate: (board: Board, _, id: number) => isPlacementAllowed(board, id),
-    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, id) => {
+    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, id) => {
       const nextBoard = placeStone(board, id);
       events.endTurn();
       if (isGameEnd(nextBoard)) {

--- a/src/components/games/magic-box/magic-box-b/magic-box-b.tsx
+++ b/src/components/games/magic-box/magic-box-b/magic-box-b.tsx
@@ -8,7 +8,7 @@ import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 const moves = {
   placeStone: {
     validate: (board: Board, _, cellId: number) => isPlacementAllowed(board, cellId),
-    apply: (board: Board, _, cellId) => {
+    legacyApply: (board: Board, _, cellId) => {
       const nextBoard: Board = { stones: placeStoneAt(board.stones, cellId), pendingLine: null };
       return { nextBoard };
     }
@@ -16,7 +16,7 @@ const moves = {
 
   designateLine: {
     validate: (board: Board, _, lineIndex: number) => isDesignationAllowed(board, lineIndex),
-    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, lineIndex) => {
+    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, lineIndex) => {
       const nextBoard: Board = { stones: board.stones, pendingLine: lineIndex };
       if (isLineFull(nextBoard.stones, lineIndex)) {
         events.endGame(ctx.currentPlayer === 0 ? 0 : 1);

--- a/src/components/games/matches-on-edges/matches-on-edges.tsx
+++ b/src/components/games/matches-on-edges/matches-on-edges.tsx
@@ -11,7 +11,7 @@ const moves = {
   // turn passes.
   placeWindow: {
     validate: (board: Board, _, a: number, b: number) => isWindowAllowed(board, a, b),
-    apply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, a: number, b: number) => {
+    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, a: number, b: number) => {
       const nextBoard = applyMove(board, a, b);
       if (isTerminal(nextBoard)) {
         events.endGame(ctx.currentPlayer!);

--- a/src/components/games/matchstick-piles/matchstick-piles.tsx
+++ b/src/components/games/matchstick-piles/matchstick-piles.tsx
@@ -126,7 +126,7 @@ export const isSplitAllowed = (board: Board, pileId: number, firstPart: number):
 const moves = {
   removeMatch: {
     validate: (board: Board, _, pileId: number) => isRemovalAllowed(board, pileId),
-    apply: (board: Board, { events }: { events: Events }, pileId: number) => {
+    legacyApply: (board: Board, { events }: { events: Events }, pileId: number) => {
       const nextBoard = board
         .map((n, i) => (i === pileId ? n - 1 : n))
         .filter(n => n > 0);
@@ -140,7 +140,7 @@ const moves = {
   splitPile: {
     validate: (board: Board, _, pileId: number, firstPart: number) =>
       isSplitAllowed(board, pileId, firstPart),
-    apply: (board: Board, { events }: { events: Events }, pileId: number, firstPart: number) => {
+    legacyApply: (board: Board, { events }: { events: Events }, pileId: number, firstPart: number) => {
       const size = board[pileId];
       const nextBoard = board.flatMap((n, i) =>
         i === pileId ? [firstPart, size - firstPart] : [n]

--- a/src/components/games/modified-mill/modified-mill.tsx
+++ b/src/components/games/modified-mill/modified-mill.tsx
@@ -10,7 +10,7 @@ export type { Board };
 const moves = {
   placePiece: {
     validate: (board: Board, _, node: number) => isPlacementAllowed(board, node),
-    apply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, node: number) => {
+    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, node: number) => {
       const nextBoard = board.slice();
       nextBoard[node] = playerColor(ctx.currentPlayer!);
       events.endTurn();

--- a/src/components/games/number-covering/number-covering.tsx
+++ b/src/components/games/number-covering/number-covering.tsx
@@ -98,7 +98,7 @@ const genericRule = {
 export const moves = {
   coverNumber: {
     validate: (board: Board, _, number: number) => isCoveringAllowed(board, number),
-    apply: (board: Board, { events }: { events: Events }, number) => {
+    legacyApply: (board: Board, { events }: { events: Events }, number) => {
       const nextBoard = cloneDeep(board);
       nextBoard[number-1] = COVERED;
       events.endTurn();

--- a/src/components/games/number-pyramid/number-pyramid.spec.ts
+++ b/src/components/games/number-pyramid/number-pyramid.spec.ts
@@ -19,7 +19,7 @@ describe('moves.combineTwo', () => {
   it('places combined value on next level', () => {
     const board = makeBoard([5, 4, 3, 2, 2, 2, 2, 2], 50);
     const events = makeEvents();
-    const { nextBoard } = moves.combineTwo.apply(
+    const { nextBoard } = moves.combineTwo.legacyApply(
       board, { ctx: makeCtx({ currentPlayer: 0 }), events }, { levelIdx: 0, indices: [0, 1] }
     );
     const level1Active = nextBoard.levels[1].find((s) => s?.state === 'active');
@@ -29,7 +29,7 @@ describe('moves.combineTwo', () => {
   it('marks both combined slots as consumed', () => {
     const board = makeBoard([5, 4, 3, 2, 2, 2, 2, 2], 50);
     const events = makeEvents();
-    const { nextBoard } = moves.combineTwo.apply(
+    const { nextBoard } = moves.combineTwo.legacyApply(
       board, { ctx: makeCtx({ currentPlayer: 0 }), events }, { levelIdx: 0, indices: [0, 1] }
     );
     expect(nextBoard.levels[0][0]!.state).toBe('consumed');
@@ -39,7 +39,9 @@ describe('moves.combineTwo', () => {
   it('calls endTurn when combined value is below k', () => {
     const board = makeBoard([5, 4, 3, 2, 2, 2, 2, 2], 50);
     const events = makeEvents();
-    moves.combineTwo.apply(board, { ctx: makeCtx({ currentPlayer: 0 }), events }, { levelIdx: 0, indices: [0, 1] });
+    moves.combineTwo.legacyApply(
+      board, { ctx: makeCtx({ currentPlayer: 0 }), events }, { levelIdx: 0, indices: [0, 1] }
+    );
     expect(events.endTurn).toHaveBeenCalledTimes(1);
     expect(events.endGame).not.toHaveBeenCalled();
   });
@@ -48,7 +50,9 @@ describe('moves.combineTwo', () => {
     // combined value 10+9=19 exactly equals k, so the "at least k" win must trigger
     const board = makeBoard([10, 9, 3, 2, 2, 2, 2, 2], 19);
     const events = makeEvents();
-    moves.combineTwo.apply(board, { ctx: makeCtx({ currentPlayer: 1 }), events }, { levelIdx: 0, indices: [0, 1] });
+    moves.combineTwo.legacyApply(
+      board, { ctx: makeCtx({ currentPlayer: 1 }), events }, { levelIdx: 0, indices: [0, 1] }
+    );
     expect(events.endGame).toHaveBeenCalledWith(1);
     expect(events.endTurn).not.toHaveBeenCalled();
   });
@@ -56,7 +60,9 @@ describe('moves.combineTwo', () => {
   it('does not mutate the original board', () => {
     const board = makeBoard([5, 4, 3, 2, 2, 2, 2, 2], 50);
     const events = makeEvents();
-    moves.combineTwo.apply(board, { ctx: makeCtx({ currentPlayer: 0 }), events }, { levelIdx: 0, indices: [0, 1] });
+    moves.combineTwo.legacyApply(
+      board, { ctx: makeCtx({ currentPlayer: 0 }), events }, { levelIdx: 0, indices: [0, 1] }
+    );
     expect(board.levels[0][0]!.state).toBe('active');
   });
 });

--- a/src/components/games/number-pyramid/number-pyramid.tsx
+++ b/src/components/games/number-pyramid/number-pyramid.tsx
@@ -8,7 +8,7 @@ import { BoardClient, type TurnState } from './board-client';
 export const moves = {
   combineTwo: {
     validate: (board: Board, _, move) => isCombineAllowed(board, move),
-    apply: (
+    legacyApply: (
       board: Board,
       { ctx, events }: { ctx: Ctx; events: Events },
       { levelIdx, indices }

--- a/src/components/games/pile-splitting-games/pile-splitter-3/pile-splitter-3.tsx
+++ b/src/components/games/pile-splitting-games/pile-splitter-3/pile-splitter-3.tsx
@@ -143,12 +143,12 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 const moves = {
   removePile: {
     validate: (board: Board, _, pileId: number) => isRemovalAllowed(board, pileId),
-    apply: (board: Board, _, pileId: number) => ({ nextBoard: withPileRemoved(board, pileId) })
+    legacyApply: (board: Board, _, pileId: number) => ({ nextBoard: withPileRemoved(board, pileId) })
   },
   splitPile: {
     validate: (board: Board, _, { pileId, pieceCount }: { pileId: number; pieceCount: number }) =>
       isSplitAllowed(board, pileId, pieceCount),
-    apply: (board: Board, { events }: { events: Events }, { pileId, pieceCount }) => {
+    legacyApply: (board: Board, { events }: { events: Events }, { pileId, pieceCount }) => {
       const nextBoard = cloneDeep(board);
       // the slot emptied earlier this turn takes the other half of the split
       const removedPileId = emptiedPileId(nextBoard)!;

--- a/src/components/games/pile-splitting-games/pile-splitter-4/pile-splitter-4.tsx
+++ b/src/components/games/pile-splitting-games/pile-splitter-4/pile-splitter-4.tsx
@@ -152,12 +152,12 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 const moves = {
   removePile: {
     validate: (board: Board, _, pileId: number) => isRemovalAllowed(board, pileId),
-    apply: (board: Board, _, pileId: number) => ({ nextBoard: withPileRemoved(board, pileId) })
+    legacyApply: (board: Board, _, pileId: number) => ({ nextBoard: withPileRemoved(board, pileId) })
   },
   splitPile: {
     validate: (board: Board, _, { pileId, pieceCount }: { pileId: number; pieceCount: number }) =>
       isSplitAllowed(board, pileId, pieceCount),
-    apply: (board: Board, { events }: { events: Events }, { pileId, pieceCount }) => {
+    legacyApply: (board: Board, { events }: { events: Events }, { pileId, pieceCount }) => {
       const nextBoard = cloneDeep(board);
       // the slot emptied earlier this turn takes the other half of the split
       const removedPileId = emptiedPileId(nextBoard)!;

--- a/src/components/games/pile-splitting-games/pile-splitter/pile-splitter.tsx
+++ b/src/components/games/pile-splitting-games/pile-splitter/pile-splitter.tsx
@@ -98,12 +98,12 @@ const getPlayerStepDescription = () => ({
 const moves = {
   removePile: {
     validate: (board: Board, _, pileId: number) => isRemovalAllowed(board, pileId),
-    apply: (board: Board, _, pileId) => ({ nextBoard: withPileRemoved(board, pileId) })
+    legacyApply: (board: Board, _, pileId) => ({ nextBoard: withPileRemoved(board, pileId) })
   },
   splitPile: {
     validate: (board: Board, _, { pileId, pieceCount }: { pileId: number; pieceCount: number }) =>
       isSplitAllowed(board, pileId, pieceCount),
-    apply: (board: Board, { events }: { events: Events }, { pileId, pieceCount }) => {
+    legacyApply: (board: Board, { events }: { events: Events }, { pileId, pieceCount }) => {
       const nextBoard = [pieceCount, board[pileId] - pieceCount];
       events.endTurn();
       if (isEqual(nextBoard, [1, 1])) {

--- a/src/components/games/pile-union/pile-union.tsx
+++ b/src/components/games/pile-union/pile-union.tsx
@@ -190,7 +190,7 @@ export const isMergeAllowed = (board: Board, piles: number[]): boolean =>
 const moves = {
   removeOne: {
     validate: (board: Board, _, pileIndex) => isPile(board, pileIndex),
-    apply: (board: Board, { events }: { events: Events }, pileIndex) => {
+    legacyApply: (board: Board, { events }: { events: Events }, pileIndex) => {
       const newSize = board[pileIndex] - 1;
       const nextBoard = [
         ...board.slice(0, pileIndex),
@@ -204,7 +204,7 @@ const moves = {
   },
   mergePiles: {
     validate: (board: Board, _, piles: number[]) => isMergeAllowed(board, piles),
-    apply: (board: Board, { events }: { events: Events }, [pileIndex1, pileIndex2]) => {
+    legacyApply: (board: Board, { events }: { events: Events }, [pileIndex1, pileIndex2]) => {
       const [firstIdx, secondIdx] = [pileIndex1, pileIndex2].sort((a, b) => a - b);
       const merged = board[firstIdx] + board[secondIdx];
       const nextBoard = board.filter((_, i) => i !== firstIdx && i !== secondIdx);

--- a/src/components/games/policeman-thief/policeman-thief-ab/policeman-thief-ab.tsx
+++ b/src/components/games/policeman-thief/policeman-thief-ab/policeman-thief-ab.tsx
@@ -51,7 +51,7 @@ export const moves = {
   moveThief: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, vertex: number) =>
       ctx.currentPlayer === THIEF && isNeighbour(board.thief, vertex),
-    apply: (board: Board, { events }: { events: Events }, vertex: number) => {
+    legacyApply: (board: Board, { events }: { events: Events }, vertex: number) => {
       const overrides: Partial<Board> = { thief: vertex, turnCount: board.turnCount + 1 };
       const nextBoard = { ...cloneDeep(board), ...overrides };
       events.endTurn();
@@ -65,7 +65,7 @@ export const moves = {
     validate: (board: Board, { ctx }: { ctx: Ctx }, vertex: number) =>
       ctx.currentPlayer === POLICE && !board.firstPolicemanMoved
         && isNeighbour(board.policemen[0], vertex),
-    apply: (board: Board, _, vertex: number) => {
+    legacyApply: (board: Board, _, vertex: number) => {
       const nextBoard = cloneDeep(board);
       nextBoard.policemen[0] = vertex;
       nextBoard.firstPolicemanMoved = true;
@@ -76,7 +76,7 @@ export const moves = {
     validate: (board: Board, { ctx }: { ctx: Ctx }, vertex: number) =>
       ctx.currentPlayer === POLICE && board.firstPolicemanMoved
         && isNeighbour(board.policemen[1], vertex),
-    apply: (board: Board, { events }: { events: Events }, vertex: number) => {
+    legacyApply: (board: Board, { events }: { events: Events }, vertex: number) => {
       const nextBoard = cloneDeep(board);
       nextBoard.policemen[1] = vertex;
       nextBoard.firstPolicemanMoved = false;

--- a/src/components/games/policeman-thief/policeman-thief-c/policeman-thief-c.spec.ts
+++ b/src/components/games/policeman-thief/policeman-thief-c/policeman-thief-c.spec.ts
@@ -43,7 +43,7 @@ describe('pickCopCount', () => {
 describe('moves.placeCop', () => {
   it('adds a policeman without ending the turn until all are placed', () => {
     const { events } = meta();
-    const { nextBoard } = moves.placeCop.apply(generateStartBoard(), { events }, 7);
+    const { nextBoard } = moves.placeCop.legacyApply(generateStartBoard(), { events }, 7);
     expect(nextBoard.policemen).toEqual([7]);
     expect(nextBoard.phase).toBe('placingCops');
     expect(events.endTurn).not.toHaveBeenCalled();
@@ -54,7 +54,7 @@ describe('moves.placeCop', () => {
     // pin copCount so placing the second cop reliably completes placement
     // (generateStartBoard randomises it to 2 or 3)
     const board = { ...generateStartBoard(), copCount: 2, policemen: [7] };
-    const { nextBoard } = moves.placeCop.apply(board, { events }, 3);
+    const { nextBoard } = moves.placeCop.legacyApply(board, { events }, 3);
     expect(nextBoard.policemen).toEqual([7, 3]);
     expect(nextBoard.phase).toBe('placingThief');
     expect(events.endTurn).toHaveBeenCalledTimes(1);
@@ -65,7 +65,7 @@ describe('moves.placeThief', () => {
   it('places the thief, enters the chasing phase and ends the turn', () => {
     const { events } = meta();
     const board: Board = { ...generateStartBoard(), policemen: [10, 11], phase: 'placingThief' };
-    const { nextBoard } = moves.placeThief.apply(board, { events }, 2);
+    const { nextBoard } = moves.placeThief.legacyApply(board, { events }, 2);
     expect(nextBoard.thief).toBe(2);
     expect(nextBoard.phase).toBe('chasing');
     expect(nextBoard.copCursor).toBe(0);
@@ -76,7 +76,7 @@ describe('moves.placeThief', () => {
 describe('moves.moveCop', () => {
   it('advances the cursor and keeps the turn until every policeman has moved', () => {
     const { events } = meta();
-    const { nextBoard } = moves.moveCop.apply(chasingBoard(), { events }, 12);
+    const { nextBoard } = moves.moveCop.legacyApply(chasingBoard(), { events }, 12);
     expect(nextBoard.policemen).toEqual([12, 11]);
     expect(nextBoard.copCursor).toBe(1);
     expect(events.endTurn).not.toHaveBeenCalled();
@@ -85,7 +85,7 @@ describe('moves.moveCop', () => {
 
   it('ends the turn after the last policeman moves', () => {
     const { events } = meta();
-    const { nextBoard } = moves.moveCop.apply(chasingBoard({ copCursor: 1 }), { events }, 13);
+    const { nextBoard } = moves.moveCop.legacyApply(chasingBoard({ copCursor: 1 }), { events }, 13);
     expect(nextBoard.policemen).toEqual([10, 13]);
     expect(nextBoard.copCursor).toBe(0);
     expect(events.endTurn).toHaveBeenCalledTimes(1);
@@ -94,7 +94,7 @@ describe('moves.moveCop', () => {
   it('ends the game for the police when a policeman steps onto the thief', () => {
     const { events } = meta();
     // thief on vertex 0; blue cop at 10 is adjacent to 0
-    moves.moveCop.apply(chasingBoard({ thief: 0 }), { events }, 0);
+    moves.moveCop.legacyApply(chasingBoard({ thief: 0 }), { events }, 0);
     expect(events.endGame).toHaveBeenCalledWith(0);
     expect(events.endTurn).not.toHaveBeenCalled();
   });
@@ -103,7 +103,7 @@ describe('moves.moveCop', () => {
 describe('moves.moveThief', () => {
   it('records a move and ends the turn when the thief stays free', () => {
     const { events } = meta();
-    const { nextBoard } = moves.moveThief.apply(chasingBoard({ thief: 0 }), { events }, 5);
+    const { nextBoard } = moves.moveThief.legacyApply(chasingBoard({ thief: 0 }), { events }, 5);
     expect(nextBoard.thief).toBe(5);
     expect(nextBoard.thiefMoveCount).toBe(1);
     expect(events.endTurn).toHaveBeenCalledTimes(1);
@@ -114,7 +114,7 @@ describe('moves.moveThief', () => {
     const { events } = meta();
     // thief at 9 (adjacent to 0 and 4); a cop sits on 9's neighbour... use direct overlap
     const board = chasingBoard({ thief: 0, policemen: [5, 11] });
-    moves.moveThief.apply(board, { events }, 5);
+    moves.moveThief.legacyApply(board, { events }, 5);
     expect(events.endGame).toHaveBeenCalledWith(0);
     expect(events.endTurn).not.toHaveBeenCalled();
   });
@@ -122,7 +122,7 @@ describe('moves.moveThief', () => {
   it('ends the game for the thief after a safe third move', () => {
     const { events } = meta();
     const board = chasingBoard({ thief: 0, thiefMoveCount: 2, policemen: [12, 13] });
-    moves.moveThief.apply(board, { events }, 5);
+    moves.moveThief.legacyApply(board, { events }, 5);
     expect(events.endGame).toHaveBeenCalledWith(1);
     expect(events.endTurn).not.toHaveBeenCalled();
   });

--- a/src/components/games/policeman-thief/policeman-thief-c/policeman-thief-c.tsx
+++ b/src/components/games/policeman-thief/policeman-thief-c/policeman-thief-c.tsx
@@ -40,7 +40,7 @@ export const moves = {
   placeCop: {
     validate: (board: Board, _, vertex: number) =>
       board.phase === 'placingCops' && isVertex(vertex),
-    apply: (board: Board, { events }: { events: Events }, vertex: number) => {
+    legacyApply: (board: Board, { events }: { events: Events }, vertex: number) => {
       const nextBoard = cloneDeep(board);
       nextBoard.policemen.push(vertex);
       if (nextBoard.policemen.length === nextBoard.copCount) {
@@ -54,7 +54,7 @@ export const moves = {
   placeThief: {
     validate: (board: Board, _, vertex: number) =>
       board.phase === 'placingThief' && isVertex(vertex) && !board.policemen.includes(vertex),
-    apply: (board: Board, { events }: { events: Events }, vertex: number) => {
+    legacyApply: (board: Board, { events }: { events: Events }, vertex: number) => {
       const nextBoard = cloneDeep(board);
       nextBoard.thief = vertex;
       nextBoard.phase = 'chasing';
@@ -69,7 +69,7 @@ export const moves = {
     validate: (board: Board, { ctx }: { ctx: Ctx }, vertex: number) =>
       board.phase === 'chasing' && ctx.currentPlayer === POLICE
         && isNeighbour(board.policemen[board.copCursor], vertex),
-    apply: (board: Board, { events }: { events: Events }, vertex: number) => {
+    legacyApply: (board: Board, { events }: { events: Events }, vertex: number) => {
       const nextBoard = cloneDeep(board);
       nextBoard.policemen[nextBoard.copCursor] = vertex;
       nextBoard.copCursor += 1;
@@ -90,7 +90,7 @@ export const moves = {
     validate: (board: Board, { ctx }: { ctx: Ctx }, vertex: number) =>
       board.phase === 'chasing' && ctx.currentPlayer === THIEF
         && isNeighbour(board.thief!, vertex),
-    apply: (board: Board, { events }: { events: Events }, vertex: number) => {
+    legacyApply: (board: Board, { events }: { events: Events }, vertex: number) => {
       const nextBoard = cloneDeep(board);
       nextBoard.thief = vertex;
       nextBoard.thiefMoveCount += 1;

--- a/src/components/games/polynomial-building/polynomial-building.tsx
+++ b/src/components/games/polynomial-building/polynomial-building.tsx
@@ -9,7 +9,7 @@ const moves = {
   setCoefficient: {
     validate: (board: Board, _, coef: Coef, value: number) =>
       isCoefficientChoiceAllowed(board, coef, value),
-    apply: (board: Board, { events }: { events: Events }, coef: Coef, value: number) => {
+    legacyApply: (board: Board, { events }: { events: Events }, coef: Coef, value: number) => {
       const nextBoard = { ...board, [coef]: value };
       const filled = nextBoard.a !== null && nextBoard.b !== null && nextBoard.c !== null;
       if (filled) {

--- a/src/components/games/recolouring-discs/recolouring-discs.tsx
+++ b/src/components/games/recolouring-discs/recolouring-discs.tsx
@@ -40,13 +40,13 @@ const moves = {
   moveDisc: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, from: number, to: number) =>
       isDiscMoveAllowed(board.cells, ctx.currentPlayer!, from, to),
-    apply: (board: Board, meta: { ctx: Ctx; events: Events }, from: number, to: number) =>
+    legacyApply: (board: Board, meta: { ctx: Ctx; events: Events }, from: number, to: number) =>
       finalize(applyMove(board.cells, meta.ctx.currentPlayer!, { type: 'move', from, to }), meta)
   },
   placeDisc: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, at: number) =>
       isPlacementAllowed(board.cells, ctx.currentPlayer!, at),
-    apply: (board: Board, meta: { ctx: Ctx; events: Events }, at: number) =>
+    legacyApply: (board: Board, meta: { ctx: Ctx; events: Events }, at: number) =>
       finalize(applyMove(board.cells, meta.ctx.currentPlayer!, { type: 'place', to: at }), meta)
   },
   pass: (board: Board, meta: { ctx: Ctx; events: Events }) =>

--- a/src/components/games/remove-divisor-multiple/remove-divisor-multiple.tsx
+++ b/src/components/games/remove-divisor-multiple/remove-divisor-multiple.tsx
@@ -64,7 +64,7 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
 const moves = {
   removeNumber: {
     validate: (board: Board, _, n) => isAllowed(board, n),
-    apply: (board: Board, { events }: { events: Events }, n) => {
+    legacyApply: (board: Board, { events }: { events: Events }, n) => {
       const nextBoard = cloneDeep(board);
       nextBoard.numbersOnTable[n - 1] = false;
       nextBoard.previousMove = n;

--- a/src/components/games/remove-row-or-column/board-client.tsx
+++ b/src/components/games/remove-row-or-column/board-client.tsx
@@ -107,7 +107,7 @@ export const BoardClient = ({ board, ctx, events, moves }: BoardClientProps<Boar
 export const moves = {
   removeLine: {
     validate: (board: Board, _, move: Move) => isRemovalAllowed(board.grid, move),
-    apply: (board: Board, { events }: { events: Events }, move: Move) => {
+    legacyApply: (board: Board, { events }: { events: Events }, move: Move) => {
       const nextBoard = { grid: applyMove(board.grid, move) };
       events.setTurnState(null);
       events.endTurn();

--- a/src/components/games/rock-paper-scissor/rock-paper-scissor.tsx
+++ b/src/components/games/rock-paper-scissor/rock-paper-scissor.tsx
@@ -69,7 +69,7 @@ const moves = {
   removeSymbol: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, idx: number) =>
       isRemovalAllowed(board, 1 - ctx.currentPlayer!, idx),
-    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, idx: number) => {
+    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, idx: number) => {
       const nextBoard = cloneDeep(board);
       nextBoard[1 - ctx.currentPlayer!][idx] = null;
       events.endTurn();

--- a/src/components/games/rook-to-corner/rook-to-corner.tsx
+++ b/src/components/games/rook-to-corner/rook-to-corner.tsx
@@ -55,7 +55,7 @@ const moves = {
   moveRook: {
     validate: (board: Board, _, target: Field) =>
       some(getAllowedMoves(board), field => isEqual(field, target)),
-    apply: (board: Board, { events }: { events: Events }, { row, col }: Field) => {
+    legacyApply: (board: Board, { events }: { events: Events }, { row, col }: Field) => {
       const nextBoard = cloneDeep(board);
       nextBoard.rookPosition = { row, col };
 

--- a/src/components/games/shark-chase/shark-4-by-4/shark-chase.tsx
+++ b/src/components/games/shark-chase/shark-4-by-4/shark-chase.tsx
@@ -20,7 +20,7 @@ const moves = {
   moveSubmarine: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, move: { from: number; to: number }) =>
       ctx.currentPlayer === RESEARCHERS && !!move && isSubmarineMoveAllowed(board, move.from, move.to),
-    apply: (board: Board, { events }: { events: Events }, { from, to }: { from: number; to: number }) => {
+    legacyApply: (board: Board, { events }: { events: Events }, { from, to }: { from: number; to: number }) => {
       const nextBoard = cloneDeep(board);
       nextBoard.submarines[from] -= 1;
       nextBoard.submarines[to] += 1;
@@ -34,7 +34,7 @@ const moves = {
   moveShark: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, to: number) =>
       ctx.currentPlayer === SHARK && isSharkMoveAllowed(board, to),
-    apply: (board: Board, { events }: { events: Events }, to: number) => {
+    legacyApply: (board: Board, { events }: { events: Events }, to: number) => {
       const nextBoard = cloneDeep(board);
       nextBoard.shark = to;
 

--- a/src/components/games/shark-chase/shark-5-by-5/shark-chase.tsx
+++ b/src/components/games/shark-chase/shark-5-by-5/shark-chase.tsx
@@ -26,7 +26,7 @@ const moves = {
   moveSubmarine: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, move: { from: number; to: number }) =>
       ctx.currentPlayer === RESEARCHERS && !!move && isSubmarineMoveAllowed(board, move.from, move.to),
-    apply: (board: Board, { events }: { events: Events }, { from, to }: { from: number; to: number }) => {
+    legacyApply: (board: Board, { events }: { events: Events }, { from, to }: { from: number; to: number }) => {
       const nextBoard = cloneDeep(board);
       nextBoard.submarines[from] -= 1;
       nextBoard.submarines[to] += 1;
@@ -40,7 +40,7 @@ const moves = {
   moveShark: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, to: number) =>
       ctx.currentPlayer === SHARK && isSharkMoveAllowed(board, to),
-    apply: (board: Board, { events }: { events: Events }, to: number) => {
+    legacyApply: (board: Board, { events }: { events: Events }, to: number) => {
       const nextBoard = cloneDeep(board);
       nextBoard.shark = to;
 

--- a/src/components/games/single-number-increase/increment-or-double/increment-or-double.tsx
+++ b/src/components/games/single-number-increase/increment-or-double/increment-or-double.tsx
@@ -49,7 +49,7 @@ const moves = {
   double: {
     // Doubling nothing says nothing, so the opening move can only be x+1 = 1.
     validate: (board: Board) => board >= 1,
-    apply: (board: Board, meta: { ctx: Ctx, events: Events }) => say(board * 2, meta)
+    legacyApply: (board: Board, meta: { ctx: Ctx, events: Events }) => say(board * 2, meta)
   }
 };
 

--- a/src/components/games/single-number-increase/plus-one-two-three/plus-one-two-three.tsx
+++ b/src/components/games/single-number-increase/plus-one-two-three/plus-one-two-three.tsx
@@ -43,7 +43,7 @@ export const isIncreaseValid = ({ board, number }: { board: Board; number: numbe
 const moves = {
   increaseTo: {
     validate: (board: Board, _, number: number) => isIncreaseValid({ board, number }),
-    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, number) => {
+    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, number) => {
       events.endTurn();
       if (number > target) {
         events.endGame(1 - ctx.currentPlayer!)

--- a/src/components/games/single-number-increase/superstitious-counting/superstitious-counting.tsx
+++ b/src/components/games/single-number-increase/superstitious-counting/superstitious-counting.tsx
@@ -73,7 +73,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 const moves = {
   step: {
     validate: (board: Board, _, step: number) => isStepAllowed(board, step),
-    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, step) => {
+    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, step) => {
       const numberAfterStep = board.current + step;
       const nextBoard = { current: numberAfterStep, target: board.target, restricted: 13 - step };
       events.endTurn();

--- a/src/components/games/single-pile-removal/doubling-reduction/doubling-reduction.tsx
+++ b/src/components/games/single-pile-removal/doubling-reduction/doubling-reduction.tsx
@@ -49,7 +49,7 @@ export const chooseSmartTake = (board: Board): number => {
 const moves = {
   take: {
     validate: validateTake,
-    apply: (board: Board, { events }: { events: Events }, count: number) => {
+    legacyApply: (board: Board, { events }: { events: Events }, count: number) => {
       // Next player may take strictly less than twice this take, i.e. up to 2·count − 1.
       const nextBoard: Board = { stones: board.stones - count, maxTake: 2 * count - 1 };
       events.endTurn();

--- a/src/components/games/single-pile-removal/prime-exponentials/prime-exponentials.tsx
+++ b/src/components/games/single-pile-removal/prime-exponentials/prime-exponentials.tsx
@@ -164,7 +164,7 @@ const moves = {
   subtractPrimeExponent: {
     validate: (board: Board, _, entry: { prime: number; exponent: number }) =>
       isSubtractionAllowed(board, entry),
-    apply: (board: Board, { events }: { events: Events }, { prime, exponent }) => {
+    legacyApply: (board: Board, { events }: { events: Events }, { prime, exponent }) => {
       const nextBoard = board - prime ** exponent;
       events.endTurn();
       if (nextBoard === 0) {

--- a/src/components/games/single-pile-removal/primely-to-zero/primely-to-zero.tsx
+++ b/src/components/games/single-pile-removal/primely-to-zero/primely-to-zero.tsx
@@ -46,7 +46,7 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
 const moves = {
   moveTo: {
     validate: (board: Board, _, target: number) => isMoveValid(board, target),
-    apply: (_board: Board, { ctx, events }: { ctx: Ctx, events: Events }, target: number) => {
+    legacyApply: (_board: Board, { ctx, events }: { ctx: Ctx, events: Events }, target: number) => {
       const winner = ctx.currentPlayer!;
       events.endTurn();
       if (target === 0) {

--- a/src/components/games/single-pile-removal/take-1-or-halve/take-1-or-halve.tsx
+++ b/src/components/games/single-pile-removal/take-1-or-halve/take-1-or-halve.tsx
@@ -63,7 +63,7 @@ const moves = {
   halve: {
     // Half may only be taken when the pile is even; taking one is always legal.
     validate: (board: Board) => board >= 2 && board % 2 === 0,
-    apply: (board: Board, { events }: { events: Events }) => {
+    legacyApply: (board: Board, { events }: { events: Events }) => {
       events.endTurn();
       return { nextBoard: board / 2 };
     }

--- a/src/components/games/single-pile-removal/take-power-of-two/take-power-of-two.tsx
+++ b/src/components/games/single-pile-removal/take-power-of-two/take-power-of-two.tsx
@@ -103,7 +103,7 @@ const moves = {
     // A power of 2 may be subtracted only if it does not exceed the number —
     // exactly the exponents the board already offers.
     validate: (board: Board, _, exponent: number) => getAvailableExponents(board).includes(exponent),
-    apply: (board: Board, { events }: { events: Events }, exponent: number) => {
+    legacyApply: (board: Board, { events }: { events: Events }, exponent: number) => {
       const nextBoard = board - 2 ** exponent;
       events.endTurn();
       if (nextBoard === 0) {

--- a/src/components/games/single-pile-removal/three-more/three-more.tsx
+++ b/src/components/games/single-pile-removal/three-more/three-more.tsx
@@ -58,7 +58,7 @@ export const chooseSmartTake = (board: Board): number => {
 const moves = {
   take: {
     validate: validateTake,
-    apply: (board: Board, { events }: { events: Events }, count: number) => {
+    legacyApply: (board: Board, { events }: { events: Events }, count: number) => {
       const nextBoard: Board = { stones: board.stones - count, maxTake: count + INCREMENT };
       events.endTurn();
       if (nextBoard.stones === 0) events.endGame(); // mover took the last stone(s) → wins

--- a/src/components/games/single-pile-removal/waning-stones/waning-stones.tsx
+++ b/src/components/games/single-pile-removal/waning-stones/waning-stones.tsx
@@ -35,7 +35,7 @@ export const chooseSmartTake = (board: Board): number => {
 const moves = {
   take: {
     validate: validateTake,
-    apply: (board: Board, { events }: { events: Events }, count: number) => {
+    legacyApply: (board: Board, { events }: { events: Events }, count: number) => {
       const nextBoard: Board = { stones: board.stones - count, maxTake: count };
       events.endTurn();
       if (nextBoard.stones === 0) events.endGame(); // mover took the last stone(s) → wins

--- a/src/components/games/six-fields-circle/six-fields-circle.tsx
+++ b/src/components/games/six-fields-circle/six-fields-circle.tsx
@@ -10,7 +10,7 @@ export type { Board };
 const moves = {
   removeFromTwo: {
     validate: (board: Board, _, move: Move) => isRemovalAllowed(board, move),
-    apply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, [i, j]: Move) => {
+    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, [i, j]: Move) => {
       const nextBoard = board.slice();
       nextBoard[i] -= 1;
       nextBoard[j] -= 1;

--- a/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
+++ b/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
@@ -73,7 +73,7 @@ const moves = {
   removeStone: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, pileId) =>
       isRemovalAllowed(board, ctx.currentPlayer!, pileId),
-    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, pileId) => {
+    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, pileId) => {
       const nextBoard = cloneDeep(board);
       nextBoard.piles[pileId] = board.piles[pileId] - 1;
       nextBoard.leftRestriction[ctx.currentPlayer!] = (pileId === 0);

--- a/src/components/games/sum-fifteen/sum-fifteen.tsx
+++ b/src/components/games/sum-fifteen/sum-fifteen.tsx
@@ -79,7 +79,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 const moves = {
   chooseNumber: {
     validate: (board: Board, _, n: number) => isChoiceAllowed(board.owner, n),
-    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, n: number) => {
+    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, n: number) => {
       const player = ctx.currentPlayer as 0 | 1;
       const owner = board.owner.slice() as Board['owner'];
       owner[n - 1] = player;

--- a/src/components/games/ten-coins/optimality.spec.ts
+++ b/src/components/games/ten-coins/optimality.spec.ts
@@ -40,9 +40,9 @@ const driveBot = (set: Vals): Vals => {
   const board = [...set];
   let captured = board;
   const ctx = makeCtx();
-  // Long-form moves ({ validate, apply }) expose their effect as `apply`.
-  const wrapped = mapValues(gameMoves, ({ apply }) => (b: number[], ...args: unknown[]) => {
-    const res = (apply as (...a: unknown[]) => { nextBoard: number[] })(b, { ctx, events: dummyEvents }, ...args);
+  // Long-form moves ({ validate, legacyApply }) expose their effect as `legacyApply`.
+  const wrapped = mapValues(gameMoves, ({ legacyApply }) => (b: number[], ...args: unknown[]) => {
+    const res = (legacyApply as (...a: unknown[]) => { nextBoard: number[] })(b, { ctx, events: dummyEvents }, ...args);
     captured = res.nextBoard;
     return res;
   }) as unknown as GameMoves<number[]>;

--- a/src/components/games/ten-coins/ten-coins.tsx
+++ b/src/components/games/ten-coins/ten-coins.tsx
@@ -163,7 +163,7 @@ export const isConversionAllowed = (board: Board, k: number, l: number): boolean
 export const moves = {
   convert: {
     validate: (board: Board, _, k, l) => isConversionAllowed(board, k, l),
-    apply: (board: Board, { events }: { events: Events }, k, l) => {
+    legacyApply: (board: Board, { events }: { events: Events }, k, l) => {
       const nextBoard = board.map(v => (v === k ? l : v)).sort((a, b) => a - b);
       if (uniq(nextBoard).length === 1) {
         events.endGame(); // whoever equalises the coins wins → current player

--- a/src/components/games/ten-digit-number/ten-digit-number.tsx
+++ b/src/components/games/ten-digit-number/ten-digit-number.tsx
@@ -94,7 +94,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 const moves = {
   chooseDigit: {
     validate: (board: Board, _, digit) => isDigitChoiceAllowed(board, digit),
-    apply: (board: Board, { events }: { events: Events }, digit) => {
+    legacyApply: (board: Board, { events }: { events: Events }, digit) => {
       const newDigits = [...board.digits, digit];
       const newSumMod9 = (board.sumMod9 + digit) % 9;
       const nextBoard = { digits: newDigits, sumMod9: newSumMod9 };

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/moves.ts
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/moves.ts
@@ -22,7 +22,9 @@ export const moves = {
     // the game happens inside `applyTakeCard`, not as a move argument.
     validate: (board: Board, _, indices: number[]) =>
       Array.isArray(indices) && indices.length === 1 && isCardAvailable(board, CARD_COUNT, indices[0]),
-    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, indices: number[]): { nextBoard: Board } => {
+    legacyApply: (
+      board: Board, { ctx, events }: { ctx: Ctx, events: Events }, indices: number[]
+    ): { nextBoard: Board } => {
       const nextBoard = applyTakeCard(board, ctx.currentPlayer!, indices);
       if (nextBoard.numTurns >= 5) {
         const winner = hasWinningTriple(nextBoard.cards[Thief]) ? Thief : Sheriff;

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/moves.ts
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/moves.ts
@@ -17,7 +17,7 @@ export const applyTakeCard = (board: Board, player: number, idx: number): Board 
 export const moves = {
   takeCard: {
     validate: (board: Board, _, idx: number) => isCardAvailable(board, CARD_COUNT, idx),
-    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, idx: number): { nextBoard: Board } => {
+    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, idx: number): { nextBoard: Board } => {
       const nextBoard = applyTakeCard(board, ctx.currentPlayer!, idx);
       if (nextBoard.numTurns === 8) {
         const winner = hasWinningTriple(nextBoard.cards[Thief]) ? Thief : Sheriff;

--- a/src/components/games/three-piles-rebuild/three-piles-rebuild.tsx
+++ b/src/components/games/three-piles-rebuild/three-piles-rebuild.tsx
@@ -175,13 +175,13 @@ const moves = {
   // Step 1 of a turn: keep one pile, discard the other two (shown as 0).
   keepPile: {
     validate: (board: Board, _, keepId: number) => isKeepAllowed(board, keepId),
-    apply: (board: Board, _, keepId: number) =>
+    legacyApply: (board: Board, _, keepId: number) =>
       ({ nextBoard: withOtherPilesDiscarded(board, keepId) })
   },
   // Step 2: rebuild three new piles from the kept pile's pebbles.
   splitPile: {
     validate: (board: Board, _, parts: number[]) => isSplitAllowed(board, parts),
-    apply: (_board: Board, { events }: { events: Events }, parts: number[]) => {
+    legacyApply: (_board: Board, { events }: { events: Events }, parts: number[]) => {
       const nextBoard = [...parts];
       events.endTurn();
       // The opponent now faces nextBoard; if they cannot split any pile they lose.

--- a/src/components/games/tictactoe-alikes/anti-tictactoe/anti-tictactoe.tsx
+++ b/src/components/games/tictactoe-alikes/anti-tictactoe/anti-tictactoe.tsx
@@ -42,7 +42,7 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
 const moves = {
   placePiece: {
     validate: validatePlacement,
-    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, id) => {
+    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, id) => {
       const nextBoard = cloneDeep(board);
       nextBoard[id] = ctx.currentPlayer === 0 ? 'red' : 'blue';
       events.endTurn();

--- a/src/components/games/tictactoe-alikes/tictactoe-doublestart/tictactoe-doublestart.tsx
+++ b/src/components/games/tictactoe-alikes/tictactoe-doublestart/tictactoe-doublestart.tsx
@@ -44,7 +44,7 @@ const isDuringFirstMove = (board: Board) => board.filter(c => c).length <= 1;
 const moves = {
   placePiece: {
     validate: validatePlacement,
-    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, id) => {
+    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, id) => {
       const nextBoard = cloneDeep(board);
       nextBoard[id] = ctx.currentPlayer === 0 ? 'red' : 'blue';
 

--- a/src/components/games/tictactoe-alikes/tictactoe/tictactoe.tsx
+++ b/src/components/games/tictactoe-alikes/tictactoe/tictactoe.tsx
@@ -61,7 +61,7 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
 const moves = {
   placePiece: {
     validate: validatePlacement,
-    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, id) => {
+    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, id) => {
       const nextBoard = cloneDeep(board);
       nextBoard[id] = currentPlayerColor(ctx);
       events.endTurn();
@@ -73,7 +73,7 @@ const moves = {
   },
   whitenPiece: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, id: number) => isWhiteningAllowed(board, ctx, id),
-    apply: (board: Board, { events }: { events: Events }, id) => {
+    legacyApply: (board: Board, { events }: { events: Events }, id) => {
       const nextBoard = cloneDeep(board);
       nextBoard[id] = 'white';
       events.endTurn();

--- a/src/components/games/totem-poles/triangular-grid-ropes-10/triangular-grid-ropes-10.tsx
+++ b/src/components/games/totem-poles/triangular-grid-ropes-10/triangular-grid-ropes-10.tsx
@@ -103,7 +103,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 const moves = {
   stretchRope: {
     validate: (board: Board, _, edge: Edge) => isAllowed(board, edge),
-    apply: (board: Board, { events }: { events: Events }, { from, to }) => {
+    legacyApply: (board: Board, { events }: { events: Events }, { from, to }) => {
       const nextBoard = cloneDeep(board);
       // A rope is stretched as far as it legally reaches, not just between the
       // two nodes that were clicked.

--- a/src/components/games/totem-poles/triangular-grid-ropes-15/triangular-grid-ropes-15.tsx
+++ b/src/components/games/totem-poles/triangular-grid-ropes-15/triangular-grid-ropes-15.tsx
@@ -103,7 +103,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 const moves = {
   stretchRope: {
     validate: (board: Board, _, edge: Edge) => isAllowed(board, edge),
-    apply: (board: Board, { events }: { events: Events }, { from, to }) => {
+    legacyApply: (board: Board, { events }: { events: Events }, { from, to }) => {
       const nextBoard = cloneDeep(board);
       // A rope is stretched as far as it legally reaches, not just between the
       // two nodes that were clicked.

--- a/src/components/games/triangle-circle-game/triangle-circle-game.spec.ts
+++ b/src/components/games/triangle-circle-game/triangle-circle-game.spec.ts
@@ -6,7 +6,7 @@ import { makeEvents } from '../../../test-utils';
 describe('moves.shadeEdge', () => {
   it('shades the edge and passes the turn', () => {
     const events = makeEvents();
-    const { nextBoard } = moves.shadeEdge.apply(generateStartBoard(), { events }, 0);
+    const { nextBoard } = moves.shadeEdge.legacyApply(generateStartBoard(), { events }, 0);
     expect(nextBoard.edges[0]).toBe(true);
     expect(events.endTurn).toHaveBeenCalled();
     expect(events.endGame).not.toHaveBeenCalled();
@@ -16,7 +16,7 @@ describe('moves.shadeEdge', () => {
     const [e0, e1, e2] = TRIANGLES[0].edgeIds;
     const board = applyShade(applyShade(generateStartBoard(), e0), e1);
     const events = makeEvents();
-    moves.shadeEdge.apply(board, { events }, e2);
+    moves.shadeEdge.legacyApply(board, { events }, e2);
     expect(events.endGame).toHaveBeenCalledWith(LINE);
     expect(events.endTurn).not.toHaveBeenCalled();
   });
@@ -25,7 +25,7 @@ describe('moves.shadeEdge', () => {
     const [e0, e1, e2] = TRIANGLES[0].edgeIds;
     const board = applyCircle(applyShade(applyShade(generateStartBoard(), e0), e1), 0);
     const events = makeEvents();
-    moves.shadeEdge.apply(board, { events }, e2);
+    moves.shadeEdge.legacyApply(board, { events }, e2);
     expect(events.endTurn).toHaveBeenCalled();
     expect(events.endGame).not.toHaveBeenCalled();
   });
@@ -34,7 +34,7 @@ describe('moves.shadeEdge', () => {
 describe('moves.placeCircle', () => {
   it('places the circle and passes the turn', () => {
     const events = makeEvents();
-    const { nextBoard } = moves.placeCircle.apply(generateStartBoard(), { events }, 7);
+    const { nextBoard } = moves.placeCircle.legacyApply(generateStartBoard(), { events }, 7);
     expect(nextBoard.circles[7]).toBe(true);
     expect(events.endTurn).toHaveBeenCalled();
     expect(events.endGame).not.toHaveBeenCalled();
@@ -44,7 +44,7 @@ describe('moves.placeCircle', () => {
     const circles = new Array(TRIANGLE_COUNT).fill(true);
     circles[12] = false;
     const events = makeEvents();
-    moves.placeCircle.apply({ edges: generateStartBoard().edges, circles }, { events }, 12);
+    moves.placeCircle.legacyApply({ edges: generateStartBoard().edges, circles }, { events }, 12);
     expect(events.endGame).toHaveBeenCalledWith(CIRCLE);
     expect(events.endTurn).not.toHaveBeenCalled();
   });

--- a/src/components/games/triangle-circle-game/triangle-circle-game.tsx
+++ b/src/components/games/triangle-circle-game/triangle-circle-game.tsx
@@ -15,7 +15,7 @@ export const moves = {
   shadeEdge: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, edgeId: number) =>
       ctx.currentPlayer === LINE && isShadeAllowed(board, edgeId),
-    apply: (board: Board, { events }: { events: Events }, edgeId: number) => {
+    legacyApply: (board: Board, { events }: { events: Events }, edgeId: number) => {
       const nextBoard = applyShade(board, edgeId);
       if (isLineWin(nextBoard)) {
         events.endGame(LINE);
@@ -30,7 +30,7 @@ export const moves = {
   placeCircle: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, triangleId: number) =>
       ctx.currentPlayer === CIRCLE && isCirclePlacementAllowed(board, triangleId),
-    apply: (board: Board, { events }: { events: Events }, triangleId: number) => {
+    legacyApply: (board: Board, { events }: { events: Events }, triangleId: number) => {
       const nextBoard = applyCircle(board, triangleId);
       if (isCircleWin(nextBoard)) {
         events.endGame(CIRCLE);

--- a/src/components/games/triangle-coloring/triangle-coloring.tsx
+++ b/src/components/games/triangle-coloring/triangle-coloring.tsx
@@ -119,7 +119,7 @@ export const isColoringAllowed = (board: Board, id: number): boolean =>
 const moves = {
   colorTriangle: {
     validate: (board: Board, _, id: number) => isColoringAllowed(board, id),
-    apply: (board: Board, { events }: { events: Events }, id: number) => {
+    legacyApply: (board: Board, { events }: { events: Events }, id: number) => {
       const nextBoard = cloneDeep(board);
       nextBoard[id] = COLORED;
       triangles[id].neighbors.forEach(n => {
@@ -148,7 +148,7 @@ const smartBotStrategy = ({ board, moves }: StrategyArgs<Board>) => {
 const getOptimalSmartBotMove = (board: Board) => {
   const allowedMoves = getAllowedMoves(board);
   const optimalPlace = shuffle(allowedMoves).find(i => {
-    const { nextBoard } = moves.colorTriangle.apply(board, { events: dummyEvents }, i);
+    const { nextBoard } = moves.colorTriangle.legacyApply(board, { events: dummyEvents }, i);
     return isWinningState(nextBoard);
   });
 
@@ -166,7 +166,7 @@ const isWinningState = (board: Board) => {
   }
 
   const optimalPlaceForOther = allowedPlacesForOther.find(i => {
-    const { nextBoard } = moves.colorTriangle.apply(board, { events: dummyEvents }, i);
+    const { nextBoard } = moves.colorTriangle.legacyApply(board, { events: dummyEvents }, i);
     return isWinningState(nextBoard);
   });
   return optimalPlaceForOther === undefined;

--- a/src/components/games/twelve-squares/twelve-squares.tsx
+++ b/src/components/games/twelve-squares/twelve-squares.tsx
@@ -76,7 +76,7 @@ const getOptimalBotStep = ({ left, right }) => {
 const moves = {
   step: {
     validate: (board: Board, _, step) => isValidStep(board, step),
-    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, step) => {
+    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, step) => {
       const nextBoard = ctx.currentPlayer === 0
         ? { left: board.left + step, right: board.right }
         : { left: board.left, right: board.right - step };

--- a/src/components/games/two-of-three-takeaway/two-of-three-takeaway.tsx
+++ b/src/components/games/two-of-three-takeaway/two-of-three-takeaway.tsx
@@ -105,7 +105,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 const moves = {
   takeChips: {
     validate: (board: Board, _, i: number, j: number) => isTakeAllowed(board, i, j),
-    apply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, i: number, j: number) => {
+    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, i: number, j: number) => {
       const nextBoard = applyMove(board, [i, j]);
       if (isTerminal(nextBoard)) {
         // The opponent cannot move, so the player who just moved wins.

--- a/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
@@ -520,7 +520,7 @@ describe('move validate enforcement', () => {
     gameplay: {
       moves: {
         guarded: {
-          apply: (board: Board, _meta: { events: Events }, arg: string) => ({ nextBoard: [...board, arg] }),
+          legacyApply: (board: Board, _meta: { events: Events }, arg: string) => ({ nextBoard: [...board, arg] }),
           validate: (_board: Board, _meta: { ctx: Ctx }, arg: string) => arg === 'ok'
         },
         handOver: (board: Board, { events }: { events: Events }) => {
@@ -606,14 +606,14 @@ describe('move validate enforcement', () => {
       moves: {
         phase1: {
           validate: (_board: Board, { ctx }: { ctx: Ctx }) => ctx.turnState === null,
-          apply: (board: Board, { events }: { events: Events }) => {
+          legacyApply: (board: Board, { events }: { events: Events }) => {
             events.setTurnState({ removedCoinValue: 3 });
             return { nextBoard: [...board, 'p1'] };
           }
         },
         phase2: {
           validate: (_board: Board, { ctx }: { ctx: Ctx }) => ctx.turnState !== null,
-          apply: (board: Board, { events }: { events: Events }) => {
+          legacyApply: (board: Board, { events }: { events: Events }) => {
             events.endTurn();
             events.setTurnState(null);
             return { nextBoard: [...board, 'p2'] };

--- a/src/components/strategy-game-factory/strategy-game-factory.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.tsx
@@ -42,9 +42,9 @@ export const strategyGameFactory = <TBoard,>({
   const { rule, roleLabels, getPlayerStepDescription } = presentation;
   const { moves, endOfTurnMove } = gameplay;
   const { defaultVariantIndex, defaultVariant, resolvedVariants } = resolveVariants(variants);
-  // Normalize the shorthand (plain function = apply with no validator) so the
+  // Normalize the shorthand (plain function = legacyApply with no validator) so the
   // rest of the engine deals with a single long-form shape.
-  const normalizedMoves = mapValues(moves, (m) => typeof m === 'function' ? { apply: m } : m);
+  const normalizedMoves = mapValues(moves, (m) => typeof m === 'function' ? { legacyApply: m } : m);
 
   return () => {
     const { t } = useTranslation();
@@ -252,9 +252,9 @@ export const strategyGameFactory = <TBoard,>({
       }
     };
 
-    wrappedGameMoves = mapValues(normalizedMoves, ({ apply }, name) => {
+    wrappedGameMoves = mapValues(normalizedMoves, ({ legacyApply }, name) => {
       const wrapped: GameMoves<TBoard>[string] = (board: TBoard, ...args: unknown[]) =>
-        moveWrapper(name, board, args, () => apply(board, { ctx, events }, ...args));
+        moveWrapper(name, board, args, () => legacyApply(board, { ctx, events }, ...args));
       return wrapped;
     });
 

--- a/src/components/strategy-game-factory/types.ts
+++ b/src/components/strategy-game-factory/types.ts
@@ -26,18 +26,21 @@ export type MoveFunction<TBoard> = (
   board: TBoard, meta: { ctx: Ctx; events: Events }, ...args: any[]
 ) => MoveResult<TBoard>
 // Pure, side-effect-free legality predicate for a single move, colocated with
-// its `apply` in the long-form move definition. Because it depends only on
+// its `legacyApply` in the long-form move definition. Because it depends only on
 // `board` + `ctx` (no React, no `events`), the same function drives the UI
 // (button `disabled`), the engine (illegal-move enforcement) and, in the
 // future, an authoritative server-side check.
 type MoveValidator<TBoard> = (
   board: TBoard, meta: { ctx: Ctx }, ...args: any[]
 ) => boolean
-// A move is either a plain apply function (shorthand — always accepted by the
+// A move is either a plain move function (shorthand — always accepted by the
 // engine) or a long-form object pairing it with an optional legality validator.
+// The key is named `legacyApply` because this events-based contract is on its
+// way out: an outcome-returning replacement lands next, and every remaining
+// `legacyApply` is one game still to migrate.
 export type MoveDefinition<TBoard> =
   | MoveFunction<TBoard>
-  | { apply: MoveFunction<TBoard>; validate?: MoveValidator<TBoard> }
+  | { legacyApply: MoveFunction<TBoard>; validate?: MoveValidator<TBoard> }
 export interface Gameplay<TBoard> {
   moves: Record<string, MoveDefinition<TBoard>>
   // move name auto-executed (after a delay) following moves returning autoEndOfTurn: true


### PR DESCRIPTION
## Summary

Purely mechanical rename, **no behavior change**, split out of #361 so that the interesting engine work there is reviewable on its own.

The events-based move contract is on its way out. #361 (stacked on this) adds an outcome-returning replacement that should get the plain name `apply`, so the old key is renamed to `legacyApply` first. Two things fall out of that: the new contract gets the natural name rather than a qualified one, and `git grep legacyApply` becomes an exact checklist of the games still to migrate.

## What changed

- `MoveDefinition` / the engine's normalized move shape: the long-form key is now `legacyApply`. The bare-function shorthand is unchanged (it normalizes to `legacyApply` internally).
- ~70 game files using the long-form object: `apply:` → `legacyApply:`.
- A handful of specs and bots that invoke a move's effect directly rather than dispatching it: `moves.x.apply(…)` → `moves.x.legacyApply(…)` (number-pyramid, chess-ducks, triangle-coloring, policeman-thief-c, triangle-circle-game, hunyadi, plus the two `optimality.spec.ts` destructures).
- Two lines rewrapped to stay under the 120-char lint limit (thief-sheriff-mean-7, number-pyramid.spec.ts).
- AGENTS.md and README updated to name the key.

Game-local helper functions that happen to be *named* `applyMove` / `applyTakeCard` (matches-on-edges, latin-square-filling, four-piles-two-grabs, …) are unrelated to the contract key and are untouched.

## Review notes

The whole diff is one find-and-replace plus the two rewraps, so it's best reviewed by confirming exactly that. Two checks that make it cheap:

- **Test count is unchanged from main: 920.** The rename adds and removes no tests, and every existing per-game and engine spec passes untouched.
- `git diff main...claude/rename-legacy-apply-key -- src/components/games` should contain no logic, only key renames.

## Test plan

`npm test` green: versions check, lint, typecheck, 920 unit tests in 130 files — identical to main's count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cECth7yywjvuhpXHuTgkS

---
_Generated by [Claude Code](https://claude.ai/code/session_015cECth7yywjvuhpXHuTgkS)_