### PR TITLE
Migrate the chess / placement games to `apply`

### DIFF
--- a/src/components/games/chess-bishops/chess-bishops.tsx
+++ b/src/components/games/chess-bishops/chess-bishops.tsx
@@ -1,6 +1,7 @@
 import { range, some, isEqual, cloneDeep } from 'lodash';
 import {
-  strategyGameFactory, type BoardClientProps, type Events, GameBoard, useHoverPreview
+  strategyGameFactory, type BoardClientProps, type Ctx, type MoveOutcome,
+  GameBoard, useHoverPreview
 } from '../../strategy-game-factory';
 import { ChessBishopSvg } from './chess-bishop-svg';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
@@ -79,15 +80,14 @@ const moves = {
   placeBishop: {
     validate: (board: Board, _, target: Field) =>
       some(getAllowedMoves(board), field => isEqual(field, target)),
-    legacyApply: (board: Board, { events }: { events: Events }, { row, col }: Field) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, { row, col }: Field): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       markForbiddenFields(nextBoard, { row, col });
       nextBoard[row][col] = BISHOP;
-      events.endTurn();
       if (getAllowedMoves(nextBoard).length === 0) {
-        events.endGame();
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/chess-ducks/bot-strategy.ts
+++ b/src/components/games/chess-ducks/bot-strategy.ts
@@ -1,5 +1,5 @@
-import { getBoardIndices, moves, getAllowedMoves, type Board, type Field } from "./helpers";
-import { dummyEvents, type StrategyArgs } from "../../strategy-game-factory";
+import { getBoardIndices, withDuckPlaced, getAllowedMoves, type Board, type Field } from "./helpers";
+import { type StrategyArgs } from "../../strategy-game-factory";
 import { shuffle, sample } from "lodash";
 
 /* This strategy file is relevant for the 4x7 case */
@@ -46,8 +46,7 @@ const getOptimalSmartBotMove = (board: Board): Field => {
     // shuffle + find has the same effect as filter + sample: find a random
     // from the optimal moves
     const optimalPlace = shuffle(allowedMoves).find(({ row, col }) => {
-      const { nextBoard } = moves.placeDuck.legacyApply(board, { events: dummyEvents }, { row, col });
-      return isWinningState(nextBoard);
+      return isWinningState(withDuckPlaced(board, { row, col }));
     });
 
     if (optimalPlace !== undefined) {
@@ -126,8 +125,7 @@ const isWinningState = (board: Board): boolean => {
   const allowedPlacesForOther = getAllowedMoves(board);
 
   const optimalPlaceForOther = allowedPlacesForOther.find(({ row, col }) => {
-    const { nextBoard } = moves.placeDuck.legacyApply(board, { events: dummyEvents }, { row, col });
-    return isWinningState(nextBoard);
+    return isWinningState(withDuckPlaced(board, { row, col }));
   });
   return optimalPlaceForOther === undefined;
 };

--- a/src/components/games/chess-ducks/helpers.ts
+++ b/src/components/games/chess-ducks/helpers.ts
@@ -1,5 +1,5 @@
 import { flatMap, range, cloneDeep } from "lodash";
-import type { Events } from "../../strategy-game-factory";
+import type { Ctx, MoveOutcome } from "../../strategy-game-factory";
 
 export const DUCK = 1 as const;
 export const FORBIDDEN = 2 as const;
@@ -39,18 +39,25 @@ export const markForbiddenFields = (board: Board, { row, col }: Field): void => 
 export const isPlacementAllowed = (board: Board, field: Field): boolean =>
   !!field && board[field.row]?.[field.col] === null;
 
+// The board transform a placement performs, with no turn or game consequences.
+// Shared by the move and by the bot's lookahead search, which wants the next
+// board and nothing else.
+export const withDuckPlaced = (board: Board, { row, col }: Field): Board => {
+  const nextBoard = cloneDeep(board);
+  nextBoard[row][col] = DUCK;
+  markForbiddenFields(nextBoard, { row, col });
+  return nextBoard;
+};
+
 export const moves = {
   placeDuck: {
     validate: (board: Board, _, field: Field) => isPlacementAllowed(board, field),
-    legacyApply: (board: Board, { events }: { events: Events }, { row, col }: Field) => {
-      const nextBoard = cloneDeep(board);
-      nextBoard[row][col] = DUCK;
-      markForbiddenFields(nextBoard, { row, col });
-      events.endTurn();
+    apply: (board: Board, { ctx }: { ctx: Ctx }, field: Field): MoveOutcome<Board> => {
+      const nextBoard = withDuckPlaced(board, field);
       if (getAllowedMoves(nextBoard).length === 0) {
-        events.endGame();
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/chess-knight/chess-knight.tsx
+++ b/src/components/games/chess-knight/chess-knight.tsx
@@ -1,5 +1,7 @@
 import { range, some, isEqual, cloneDeep } from 'lodash';
-import { strategyGameFactory, type BoardClientProps, type Events, GameBoard } from '../../strategy-game-factory';
+import {
+  strategyGameFactory, type BoardClientProps, type Ctx, type MoveOutcome, GameBoard
+} from '../../strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { getAllowedMoves, generateStartBoard, markVisitedFields, type Board, type Field } from './helpers';
 import { ChessKnightSvg } from './chess-knight-svg';
@@ -51,18 +53,17 @@ const moves = {
   moveKnight: {
     validate: (board: Board, _, target: Field) =>
       some(getAllowedMoves(board), field => isEqual(field, target)),
-    legacyApply: (board: Board, { events }: { events: Events }, { row, col }: Field) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, { row, col }: Field): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       markVisitedFields(nextBoard, nextBoard.knightPosition);
 
       nextBoard.chessBoard[row][col] = 'knight';
       nextBoard.knightPosition = { row, col };
 
-      events.endTurn();
       if (getAllowedMoves(nextBoard).length === 0) {
-        events.endGame();
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/chess-rook/chess-rook.tsx
+++ b/src/components/games/chess-rook/chess-rook.tsx
@@ -1,5 +1,7 @@
 import { range, some, isEqual, cloneDeep } from 'lodash';
-import { strategyGameFactory, type BoardClientProps, type Events, GameBoard } from '../../strategy-game-factory';
+import {
+  strategyGameFactory, type BoardClientProps, type Ctx, type MoveOutcome, GameBoard
+} from '../../strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { getAllowedMoves, generateStartBoard, markVisitedFields, type Board, type Field } from './helpers';
 import { RookSvg } from '../shared/rook-svg';
@@ -51,18 +53,17 @@ const moves = {
   moveRook: {
     validate: (board: Board, _, target: Field) =>
       some(getAllowedMoves(board), field => isEqual(field, target)),
-    legacyApply: (board: Board, { events }: { events: Events }, { row, col }: Field) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, { row, col }: Field): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       markVisitedFields(nextBoard, nextBoard.rookPosition, { row, col });
 
       nextBoard.chessBoard[row][col] = 'rook';
       nextBoard.rookPosition = { row, col };
 
-      events.endTurn();
       if (getAllowedMoves(nextBoard).length === 0) {
-        events.endGame();
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/dominoes-4x4/dominoes-4x4.tsx
+++ b/src/components/games/dominoes-4x4/dominoes-4x4.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { range, cloneDeep, isEqual, flatMap } from 'lodash';
 import {
   strategyGameFactory,
-  type Events, type Ctx, type BoardClientProps,
+  type MoveOutcome, type Ctx, type BoardClientProps,
   GameBoard, useHoverPreview
 } from '../../strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
@@ -164,17 +164,14 @@ const moves = {
   placeDomino: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, domino: Domino) =>
       isDominoAllowed(board, ctx.currentPlayer!, domino),
-    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, domino: Domino) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, domino: Domino): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard.push(domino);
       const nextPlayer = 1 - ctx.currentPlayer!;
-      events.endTurn();
-      // Normal play: if the next player has no legal placement, they lose and the player
-      // who just moved wins (endGame with no argument credits the mover).
       if (getPossibleMoves(nextBoard, nextPlayer).length === 0) {
-        events.endGame();
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/dominoes-on-chessboard/dominoes-on-chessboard.tsx
+++ b/src/components/games/dominoes-on-chessboard/dominoes-on-chessboard.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { range, cloneDeep, isEqual, flatMap } from 'lodash';
 import {
   strategyGameFactory,
-  type Events, type BoardClientProps,
+  type Ctx, type MoveOutcome, type BoardClientProps,
   GameBoard, useHoverPreview
 } from '../../strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
@@ -162,14 +162,13 @@ export const isDominoAllowed = (board: Board, domino: Domino): boolean =>
 const moves = {
   placeDomino: {
     validate: (board: Board, _, domino: Domino) => isDominoAllowed(board, domino),
-    legacyApply: (board: Board, { events }: { events: Events }, domino: Domino) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, domino: Domino): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard.push(domino);
-      events.endTurn();
       if (getPossibleMoves(nextBoard).length === 0) {
-        events.endGame();
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 }

--- a/src/components/games/rook-to-corner/rook-to-corner.tsx
+++ b/src/components/games/rook-to-corner/rook-to-corner.tsx
@@ -1,5 +1,7 @@
 import { range, some, isEqual, cloneDeep } from 'lodash';
-import { strategyGameFactory, type BoardClientProps, type Events, GameBoard } from '../../strategy-game-factory';
+import {
+  strategyGameFactory, type BoardClientProps, type Ctx, type MoveOutcome, GameBoard
+} from '../../strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { getAllowedMoves, generateStartBoard, isTarget, boardSize, type Board, type Field } from './helpers';
 import { RookSvg } from '../shared/rook-svg';
@@ -55,16 +57,14 @@ const moves = {
   moveRook: {
     validate: (board: Board, _, target: Field) =>
       some(getAllowedMoves(board), field => isEqual(field, target)),
-    legacyApply: (board: Board, { events }: { events: Events }, { row, col }: Field) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, { row, col }: Field): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard.rookPosition = { row, col };
 
       if (isTarget({ row, col })) {
-        events.endGame();
-      } else {
-        events.endTurn();
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/triangle-coloring/triangle-coloring.tsx
+++ b/src/components/games/triangle-coloring/triangle-coloring.tsx
@@ -1,6 +1,6 @@
 import {
-  strategyGameFactory, dummyEvents,
-  type Events, type StrategyArgs, type BoardClientProps,
+  strategyGameFactory,
+  type Ctx, type MoveOutcome, type StrategyArgs, type BoardClientProps,
   GameBoard
 } from '../../strategy-game-factory';
 import { range, cloneDeep, sample, shuffle } from 'lodash';
@@ -116,20 +116,27 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
 export const isColoringAllowed = (board: Board, id: number): boolean =>
   Number.isInteger(id) && id >= 0 && id < triangles.length && board[id] === ALLOWED;
 
+// The board transform a colouring performs, with no turn or game consequences.
+// Shared by the move and by the lookahead search below, which wants the next
+// board and nothing else.
+const withTriangleColored = (board: Board, id: number): Board => {
+  const nextBoard = cloneDeep(board);
+  nextBoard[id] = COLORED;
+  triangles[id].neighbors.forEach(n => {
+    nextBoard[n] = FORBIDDEN;
+  });
+  return nextBoard;
+};
+
 const moves = {
   colorTriangle: {
     validate: (board: Board, _, id: number) => isColoringAllowed(board, id),
-    legacyApply: (board: Board, { events }: { events: Events }, id: number) => {
-      const nextBoard = cloneDeep(board);
-      nextBoard[id] = COLORED;
-      triangles[id].neighbors.forEach(n => {
-        nextBoard[n] = FORBIDDEN;
-      });
-      events.endTurn();
+    apply: (board: Board, { ctx }: { ctx: Ctx }, id: number): MoveOutcome<Board> => {
+      const nextBoard = withTriangleColored(board, id);
       if (getAllowedMoves(nextBoard).length === 0) {
-        events.endGame();
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };
@@ -147,10 +154,9 @@ const smartBotStrategy = ({ board, moves }: StrategyArgs<Board>) => {
 
 const getOptimalSmartBotMove = (board: Board) => {
   const allowedMoves = getAllowedMoves(board);
-  const optimalPlace = shuffle(allowedMoves).find(i => {
-    const { nextBoard } = moves.colorTriangle.legacyApply(board, { events: dummyEvents }, i);
-    return isWinningState(nextBoard);
-  });
+  const optimalPlace = shuffle(allowedMoves).find(
+    i => isWinningState(withTriangleColored(board, i))
+  );
 
   if (optimalPlace !== undefined) {
     return optimalPlace;
@@ -165,10 +171,9 @@ const isWinningState = (board: Board) => {
     return true;
   }
 
-  const optimalPlaceForOther = allowedPlacesForOther.find(i => {
-    const { nextBoard } = moves.colorTriangle.legacyApply(board, { events: dummyEvents }, i);
-    return isWinningState(nextBoard);
-  });
+  const optimalPlaceForOther = allowedPlacesForOther.find(
+    i => isWinningState(withTriangleColored(board, i))
+  );
   return optimalPlaceForOther === undefined;
 };
 


### PR DESCRIPTION
Phase 3 of #313, batch 3 of 5. Independent of #367 and #368 — no overlapping files.

## Games

- `chess-bishops`
- `chess-knight`
- `chess-rook`
- `rook-to-corner`
- `chess-ducks`
- `triangle-coloring`
- `dominoes-4x4`
- `dominoes-on-chessboard`

Six of the eight are the plain "place a piece; if the opponent has no square left, you win" shape and translate one-for-one. Two needed a decision.

## Bot lookahead without `events`

`chess-ducks` and `triangle-coloring` both search by calling their own move with `dummyEvents`, purely to get `nextBoard` out of it:

```js
const { nextBoard } = moves.colorTriangle.legacyApply(board, { events: dummyEvents }, i);
return isWinningState(nextBoard);
```

An outcome-returning move takes `{ ctx }` instead of `{ events }`, so a literal port would have meant fabricating a fake `ctx` for a move that reads `ctx.currentPlayer` only to name the winner — a value the search discards. Rather than invent a dummy ctx, this extracts the board transform the search actually wants:

```js
const optimalPlace = shuffle(allowedMoves).find(
  i => isWinningState(withTriangleColored(board, i))
);
```

`withDuckPlaced` (exported from `chess-ducks/helpers.ts`, used by `bot-strategy.ts`) and `withTriangleColored` (module-local) are each called by both the move and the search, so the two cannot drift. The search no longer reaches its board transform by going through a move definition, which also drops `chess-ducks/bot-strategy.ts`'s import of the engine barrel down to `StrategyArgs`.

`dummyEvents` stays exported — `ten-coins` and `discs-flip-or-remove` optimality specs still use it, and there are still legacy moves for it to serve.

## The `currentPlayer` no-flip check

`dominoes-4x4` is the only game in the batch whose BoardClient reads `ctx.currentPlayer`: it decides whether the player extends a domino vertically or horizontally, and tints the hover preview blue or amber to match. Both live behind an `if (!ctx.isClientMoveAllowed) return …` early exit (`getCellBgClass`, `isClickAllowed`), which is already false at `phase === 'gameEnd'`. `hasPlaceablePartner` reads the derived `step`, but is only reachable through `isClickAllowed`. So the finished board renders identically.

No other game in the batch reads `ctx.currentPlayer` outside a move body or a bot.

## Verification

`npm test` green: lint, typecheck, and 972 tests, same count as `main`.

Migration progress after this batch: 27 games on `apply`, 53 still on `legacyApply`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cECth7yywjvuhpXHuTgkS)_