### PR TITLE
Drop the plain-function move shorthand: every move is long-form

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,8 @@ omitted on a variant, the default variant's `botStrategy` is used as fallback.
 If multiple variants are provided, exactly one must be `isDefault: true`. A
 single-entry array needs no `isDefault` flag.
 
-**`moves`** — each move is one of three shapes, all mixable within one game:
+**`moves`** — every move is an object pairing an optional `validate` with
+exactly one apply function. The two apply contracts are mixable within one game:
 
 - **`{ apply, validate? }` (preferred, use for new games)** — an
   outcome-returning move `(board, { ctx }, ...args) => MoveOutcome`. It gets no
@@ -108,9 +109,9 @@ single-entry array needs no `isDefault` flag.
   `autoEndOfTurn: true` schedules `endOfTurnMove`. Being `events`-free makes the
   move a pure reducer — the piece a future authoritative competition server
   and the planned external state store both need (see issue #313).
-- **legacy plain move function** `(board, { ctx, events }, ...args) =>
-  { nextBoard }` (shorthand), or **legacy `{ legacyApply, validate? }`** — the
-  move calls `events.endTurn()` / `events.endGame(winnerIndex?)` imperatively
+- **`{ legacyApply, validate? }` (legacy)** — `legacyApply` has the signature
+  `(board, { ctx, events }, ...args) => { nextBoard }` and calls
+  `events.endTurn()` / `events.endGame(winnerIndex?)` imperatively
   (bare `endGame()` credits the mover). Existing games migrate to the
   outcome-returning `apply` one by one; don't add new legacy moves.
 
@@ -123,9 +124,9 @@ enforced by `validate` (below) and/or the `BoardClient`'s `disabled` gating.
 `apply`/`legacyApply`. When
 present, the engine rejects any dispatch whose args fail it (in dev it throws
 loudly to surface the bug; in prod it warns, fires an `illegal-move` analytics
-event, and no-ops so a stray call cannot corrupt the board). The function
-shorthand means "always legal", so this is fully opt-in and games that predate
-it keep working unchanged. The validator is the **single source of truth** for
+event, and no-ops so a stray call cannot corrupt the board). Omitting it means
+"always legal", so this is fully opt-in and moves whose legality is trivial
+simply leave it out. The validator is the **single source of truth** for
 legality: it drives the engine's enforcement, and — being React-free — a
 possible future server-side authoritative check can reuse the same predicate.
 Do **not** put the "whose turn is it" check (`ctx.isClientMoveAllowed`) inside

