### PR TITLE
Migrate single-pile-removal family + digit-subtraction to `apply`

### DIFF
--- a/src/components/games/digit-subtraction/digit-subtraction.tsx
+++ b/src/components/games/digit-subtraction/digit-subtraction.tsx
@@ -1,7 +1,7 @@
 import { sample } from 'lodash';
 import {
   strategyGameFactory,
-  type Ctx, type Events, type StrategyArgs, type BoardClientProps,
+  type Ctx, type MoveOutcome, type StrategyArgs, type BoardClientProps,
   GameBoard
 } from '../../strategy-game-factory';
 
@@ -44,14 +44,12 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
 const moves = {
   subtractDigit: {
     validate: (board: Board, _, digit: number) => isSubtractableDigit(board, digit),
-    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, digit: number) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, digit: number): MoveOutcome<Board> => {
       const nextBoard = board - digit;
       if (nextBoard === 0) {
-        events.endGame(ctx.currentPlayer!);
-      } else {
-        events.endTurn();
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/single-pile-removal/doubling-reduction/doubling-reduction.tsx
+++ b/src/components/games/single-pile-removal/doubling-reduction/doubling-reduction.tsx
@@ -1,4 +1,6 @@
-import { strategyGameFactory, type Events, type StrategyArgs } from '../../../strategy-game-factory';
+import {
+  strategyGameFactory, type Ctx, type MoveOutcome, type StrategyArgs
+} from '../../../strategy-game-factory';
 import { range, random, sample, minBy } from 'lodash';
 import { type Board, cap, validateTake, BoardClient, getPlayerStepDescription } from '../pebble-pile';
 
@@ -49,12 +51,11 @@ export const chooseSmartTake = (board: Board): number => {
 const moves = {
   take: {
     validate: validateTake,
-    legacyApply: (board: Board, { events }: { events: Events }, count: number) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, count: number): MoveOutcome<Board> => {
       // Next player may take strictly less than twice this take, i.e. up to 2·count − 1.
       const nextBoard: Board = { stones: board.stones - count, maxTake: 2 * count - 1 };
-      events.endTurn();
-      if (nextBoard.stones === 0) events.endGame(); // mover took the last stone(s) → wins
-      return { nextBoard };
+      if (nextBoard.stones === 0) return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/single-pile-removal/prime-exponentials/prime-exponentials.tsx
+++ b/src/components/games/single-pile-removal/prime-exponentials/prime-exponentials.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import {
-  strategyGameFactory, type Events, type StrategyArgs, type BoardClientProps, GameBoard, useHoverPreview
+  strategyGameFactory, type Ctx, type MoveOutcome, type StrategyArgs, type BoardClientProps,
+  GameBoard, useHoverPreview
 } from '../../../strategy-game-factory';
 import { sample, random } from 'lodash';
 import { useTranslation } from '../../../../language';
@@ -164,13 +165,12 @@ const moves = {
   subtractPrimeExponent: {
     validate: (board: Board, _, entry: { prime: number; exponent: number }) =>
       isSubtractionAllowed(board, entry),
-    legacyApply: (board: Board, { events }: { events: Events }, { prime, exponent }) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, { prime, exponent }): MoveOutcome<Board> => {
       const nextBoard = board - prime ** exponent;
-      events.endTurn();
       if (nextBoard === 0) {
-        events.endGame();
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/single-pile-removal/primely-to-zero/primely-to-zero.tsx
+++ b/src/components/games/single-pile-removal/primely-to-zero/primely-to-zero.tsx
@@ -1,6 +1,6 @@
 import {
   strategyGameFactory,
-  type Ctx, type Events, type StrategyArgs, type BoardClientProps,
+  type Ctx, type MoveOutcome, type StrategyArgs, type BoardClientProps,
   GameBoard
 } from '../../../strategy-game-factory';
 import { range, sample } from 'lodash';
@@ -46,13 +46,11 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
 const moves = {
   moveTo: {
     validate: (board: Board, _, target: number) => isMoveValid(board, target),
-    legacyApply: (_board: Board, { ctx, events }: { ctx: Ctx, events: Events }, target: number) => {
-      const winner = ctx.currentPlayer!;
-      events.endTurn();
+    apply: (_board: Board, { ctx }: { ctx: Ctx }, target: number): MoveOutcome<Board> => {
       if (target === 0) {
-        events.endGame(winner);
+        return { nextBoard: target, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard: target };
+      return { nextBoard: target, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/single-pile-removal/take-1-or-halve/take-1-or-halve.tsx
+++ b/src/components/games/single-pile-removal/take-1-or-halve/take-1-or-halve.tsx
@@ -1,5 +1,6 @@
 import {
-  strategyGameFactory, type Events, type StrategyArgs, type BoardClientProps, GameBoard, useHoverPreview
+  strategyGameFactory, type Ctx, type MoveOutcome, type StrategyArgs, type BoardClientProps,
+  GameBoard, useHoverPreview
 } from '../../../strategy-game-factory';
 import { random, range } from 'lodash';
 import { useTranslation } from '../../../../language';
@@ -54,21 +55,18 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 
 const moves = {
   take1: {
-    legacyApply: (board: Board, { events }: { events: Events }) => {
-      events.endTurn();
+    apply: (board: Board, { ctx }: { ctx: Ctx }): MoveOutcome<Board> => {
+      const nextBoard = board - 1;
       if (board === 1) {
-        events.endGame();
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard: board - 1 }
+      return { nextBoard, isTurnEnd: true };
     }
   },
   halve: {
     // Half may only be taken when the pile is even; taking one is always legal.
     validate: (board: Board) => board >= 2 && board % 2 === 0,
-    legacyApply: (board: Board, { events }: { events: Events }) => {
-      events.endTurn();
-      return { nextBoard: board / 2 };
-    }
+    apply: (board: Board): MoveOutcome<Board> => ({ nextBoard: board / 2, isTurnEnd: true })
   }
 };
 

--- a/src/components/games/single-pile-removal/take-power-of-two/take-power-of-two.tsx
+++ b/src/components/games/single-pile-removal/take-power-of-two/take-power-of-two.tsx
@@ -1,5 +1,6 @@
 import {
-  strategyGameFactory, type Events, type StrategyArgs, type BoardClientProps, GameBoard, useHoverPreview
+  strategyGameFactory, type Ctx, type MoveOutcome, type StrategyArgs, type BoardClientProps,
+  GameBoard, useHoverPreview
 } from '../../../strategy-game-factory';
 import { range, random, reverse, sample } from 'lodash';
 import { useTranslation } from '../../../../language';
@@ -103,13 +104,12 @@ const moves = {
     // A power of 2 may be subtracted only if it does not exceed the number —
     // exactly the exponents the board already offers.
     validate: (board: Board, _, exponent: number) => getAvailableExponents(board).includes(exponent),
-    legacyApply: (board: Board, { events }: { events: Events }, exponent: number) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, exponent: number): MoveOutcome<Board> => {
       const nextBoard = board - 2 ** exponent;
-      events.endTurn();
       if (nextBoard === 0) {
-        events.endGame();
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 }

--- a/src/components/games/single-pile-removal/three-more/three-more.tsx
+++ b/src/components/games/single-pile-removal/three-more/three-more.tsx
@@ -1,4 +1,6 @@
-import { strategyGameFactory, type Events, type StrategyArgs } from '../../../strategy-game-factory';
+import {
+  strategyGameFactory, type Ctx, type MoveOutcome, type StrategyArgs
+} from '../../../strategy-game-factory';
 import { range, random, sample, minBy } from 'lodash';
 import { type Board, cap, validateTake, BoardClient, getPlayerStepDescription } from '../pebble-pile';
 
@@ -58,11 +60,10 @@ export const chooseSmartTake = (board: Board): number => {
 const moves = {
   take: {
     validate: validateTake,
-    legacyApply: (board: Board, { events }: { events: Events }, count: number) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, count: number): MoveOutcome<Board> => {
       const nextBoard: Board = { stones: board.stones - count, maxTake: count + INCREMENT };
-      events.endTurn();
-      if (nextBoard.stones === 0) events.endGame(); // mover took the last stone(s) → wins
-      return { nextBoard };
+      if (nextBoard.stones === 0) return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/single-pile-removal/waning-stones/waning-stones.tsx
+++ b/src/components/games/single-pile-removal/waning-stones/waning-stones.tsx
@@ -1,4 +1,6 @@
-import { strategyGameFactory, type Events, type StrategyArgs } from '../../../strategy-game-factory';
+import {
+  strategyGameFactory, type Ctx, type MoveOutcome, type StrategyArgs
+} from '../../../strategy-game-factory';
 import { range, random, sample, minBy } from 'lodash';
 import { type Board, cap, validateTake, BoardClient, getPlayerStepDescription } from '../pebble-pile';
 
@@ -35,11 +37,10 @@ export const chooseSmartTake = (board: Board): number => {
 const moves = {
   take: {
     validate: validateTake,
-    legacyApply: (board: Board, { events }: { events: Events }, count: number) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, count: number): MoveOutcome<Board> => {
       const nextBoard: Board = { stones: board.stones - count, maxTake: count };
-      events.endTurn();
-      if (nextBoard.stones === 0) events.endGame(); // mover took the last stone(s) → wins
-      return { nextBoard };
+      if (nextBoard.stones === 0) return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };


### PR DESCRIPTION
Phase 3 of #313, batch 1 of 5. Eight games move from the legacy `legacyApply` + `events` contract to the outcome-returning `apply` form, so their moves become pure reducers with no `events` parameter.

Rebased onto `main` after #370 (drop the plain-function shorthand). That commit had converted `take-1-or-halve`'s `take1` from a bare function to long-form `legacyApply`; here it goes the rest of the way to `apply`.

## Games

- `single-pile-removal/doubling-reduction`
- `single-pile-removal/prime-exponentials`
- `single-pile-removal/primely-to-zero`
- `single-pile-removal/take-1-or-halve` (both moves)
- `single-pile-removal/take-power-of-two`
- `single-pile-removal/three-more`
- `single-pile-removal/waning-stones`
- `digit-subtraction`

## The mapping

Uniform across the whole batch:

| legacy | outcome |
| --- | --- |
| `events.endTurn()` | `isTurnEnd: true` |
| `events.endGame()` (bare) | `gameEnd: { winnerIndex: ctx.currentPlayer! }` |
| `events.endGame(w)` | `gameEnd: { winnerIndex: w }` |

Every one of these games is the dominant single-move "take from the pile" shape, so each move collapses to one `if` returning `gameEnd` and a fallthrough returning `isTurnEnd: true`.

## The one semantic difference, checked per game

`gameEnd` does not flip `currentPlayer`, whereas the legacy `endTurn(); endGame()` pair did (harmlessly — `endGame` resolves its winner against the pre-flip mover either way, which is what `reducer.ts` pins with a dedicated test). So the only thing that could change is UI that reads `ctx.currentPlayer` while the game is over.

`grep currentPlayer` over these eight games returns only the two move bodies themselves — no BoardClient and no `getPlayerStepDescription` in the batch reads it (and step descriptions only render during `phase === 'play'` anyway). Nothing rendered at game end changes, and the resolved `winnerIndex` is identical.

## Verification

`npm test` green after the rebase: lint, typecheck, and 972 tests — the same count as `main`, since this batch changes no behaviour and adds no tests.

Migration progress after this batch: 11 games on `apply`, 69 still on `legacyApply`.