### PR TITLE
Migrate the counting / number games to `apply`

### DIFF
--- a/src/components/games/add-reduce-double/add-reduce-double.tsx
+++ b/src/components/games/add-reduce-double/add-reduce-double.tsx
@@ -1,6 +1,6 @@
 import { range, isEqual, random, cloneDeep } from 'lodash';
 import {
-  strategyGameFactory, type BoardClientProps, type Events, GameBoard, useHoverPreview
+  strategyGameFactory, type BoardClientProps, type Ctx, type MoveOutcome, GameBoard, useHoverPreview
 } from '../../strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 
@@ -108,16 +108,15 @@ export const isTransferAllowed = (board: Board, { pileId, pieceCount }): boolean
 const moves = {
   moveHalvedPieces: {
     validate: (board: Board, _, piece) => isTransferAllowed(board, piece),
-    legacyApply: (board: Board, { events }: { events: Events }, { pileId, pieceCount }) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, { pileId, pieceCount }): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard[pileId] -= pieceCount;
       nextBoard[1 - pileId] += pieceCount / 2;
-      events.endTurn();
       const isGameEnd = isEqual(nextBoard, [1, 1]) || isEqual(nextBoard, [0, 1]) || isEqual(nextBoard, [1, 0]);
       if (isGameEnd) {
-        events.endGame();
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/number-covering/number-covering.tsx
+++ b/src/components/games/number-covering/number-covering.tsx
@@ -1,5 +1,5 @@
 import {
-  strategyGameFactory, type Events, type StrategyArgs, type BoardClientProps, GameBoard
+  strategyGameFactory, type MoveOutcome, type StrategyArgs, type BoardClientProps, GameBoard
 } from '../../strategy-game-factory';
 import { range, sum, sample, cloneDeep } from 'lodash';
 import { useTranslation } from '../../../language';
@@ -98,16 +98,15 @@ const genericRule = {
 export const moves = {
   coverNumber: {
     validate: (board: Board, _, number: number) => isCoveringAllowed(board, number),
-    legacyApply: (board: Board, { events }: { events: Events }, number) => {
+    apply: (board: Board, _, number): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard[number-1] = COVERED;
-      events.endTurn();
 
       const remaining = getRemaining(nextBoard);
       if (remaining.length === 2) {
-        events.endGame(sum(remaining) % 2);
+        return { nextBoard, gameEnd: { winnerIndex: sum(remaining) % 2 } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 }

--- a/src/components/games/polynomial-building/polynomial-building.tsx
+++ b/src/components/games/polynomial-building/polynomial-building.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory, type Events } from '../../strategy-game-factory';
+import { strategyGameFactory, type MoveOutcome } from '../../strategy-game-factory';
 import {
   type Board, type Coef, COEFS, hasThreeIntegerRoots, isCoefficientChoiceAllowed
 } from './helpers';
@@ -9,16 +9,15 @@ const moves = {
   setCoefficient: {
     validate: (board: Board, _, coef: Coef, value: number) =>
       isCoefficientChoiceAllowed(board, coef, value),
-    legacyApply: (board: Board, { events }: { events: Events }, coef: Coef, value: number) => {
+    apply: (board: Board, _, coef: Coef, value: number): MoveOutcome<Board> => {
       const nextBoard = { ...board, [coef]: value };
       const filled = nextBoard.a !== null && nextBoard.b !== null && nextBoard.c !== null;
       if (filled) {
         // A (player 0) wins iff all three roots are integers; otherwise B (player 1).
-        events.endGame(hasThreeIntegerRoots(nextBoard.a!, nextBoard.b!, nextBoard.c!) ? 0 : 1);
-      } else {
-        events.endTurn();
+        const winnerIndex = hasThreeIntegerRoots(nextBoard.a!, nextBoard.b!, nextBoard.c!) ? 0 : 1;
+        return { nextBoard, gameEnd: { winnerIndex } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/single-number-increase/increment-or-double/increment-or-double.tsx
+++ b/src/components/games/single-number-increase/increment-or-double/increment-or-double.tsx
@@ -1,5 +1,5 @@
 import {
-  strategyGameFactory, type Ctx, type Events, type StrategyArgs, type BoardClientProps, GameBoard
+  strategyGameFactory, type Ctx, type MoveOutcome, type StrategyArgs, type BoardClientProps, GameBoard
 } from '../../../strategy-game-factory';
 import { sample } from 'lodash';
 
@@ -36,22 +36,19 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
   );
 };
 
-const say = (next: number, { ctx, events }: { ctx: Ctx, events: Events }) => {
-  events.endTurn();
+const say = (next: number, ctx: Ctx): MoveOutcome<Board> => {
   if (isLosing(next)) {
-    events.endGame(1 - ctx.currentPlayer!);
+    return { nextBoard: next, gameEnd: { winnerIndex: 1 - ctx.currentPlayer! } };
   }
-  return { nextBoard: next };
+  return { nextBoard: next, isTurnEnd: true };
 };
 
 const moves = {
-  increment: {
-    legacyApply: (board: Board, meta: { ctx: Ctx, events: Events }) => say(board + 1, meta)
-  },
+  increment: { apply: (board: Board, { ctx }: { ctx: Ctx }) => say(board + 1, ctx) },
   double: {
     // Doubling nothing says nothing, so the opening move can only be x+1 = 1.
     validate: (board: Board) => board >= 1,
-    legacyApply: (board: Board, meta: { ctx: Ctx, events: Events }) => say(board * 2, meta)
+    apply: (board: Board, { ctx }: { ctx: Ctx }) => say(board * 2, ctx)
   }
 };
 

--- a/src/components/games/single-number-increase/plus-one-two-three/plus-one-two-three.tsx
+++ b/src/components/games/single-number-increase/plus-one-two-three/plus-one-two-three.tsx
@@ -1,6 +1,6 @@
 import {
   strategyGameFactory,
-  type Ctx, type Events, type StrategyArgs, type BoardClientProps,
+  type Ctx, type MoveOutcome, type StrategyArgs, type BoardClientProps,
   GameBoard
 } from '../../../strategy-game-factory';
 import { range, random } from 'lodash';
@@ -43,12 +43,11 @@ export const isIncreaseValid = ({ board, number }: { board: Board; number: numbe
 const moves = {
   increaseTo: {
     validate: (board: Board, _, number: number) => isIncreaseValid({ board, number }),
-    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, number) => {
-      events.endTurn();
+    apply: (board: Board, { ctx }: { ctx: Ctx }, number): MoveOutcome<Board> => {
       if (number > target) {
-        events.endGame(1 - ctx.currentPlayer!)
+        return { nextBoard: number, gameEnd: { winnerIndex: 1 - ctx.currentPlayer! } };
       }
-      return { nextBoard: number }
+      return { nextBoard: number, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/single-number-increase/superstitious-counting/superstitious-counting.tsx
+++ b/src/components/games/single-number-increase/superstitious-counting/superstitious-counting.tsx
@@ -1,6 +1,6 @@
 import { range, sample, difference } from 'lodash';
 import {
-  strategyGameFactory, type Ctx, type Events, type BoardClientProps, GameBoard
+  strategyGameFactory, type Ctx, type MoveOutcome, type BoardClientProps, GameBoard
 } from '../../../strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { useTranslation } from '../../../../language';
@@ -73,14 +73,13 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 const moves = {
   step: {
     validate: (board: Board, _, step: number) => isStepAllowed(board, step),
-    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, step) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, step): MoveOutcome<Board> => {
       const numberAfterStep = board.current + step;
       const nextBoard = { current: numberAfterStep, target: board.target, restricted: 13 - step };
-      events.endTurn();
       if (numberAfterStep >= board.target) {
-        events.endGame(1 - ctx.currentPlayer!)
+        return { nextBoard, gameEnd: { winnerIndex: 1 - ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/ten-digit-number/ten-digit-number.tsx
+++ b/src/components/games/ten-digit-number/ten-digit-number.tsx
@@ -1,6 +1,6 @@
 import { sample } from 'lodash';
 import {
-  strategyGameFactory, type Events, type StrategyArgs, type BoardClientProps, GameBoard
+  strategyGameFactory, type MoveOutcome, type StrategyArgs, type BoardClientProps, GameBoard
 } from '../../strategy-game-factory';
 import { useTranslation } from '../../../language';
 
@@ -94,16 +94,14 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 const moves = {
   chooseDigit: {
     validate: (board: Board, _, digit) => isDigitChoiceAllowed(board, digit),
-    legacyApply: (board: Board, { events }: { events: Events }, digit) => {
+    apply: (board: Board, _, digit): MoveOutcome<Board> => {
       const newDigits = [...board.digits, digit];
       const newSumMod9 = (board.sumMod9 + digit) % 9;
       const nextBoard = { digits: newDigits, sumMod9: newSumMod9 };
       if (newDigits.length === totalDigits) {
-        events.endGame(newSumMod9 === 0 ? 1 : 0);
-      } else {
-        events.endTurn();
+        return { nextBoard, gameEnd: { winnerIndex: newSumMod9 === 0 ? 1 : 0 } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/twelve-squares/twelve-squares.tsx
+++ b/src/components/games/twelve-squares/twelve-squares.tsx
@@ -1,6 +1,6 @@
 import {
   strategyGameFactory,
-  type Ctx, type Events, type StrategyArgs, type BoardClientProps,
+  type Ctx, type MoveOutcome, type StrategyArgs, type BoardClientProps,
   GameBoard
 } from '../../strategy-game-factory';
 import { range, random, sample } from 'lodash';
@@ -76,15 +76,15 @@ const getOptimalBotStep = ({ left, right }) => {
 const moves = {
   step: {
     validate: (board: Board, _, step) => isValidStep(board, step),
-    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, step) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, step): MoveOutcome<Board> => {
       const nextBoard = ctx.currentPlayer === 0
         ? { left: board.left + step, right: board.right }
         : { left: board.left, right: board.right - step };
-      events.endTurn();
+      // Jumping past the other piece wins for the player who just moved.
       if (nextBoard.right < nextBoard.left) {
-        events.endGame();
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };


### PR DESCRIPTION
Phase 3 of #313, batch 2 of 5. Independent of #367 — different games, no overlapping files.

Rebased onto `main` after #370 (drop the plain-function shorthand), which had converted `increment-or-double`'s `increment` from a bare function to long-form `legacyApply`; here it goes the rest of the way to `apply`.

## Games

- `single-number-increase/increment-or-double`
- `single-number-increase/plus-one-two-three`
- `single-number-increase/superstitious-counting`
- `ten-digit-number`
- `twelve-squares`
- `number-covering`
- `polynomial-building`
- `add-reduce-double`

## Notable in this batch

**Misère-flavoured endings.** The three `single-number-increase` games lose on the terminal move (reaching or passing the target), so they carry an explicit `gameEnd: { winnerIndex: 1 - ctx.currentPlayer! }` — exactly the value the legacy `endGame(1 - ctx.currentPlayer!)` produced. The rest of the batch either credits the mover or computes the winner from the final board (`ten-digit-number`, `number-covering`, `polynomial-building`), which translates to a straight `winnerIndex` expression.

**A shared helper going pure.** `increment-or-double` funnels both of its moves through a `say(next, meta)` helper that called `events`. It now takes `ctx` and returns a `MoveOutcome`, so both moves collapse to one-liners and neither mentions `events`.

**Moves that never read `ctx`** (`ten-digit-number`, `number-covering`, `polynomial-building`) take `_` for the meta parameter, matching how the existing validators in those files are written.

## The `currentPlayer` no-flip check

`twelve-squares` is the only game here whose BoardClient reads `ctx.currentPlayer`: it picks which piece a clicked square would move and colours the reachable squares accordingly. Both uses go through `moves.step.isAllowed` and `onClick`, and `isAllowed` is already false for every square once the phase is `gameEnd` (it folds in `ctx.isClientMoveAllowed`). So the rendered board after the game ends is the all-disabled one either way.

The other seven games read `ctx.currentPlayer` nowhere outside the move bodies — `ten-digit-number`'s several `currentPlayer` locals are derived from the digit count in its solver, not from `ctx`.

## Verification

`npm test` green after the rebase: lint, typecheck, and 972 tests, same count as `main`.

Migration progress after this batch: 19 games on `apply`, 61 still on `legacyApply`.