--- a/README.md
+++ b/README.md
@@ -241,8 +241,8 @@ chaining bugs: passing a stale board to a chained move throws in development
 [AGENTS.md § Game state architecture: synchronous store outside
 React](AGENTS.md#game-state-architecture-synchronous-store-outside-react).
 
-In `gameplay.moves`, each entry is either a legacy move function itself
-(shorthand) or a long-form object `{ apply, validate? }` (preferred) /
+In `gameplay.moves`, each entry is an object pairing an optional `validate`
+with exactly one apply function: `{ apply, validate? }` (preferred) or
 `{ legacyApply, validate? }` (legacy):
 
 ```ts
@@ -275,7 +275,8 @@ bound) for the `BoardClient`'s `disabled` state. Full contract in
   UI state to a successful move, see `cube-coloring`). Bot and auto
   end-of-turn dispatches failing `validate` throw in development, and warn +
   record an `illegal-move` analytics event + no-op in production.
-- A shorthand move (plain function) has no argument validation — fully opt-in.
+- `validate` is optional: a move without one is always accepted, so this is
+  fully opt-in and moves with trivial legality simply omit it.
 - Keep the "whose turn is it" check out of `validate` — `isAllowed` folds
   `ctx.isClientMoveAllowed` in for you.
 - `isAllowed` is not for bots: during the bot's turn `isClientMoveAllowed` is
@@ -328,10 +329,10 @@ framework.
   getPlayerStepDescription
 
 `events` is an object that will contain the following (extendable):
-- `endTurn`: a function (legacy `legacyApply`/shorthand moves only — outcome-returning moves
+- `endTurn`: a function (legacy `legacyApply` moves only — outcome-returning moves
   return `isTurnEnd: true` instead)
 - `endGame`: a function with optional winnerIndex specified, if not, last player
-  to move is the winner (legacy `legacyApply`/shorthand moves only — outcome-returning moves
+  to move is the winner (legacy `legacyApply` moves only — outcome-returning moves
   return `gameEnd: { winnerIndex }` with an explicit winner instead)
 - `setTurnState`: a function to set `turnState` — still current for
   `BoardClient` components that keep mid-turn UI state in `ctx.turnState`

--- a/src/components/games/architect-and-bandits/architect-and-bandits-a/architect-and-bandits-a.tsx
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-a/architect-and-bandits-a.tsx
@@ -62,13 +62,15 @@ const moves = {
       return { nextBoard, autoEndOfTurn: true };
     }
   },
-  startNextDay: (board: Board, { events }: { events: Events }) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard.day += 1;
-    nextBoard.kmUsedToday = 0;
-    nextBoard.towers[nextBoard.architectPosition] = true;
-    events.endTurn();
-    return { nextBoard };
+  startNextDay: {
+    legacyApply: (board: Board, { events }: { events: Events }) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard.day += 1;
+      nextBoard.kmUsedToday = 0;
+      nextBoard.towers[nextBoard.architectPosition] = true;
+      events.endTurn();
+      return { nextBoard };
+    }
   }
 };
 

--- a/src/components/games/architect-and-bandits/architect-and-bandits-b/architect-and-bandits-b.tsx
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-b/architect-and-bandits-b.tsx
@@ -60,13 +60,15 @@ const moves = {
     }
   },
 
-  startNextDay: (board: Board, { events }: { events: Events }) => {
-    const nextBoard = cloneDeep(board);
-    nextBoard.day += 1;
-    nextBoard.kmUsedToday = 0;
-    nextBoard.towers[nextBoard.architectPosition] = true;
-    events.endTurn();
-    return { nextBoard };
+  startNextDay: {
+    legacyApply: (board: Board, { events }: { events: Events }) => {
+      const nextBoard = cloneDeep(board);
+      nextBoard.day += 1;
+      nextBoard.kmUsedToday = 0;
+      nextBoard.towers[nextBoard.architectPosition] = true;
+      events.endTurn();
+      return { nextBoard };
+    }
   }
 };
 

--- a/src/components/games/pairs-of-numbers/pairs-of-numbers.tsx
+++ b/src/components/games/pairs-of-numbers/pairs-of-numbers.tsx
@@ -38,16 +38,20 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 };
 
 const moves = {
-  add1: (board: Board, { events }: { events: Events }) => {
-    events.endTurn();
-    return { nextBoard: [board[0], board[1] + 1] }
-  },
-  subtract: (board: Board, { events }: { events: Events }) => {
-    events.endTurn();
-    if (board[0] - board[1] <= 0) {
-      events.endGame();
+  add1: {
+    legacyApply: (board: Board, { events }: { events: Events }) => {
+      events.endTurn();
+      return { nextBoard: [board[0], board[1] + 1] }
     }
-    return { nextBoard: [board[0] - board[1], board[1]] };
+  },
+  subtract: {
+    legacyApply: (board: Board, { events }: { events: Events }) => {
+      events.endTurn();
+      if (board[0] - board[1] <= 0) {
+        events.endGame();
+      }
+      return { nextBoard: [board[0] - board[1], board[1]] };
+    }
   }
 };
 

--- a/src/components/games/recolouring-discs/recolouring-discs.tsx
+++ b/src/components/games/recolouring-discs/recolouring-discs.tsx
@@ -49,8 +49,10 @@ const moves = {
     legacyApply: (board: Board, meta: { ctx: Ctx; events: Events }, at: number) =>
       finalize(applyMove(board.cells, meta.ctx.currentPlayer!, { type: 'place', to: at }), meta)
   },
-  pass: (board: Board, meta: { ctx: Ctx; events: Events }) =>
-    finalize([...board.cells], meta)
+  pass: {
+    legacyApply: (board: Board, meta: { ctx: Ctx; events: Events }) =>
+      finalize([...board.cells], meta)
+  }
 };
 
 const rule = {

--- a/src/components/games/single-number-increase/increment-or-double/increment-or-double.tsx
+++ b/src/components/games/single-number-increase/increment-or-double/increment-or-double.tsx
@@ -45,7 +45,9 @@ const say = (next: number, { ctx, events }: { ctx: Ctx, events: Events }) => {
 };
 
 const moves = {
-  increment: (board: Board, meta: { ctx: Ctx, events: Events }) => say(board + 1, meta),
+  increment: {
+    legacyApply: (board: Board, meta: { ctx: Ctx, events: Events }) => say(board + 1, meta)
+  },
   double: {
     // Doubling nothing says nothing, so the opening move can only be x+1 = 1.
     validate: (board: Board) => board >= 1,

--- a/src/components/games/single-pile-removal/take-1-or-halve/take-1-or-halve.tsx
+++ b/src/components/games/single-pile-removal/take-1-or-halve/take-1-or-halve.tsx
@@ -53,12 +53,14 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 };
 
 const moves = {
-  take1: (board: Board, { events }: { events: Events }) => {
-    events.endTurn();
-    if (board === 1) {
-      events.endGame();
+  take1: {
+    legacyApply: (board: Board, { events }: { events: Events }) => {
+      events.endTurn();
+      if (board === 1) {
+        events.endGame();
+      }
+      return { nextBoard: board - 1 }
     }
-    return { nextBoard: board - 1 }
   },
   halve: {
     // Half may only be taken when the pile is even; taking one is always legal.

--- a/src/components/strategy-game-factory/engine/reducer.spec.ts
+++ b/src/components/strategy-game-factory/engine/reducer.spec.ts
@@ -1,6 +1,6 @@
 import { reduceMove } from './reducer';
 import { createInitialCoreState, type CoreState } from './store';
-import type { Events, NormalizedMove } from '../types';
+import type { Events, EngineMove } from '../types';
 
 type Board = string[];
 
@@ -14,7 +14,7 @@ const playState = (overrides: Partial<CoreState<Board>> = {}): CoreState<Board> 
   ...overrides
 });
 
-const reduce = (state: CoreState<Board>, def: NormalizedMove<Board>, ...args: unknown[]) =>
+const reduce = (state: CoreState<Board>, def: EngineMove<Board>, ...args: unknown[]) =>
   reduceMove(state, def, 'testMove', args, NAMES);
 
 describe('reduceMove — legacy (events-based) contract equivalence', () => {
@@ -22,7 +22,7 @@ describe('reduceMove — legacy (events-based) contract equivalence', () => {
     // The one real trap of moving from async React setState to a synchronous
     // reducer: ~40 legacy games call endTurn() first, then a bare endGame(),
     // which must still resolve to the player at move start.
-    const def: NormalizedMove<Board> = {
+    const def: EngineMove<Board> = {
       legacyApply: (board, { events }: { events: Events }) => {
         events.endTurn();
         events.endGame();
@@ -36,7 +36,7 @@ describe('reduceMove — legacy (events-based) contract equivalence', () => {
   });
 
   it('endGame(winner) followed by endTurn() keeps the winner intact (thief-sheriff shape)', () => {
-    const def: NormalizedMove<Board> = {
+    const def: EngineMove<Board> = {
       legacyApply: (board, { events }: { events: Events }) => {
         events.endGame(1);
         events.endTurn();
@@ -50,7 +50,7 @@ describe('reduceMove — legacy (events-based) contract equivalence', () => {
   });
 
   it('endTurn() flips the player and closes the turn', () => {
-    const def: NormalizedMove<Board> = {
+    const def: EngineMove<Board> = {
       legacyApply: (board, { events }: { events: Events }) => {
         events.endTurn();
         return { nextBoard: [...board, 'x'] };
@@ -64,7 +64,7 @@ describe('reduceMove — legacy (events-based) contract equivalence', () => {
   });
 
   it('setTurnState writes turnState', () => {
-    const def: NormalizedMove<Board> = {
+    const def: EngineMove<Board> = {
       legacyApply: (board, { events }: { events: Events }) => {
         events.setTurnState('stage2');
         return { nextBoard: board };
@@ -74,7 +74,7 @@ describe('reduceMove — legacy (events-based) contract equivalence', () => {
   });
 
   it('legacy autoEndOfTurn passes through', () => {
-    const def: NormalizedMove<Board> = {
+    const def: EngineMove<Board> = {
       legacyApply: (board) => ({ nextBoard: board, autoEndOfTurn: true })
     };
     expect(reduce(playState(), def).autoEndOfTurn).toBe(true);
@@ -83,7 +83,7 @@ describe('reduceMove — legacy (events-based) contract equivalence', () => {
 
 describe('reduceMove — outcome-returning (apply) contract', () => {
   it('isTurnEnd flips the player and closes the turn', () => {
-    const def: NormalizedMove<Board> = {
+    const def: EngineMove<Board> = {
       apply: (board) => ({ nextBoard: board, isTurnEnd: true })
     };
     const transition = reduce(playState(), def);
@@ -92,7 +92,7 @@ describe('reduceMove — outcome-returning (apply) contract', () => {
   });
 
   it('gameEnd sets phase and winner without flipping the player', () => {
-    const def: NormalizedMove<Board> = {
+    const def: EngineMove<Board> = {
       apply: (board) => ({ nextBoard: board, gameEnd: { winnerIndex: 1 } })
     };
     const transition = reduce(playState(), def);
@@ -103,9 +103,9 @@ describe('reduceMove — outcome-returning (apply) contract', () => {
   });
 
   it('nextTurnState sets, undefined keeps, null clears turnState', () => {
-    const set: NormalizedMove<Board> = { apply: (b) => ({ nextBoard: b, nextTurnState: 's' }) };
-    const keep: NormalizedMove<Board> = { apply: (b) => ({ nextBoard: b }) };
-    const clear: NormalizedMove<Board> = { apply: (b) => ({ nextBoard: b, nextTurnState: null }) };
+    const set: EngineMove<Board> = { apply: (b) => ({ nextBoard: b, nextTurnState: 's' }) };
+    const keep: EngineMove<Board> = { apply: (b) => ({ nextBoard: b }) };
+    const clear: EngineMove<Board> = { apply: (b) => ({ nextBoard: b, nextTurnState: null }) };
     const afterSet = reduce(playState(), set).state;
     expect(afterSet.turnState).toBe('s');
     const afterKeep = reduce(afterSet, keep).state;
@@ -114,7 +114,7 @@ describe('reduceMove — outcome-returning (apply) contract', () => {
   });
 
   it('throws in dev when gameEnd is combined with isTurnEnd or autoEndOfTurn', () => {
-    const def: NormalizedMove<Board> = {
+    const def: EngineMove<Board> = {
       apply: (board) => ({ nextBoard: board, isTurnEnd: true, gameEnd: { winnerIndex: 0 } })
     };
     expect(() => reduce(playState(), def)).toThrow(/gameEnd together with/);
@@ -125,7 +125,7 @@ describe('reduceMove — outcome-returning (apply) contract', () => {
     // no endOfTurnMove may be scheduled afterwards
     vi.stubEnv('DEV', false);
     try {
-      const def: NormalizedMove<Board> = {
+      const def: EngineMove<Board> = {
         apply: (board) => ({ nextBoard: board, autoEndOfTurn: true, gameEnd: { winnerIndex: 0 } })
       };
       const transition = reduce(playState(), def);
@@ -139,7 +139,7 @@ describe('reduceMove — outcome-returning (apply) contract', () => {
 
 describe('reduceMove — shared mechanics', () => {
   it('a failing validator returns the state unchanged (same reference) and flags illegal', () => {
-    const def: NormalizedMove<Board> = {
+    const def: EngineMove<Board> = {
       validate: () => false,
       apply: (board) => ({ nextBoard: [...board, 'x'] })
     };
@@ -151,7 +151,7 @@ describe('reduceMove — shared mechanics', () => {
   });
 
   it('takes the undo snapshot on the first move of a turn only', () => {
-    const midMove: NormalizedMove<Board> = {
+    const midMove: EngineMove<Board> = {
       apply: (board) => ({ nextBoard: [...board, 'x'] })
     };
     const first = reduce(playState(), midMove);
@@ -164,7 +164,7 @@ describe('reduceMove — shared mechanics', () => {
   });
 
   it('the validator sees current turnState and moveCount through ctx', () => {
-    const def: NormalizedMove<Board> = {
+    const def: EngineMove<Board> = {
       validate: (_board, { ctx }) => ctx.turnState === 'armed' && ctx.moveCount === 3,
       apply: (board) => ({ nextBoard: board, isTurnEnd: true })
     };

--- a/src/components/strategy-game-factory/engine/reducer.ts
+++ b/src/components/strategy-game-factory/engine/reducer.ts
@@ -1,5 +1,5 @@
 import { cloneDeep } from 'lodash';
-import type { MoveOutcome, NormalizedMove } from '../types';
+import type { MoveOutcome, EngineMove } from '../types';
 import { buildCtx } from './build-ctx';
 import type { CoreState } from './store';
 
@@ -20,7 +20,7 @@ export type MoveTransition<TBoard> = {
 // what to do with the returned transition (store write, dialog, timers).
 export const reduceMove = <TBoard>(
   state: CoreState<TBoard>,
-  def: NormalizedMove<TBoard>,
+  def: EngineMove<TBoard>,
   name: string,
   args: unknown[],
   resolvedPlayerNames: [string, string]

--- a/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
@@ -3,7 +3,7 @@ import { render, fireEvent, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { strategyGameFactory, type StrategyGameConfig } from './strategy-game-factory';
 import type {
-  BoardClientProps, Ctx, Events, Gameplay, GameMoves, MoveDefinition, StrategyArgs
+  BoardClientProps, Ctx, Events, Gameplay, MoveDefinition, StrategyArgs
 } from './types';
 
 type Board = string[];
@@ -28,9 +28,11 @@ const CtxAwareBoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => 
 
 const defaultGameplay: Gameplay<Board> = {
   moves: {
-    mainMove: (board: Board, { events }: { events: Events }) => {
-      events.endTurn();
-      return { nextBoard: board };
+    mainMove: {
+      legacyApply: (board: Board, { events }: { events: Events }) => {
+        events.endTurn();
+        return { nextBoard: board };
+      }
     }
   }
 };
@@ -130,12 +132,14 @@ describe('strategyGameFactory endOfTurnMove', () => {
 
   it('calls endOfTurnMove after 750ms when a move returns autoEndOfTurn: true', () => {
     const autoMove = vi.fn((board: Board) => ({ nextBoard: board }));
-    const moves: GameMoves<Board> = {
-      mainMove: (board, { events }: { events: Events }) => {
-        events.endTurn();
-        return { nextBoard: board, autoEndOfTurn: true };
+    const moves: Gameplay<Board>['moves'] = {
+      mainMove: {
+        legacyApply: (board, { events }: { events: Events }) => {
+          events.endTurn();
+          return { nextBoard: board, autoEndOfTurn: true };
+        }
       },
-      autoMove
+      autoMove: { legacyApply: autoMove }
     };
 
     const { getByTestId } = renderGame(minimalConfig({ moves, endOfTurnMove: 'autoMove' }));
@@ -151,12 +155,14 @@ describe('strategyGameFactory endOfTurnMove', () => {
 
   it('does not call endOfTurnMove when a move does not return autoEndOfTurn', () => {
     const autoMove = vi.fn((board: Board) => ({ nextBoard: board }));
-    const moves: GameMoves<Board> = {
-      mainMove: (board, { events }: { events: Events }) => {
-        events.endTurn();
-        return { nextBoard: board };
+    const moves: Gameplay<Board>['moves'] = {
+      mainMove: {
+        legacyApply: (board, { events }: { events: Events }) => {
+          events.endTurn();
+          return { nextBoard: board };
+        }
       },
-      autoMove
+      autoMove: { legacyApply: autoMove }
     };
 
     const { getByTestId } = renderGame(minimalConfig({ moves, endOfTurnMove: 'autoMove' }));
@@ -195,9 +201,11 @@ describe('undo', () => {
       );
       const gameplay: Gameplay<Board> = {
         moves: {
-          mainMove: (board: Board, { events }: { events: Events }) => {
-            events.endTurn();
-            return { nextBoard: [...board, 'moved'] };
+          mainMove: {
+            legacyApply: (board: Board, { events }: { events: Events }) => {
+              events.endTurn();
+              return { nextBoard: [...board, 'moved'] };
+            }
           }
         }
       };
@@ -236,13 +244,17 @@ describe('undo', () => {
       // A turn with two moves before endTurn: undo must roll moveCount back by both.
       const gameplay: Gameplay<Board> = {
         moves: {
-          mainMove: (board: Board, { events }: { events: Events }) => {
-            events.setTurnState('step2');
-            return { nextBoard: board };
+          mainMove: {
+            legacyApply: (board: Board, { events }: { events: Events }) => {
+              events.setTurnState('step2');
+              return { nextBoard: board };
+            }
           },
-          secondMove: (board: Board, { events }: { events: Events }) => {
-            events.endTurn();
-            return { nextBoard: board };
+          secondMove: {
+            legacyApply: (board: Board, { events }: { events: Events }) => {
+              events.endTurn();
+              return { nextBoard: board };
+            }
           }
         }
       };
@@ -294,9 +306,11 @@ describe('undo', () => {
     it('undo is enabled mid-turn (after first move but before endTurn)', () => {
       const gameplay: Gameplay<Board> = {
         moves: {
-          mainMove: (board: Board, { events }: { events: Events }) => {
-            events.setTurnState('step2');
-            return { nextBoard: board };
+          mainMove: {
+            legacyApply: (board: Board, { events }: { events: Events }) => {
+              events.setTurnState('step2');
+              return { nextBoard: board };
+            }
           }
         }
       };
@@ -362,13 +376,17 @@ const gameEndingConfig = () => makeConfig({
   ),
   gameplay: {
     moves: {
-      endWin: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }) => {
-        events.endGame(ctx.currentPlayer);
-        return { nextBoard: board };
+      endWin: {
+        legacyApply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }) => {
+          events.endGame(ctx.currentPlayer);
+          return { nextBoard: board };
+        }
       },
-      endLose: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }) => {
-        events.endGame(ctx.currentPlayer === 0 ? 1 : 0);
-        return { nextBoard: board };
+      endLose: {
+        legacyApply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }) => {
+          events.endGame(ctx.currentPlayer === 0 ? 1 : 0);
+          return { nextBoard: board };
+        }
       }
     }
   }
@@ -525,9 +543,11 @@ describe('move validate enforcement', () => {
           legacyApply: (board: Board, _meta: { events: Events }, arg: string) => ({ nextBoard: [...board, arg] }),
           validate: (_board: Board, _meta: { ctx: Ctx }, arg: string) => arg === 'ok'
         },
-        handOver: (board: Board, { events }: { events: Events }) => {
-          events.endTurn();
-          return { nextBoard: board };
+        handOver: {
+          legacyApply: (board: Board, { events }: { events: Events }) => {
+            events.endTurn();
+            return { nextBoard: board };
+          }
         }
       }
     },
@@ -586,8 +606,8 @@ describe('move validate enforcement', () => {
     expect(getByTestId('can-bad').textContent).toBe('false');
   });
 
-  it('runs a plain-function (shorthand) move unchanged — no validator', () => {
-    // defaultGameplay uses the function shorthand, so mainMove applies + endTurn as before
+  it('dispatches a move with no validator unconditionally', () => {
+    // defaultGameplay's mainMove is legacyApply-only, so every dispatch applies
     const { getByTestId } = renderGame(ctxAwareConfig());
     fireEvent.click(getByTestId('role-btn-0'));
     fireEvent.click(getByTestId('move-btn'));
@@ -810,9 +830,11 @@ describe('outcome-returning moves (apply)', () => {
   it('legacy and outcome-returning moves coexist within one game', () => {
     const gameplay: Gameplay<Board> = {
       moves: {
-        legacyMove: (board: Board, { events }: { events: Events }) => {
-          events.endTurn();
-          return { nextBoard: [...board, 'legacy'] };
+        legacyMove: {
+          legacyApply: (board: Board, { events }: { events: Events }) => {
+            events.endTurn();
+            return { nextBoard: [...board, 'legacy'] };
+          }
         },
         v2Move: { apply: (board: Board) => ({ nextBoard: [...board, 'v2'], isTurnEnd: true }) }
       }
@@ -837,13 +859,15 @@ describe('outcome-returning moves (apply)', () => {
     // old isGameEnd did) — the engine must not interpret them as v2 outcomes.
     const gameplay: Gameplay<Board> = {
       moves: {
-        mainMove: (board: Board) => {
-          // a non-fresh object dodges the excess-property check, like real
-          // legacy code returning ad-hoc extra fields did
-          const strayOutcome = {
-            nextBoard: [...board, 'x'], isTurnEnd: true, gameEnd: { winnerIndex: 0 }
-          };
-          return strayOutcome;
+        mainMove: {
+          legacyApply: (board: Board) => {
+            // a non-fresh object dodges the excess-property check, like real
+            // legacy code returning ad-hoc extra fields did
+            const strayOutcome = {
+              nextBoard: [...board, 'x'], isTurnEnd: true, gameEnd: { winnerIndex: 0 }
+            };
+            return strayOutcome;
+          }
         }
       }
     };

--- a/src/components/strategy-game-factory/strategy-game-factory.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.tsx
@@ -10,7 +10,7 @@ import { useLocation } from 'react-router';
 import { useGameStats } from './hooks/use-game-stats';
 import { trackEvent } from '../../tracking';
 import type {
-  Mode, Ctx, Events, MoveOutcome, NormalizedMove, Gameplay, GameMoves,
+  Mode, Ctx, Events, MoveOutcome, EngineMove, Gameplay, GameMoves,
   BoardClientProps, Variant as DisplayVariant, VariantInput
 } from './types';
 import { resolveVariants } from './helpers/resolve-variants';
@@ -45,11 +45,8 @@ export const strategyGameFactory = <TBoard,>({
   const { rule, roleLabels, getPlayerStepDescription } = presentation;
   const { moves, endOfTurnMove } = gameplay;
   const { defaultVariantIndex, defaultVariant, resolvedVariants } = resolveVariants(variants);
-  // Normalize the shorthand (plain function = legacy move with no validator)
-  // so the rest of the engine deals with a single long-form shape.
-  const normalizedMoves: Record<string, NormalizedMove<TBoard>> =
-    mapValues(moves, (m) => typeof m === 'function' ? { legacyApply: m } : m);
-  Object.entries(normalizedMoves).forEach(([name, def]) => {
+  const moveDefinitions: Record<string, EngineMove<TBoard>> = moves;
+  Object.entries(moveDefinitions).forEach(([name, def]) => {
     if (!!def.legacyApply === !!def.apply) {
       const message = `strategyGameFactory: move ${name} must define exactly one of apply/legacyApply`;
       if (import.meta.env.DEV) {
@@ -146,7 +143,7 @@ export const strategyGameFactory = <TBoard,>({
           + 'pass the latest nextBoard when chaining moves within a turn');
       }
       const transition = reduceMove(
-        store.getState(), normalizedMoves[name]!, name, args, resolvedPlayerNames
+        store.getState(), moveDefinitions[name]!, name, args, resolvedPlayerNames
       );
       if (transition.illegal) {
         reportIllegalMove(name, moveBoard, args);
@@ -236,7 +233,7 @@ export const strategyGameFactory = <TBoard,>({
       }
     };
 
-    wrappedGameMoves = mapValues(normalizedMoves, (_def, name) => {
+    wrappedGameMoves = mapValues(moveDefinitions, (_def, name) => {
       const wrapped: GameMoves<TBoard>[string] = (moveBoard: TBoard, ...args: unknown[]) =>
         dispatchMove(name, moveBoard, args);
       return wrapped;
@@ -250,7 +247,7 @@ export const strategyGameFactory = <TBoard,>({
     // Bots and the auto `endOfTurnMove` dispatch use `wrappedGameMoves` instead:
     // there an illegal move is a bug, and the validator fails loudly (see
     // `reportIllegalMove`).
-    const clientGameMoves: GameMoves<TBoard> = mapValues(normalizedMoves, ({ validate }, name) => {
+    const clientGameMoves: GameMoves<TBoard> = mapValues(moveDefinitions, ({ validate }, name) => {
       const isAllowed = (moveBoard: TBoard, ...args: unknown[]) => {
         const liveCtx = buildCtx(store.getState(), resolvedPlayerNames);
         return liveCtx.isClientMoveAllowed

--- a/src/components/strategy-game-factory/types.ts
+++ b/src/components/strategy-game-factory/types.ts
@@ -55,21 +55,21 @@ export type PureMoveFunction<TBoard> = (
 type MoveValidator<TBoard> = (
   board: TBoard, meta: { ctx: Ctx }, ...args: any[]
 ) => boolean
-// A move is either a legacy plain function (shorthand — always accepted by the
-// engine), a long-form `legacyApply` object pairing it with an optional
-// legality validator, or — the preferred contract for new games — an
-// outcome-returning `apply` that gets no `events` and instead returns
-// turn/game consequences as data. The distinct key is the contract marker: the
-// engine interprets the returned MoveOutcome only for `apply` moves, and a
-// migrated move that still touches `events` fails to compile.
+// Every move is an object pairing an optional legality validator with exactly
+// one apply function: either a legacy `legacyApply` or — the preferred contract
+// for new games — an outcome-returning `apply` that gets no `events` and
+// instead returns turn/game consequences as data. The distinct key is the
+// contract marker: the engine interprets the returned MoveOutcome only for
+// `apply` moves, and a migrated move that still touches `events` fails to
+// compile.
 export type MoveDefinition<TBoard> =
-  | MoveFunction<TBoard>
   | { legacyApply: MoveFunction<TBoard>; validate?: MoveValidator<TBoard> }
   | { apply: PureMoveFunction<TBoard>; validate?: MoveValidator<TBoard> }
-// Engine-internal normalized move shape (not re-exported from the barrel):
-// the shorthand folded into long form, carrying exactly one of
-// apply/legacyApply (enforced at factory time).
-export type NormalizedMove<TBoard> = {
+// Engine-internal move shape (not re-exported from the barrel): the union above
+// collapsed to one object with both apply keys optional, which is what the
+// reducer's truthiness branch reads. Exactly one of them is present — enforced
+// at factory time, since plain JS callers can bypass MoveDefinition.
+export type EngineMove<TBoard> = {
   legacyApply?: MoveFunction<TBoard>
   apply?: PureMoveFunction<TBoard>
   validate?: MoveValidator<TBoard>


### PR DESCRIPTION
Follow-up to the `validate` migration: with legality now covered everywhere, the plain-function move shorthand was the last thing keeping two move shapes alive in the engine.

## What was still short-form

Six moves across five games — none of them needing a validator, all now `{ legacyApply }`:

| game | move |
| --- | --- |
| `architect-and-bandits-a` / `-b` | `startNextDay` |
| `recolouring-discs` | `pass` |
| `increment-or-double` | `increment` |
| `take-1-or-halve` | `take1` |
| `pairs-of-numbers` | `add1`, `subtract` |

Behaviour is unchanged — these are pure re-wrappings.

(`bacteria`'s four attacker moves look short-form at a glance but are built by an `attackerMove(type)` factory that already returns long form.)

## What that buys in the factory

`MoveDefinition` loses its plain-function union member, so `gameplay.moves` already has the shape the engine wants and the normalization step goes away:

```diff
-  // Normalize the shorthand (plain function = legacy move with no validator)
-  // so the rest of the engine deals with a single long-form shape.
-  const normalizedMoves: Record<string, NormalizedMove<TBoard>> =
-    mapValues(moves, (m) => typeof m === 'function' ? { legacyApply: m } : m);
+  const moveDefinitions: Record<string, EngineMove<TBoard>> = moves;
```

With nothing left to normalize, `NormalizedMove` is renamed `EngineMove` — it is still the useful engine-internal shape (the union collapsed to one object with both apply keys optional, which is what the reducer's truthiness branch reads), just no longer named after a step that no longer exists.

The factory-time "exactly one of apply/legacyApply" check stays: plain JS callers can bypass `MoveDefinition`, and its spec coverage is unchanged.

## Tests and docs

The engine spec used the shorthand in a dozen fixtures; all converted. Two of them were annotated `GameMoves<Board>` (the *wrapped* moves type) rather than `Gameplay<Board>['moves']`, which is why the compiler had not been guarding them — corrected, so the type system now catches a stray plain function everywhere. One test title stopped describing what it tests and was retitled:

```diff
-  it('runs a plain-function (shorthand) move unchanged — no validator', () => {
+  it('dispatches a move with no validator unconditionally', () => {
```

`README.md` and `AGENTS.md` drop the shorthand from the move contract: `moves` is now described as "three shapes" → two apply contracts, and "the function shorthand means always legal" → "omitting `validate` means always legal".

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSxP4EAjGt4vDBxsQt32c)_