### PR TITLE
Migrate the tic-tac-toe alikes / grid games to `apply`

### DIFF
--- a/src/components/games/amor-and-cupido/amor-and-cupido.tsx
+++ b/src/components/games/amor-and-cupido/amor-and-cupido.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory, type Ctx, type Events } from '../../strategy-game-factory';
+import { strategyGameFactory, type Ctx, type MoveOutcome } from '../../strategy-game-factory';
 import { type Board, completesTriangle, generateStartBoard, isClaimAllowed } from './helpers';
 import { smartBotStrategy } from './bot-strategy';
 import { BoardClient } from './board-client';
@@ -6,15 +6,13 @@ import { BoardClient } from './board-client';
 const moves = {
   claimEdge: {
     validate: (board: Board, _, edge: number) => isClaimAllowed(board, edge),
-    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, edge: number) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, edge: number): MoveOutcome<Board> => {
       const nextBoard = board.slice();
       nextBoard[edge] = ctx.currentPlayer;
       if (completesTriangle(board, ctx.currentPlayer!, edge)) {
-        events.endGame(ctx.currentPlayer);
-      } else {
-        events.endTurn();
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/magic-box/magic-box-a/magic-box-a.tsx
+++ b/src/components/games/magic-box/magic-box-a/magic-box-a.tsx
@@ -1,6 +1,6 @@
 import { range } from 'lodash';
 import {
-  strategyGameFactory, type Events, type BoardClientProps, type Ctx, GameBoard
+  strategyGameFactory, type MoveOutcome, type BoardClientProps, type Ctx, GameBoard
 } from '../../../strategy-game-factory';
 import { generateEmptyBoard, isGameEnd, isPlacementAllowed, placeStone, type Board } from './helpers';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
@@ -27,13 +27,13 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => (
 const moves = {
   placeStone: {
     validate: (board: Board, _, id: number) => isPlacementAllowed(board, id),
-    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, id) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, id): MoveOutcome<Board> => {
       const nextBoard = placeStone(board, id);
-      events.endTurn();
+      // The box breaks under the stone just placed, so the mover loses.
       if (isGameEnd(nextBoard)) {
-        events.endGame(ctx.currentPlayer === 0 ? 1 : 0);
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer === 0 ? 1 : 0 } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 }

--- a/src/components/games/magic-box/magic-box-b/magic-box-b.tsx
+++ b/src/components/games/magic-box/magic-box-b/magic-box-b.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory, type Events, type Ctx } from '../../../strategy-game-factory';
+import { strategyGameFactory, type MoveOutcome, type Ctx } from '../../../strategy-game-factory';
 import { BoardClient } from './board-client';
 import {
   generateEmptyBoard, isDesignationAllowed, isLineFull, isPlacementAllowed, placeStoneAt, type Board
@@ -8,7 +8,9 @@ import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 const moves = {
   placeStone: {
     validate: (board: Board, _, cellId: number) => isPlacementAllowed(board, cellId),
-    legacyApply: (board: Board, _, cellId) => {
+    // First half of the turn: place a stone, then designate a line — the turn
+    // stays open in between.
+    apply: (board: Board, _, cellId): MoveOutcome<Board> => {
       const nextBoard: Board = { stones: placeStoneAt(board.stones, cellId), pendingLine: null };
       return { nextBoard };
     }
@@ -16,14 +18,13 @@ const moves = {
 
   designateLine: {
     validate: (board: Board, _, lineIndex: number) => isDesignationAllowed(board, lineIndex),
-    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, lineIndex) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, lineIndex): MoveOutcome<Board> => {
       const nextBoard: Board = { stones: board.stones, pendingLine: lineIndex };
+      // A full designated line leaves the other player nowhere to place.
       if (isLineFull(nextBoard.stones, lineIndex)) {
-        events.endGame(ctx.currentPlayer === 0 ? 0 : 1);
-      } else {
-        events.endTurn();
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/modified-mill/modified-mill.tsx
+++ b/src/components/games/modified-mill/modified-mill.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory, type Ctx, type Events } from '../../strategy-game-factory';
+import { strategyGameFactory, type Ctx, type MoveOutcome } from '../../strategy-game-factory';
 import {
   type Board, generateEmptyBoard, playerColor, playerHasLine, isBoardFull, isPlacementAllowed
 } from './helpers';
@@ -10,18 +10,16 @@ export type { Board };
 const moves = {
   placePiece: {
     validate: (board: Board, _, node: number) => isPlacementAllowed(board, node),
-    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, node: number) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, node: number): MoveOutcome<Board> => {
       const nextBoard = board.slice();
       nextBoard[node] = playerColor(ctx.currentPlayer!);
-      events.endTurn();
       if (playerHasLine(nextBoard, ctx.currentPlayer!)) {
-        // Three of your discs adjacent in a line: the player who placed them wins.
-        events.endGame(ctx.currentPlayer);
-      } else if (isBoardFull(nextBoard)) {
-        // Board full with no line: the second player wins.
-        events.endGame(1);
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      if (isBoardFull(nextBoard)) {
+        return { nextBoard, gameEnd: { winnerIndex: 1 } };
+      }
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/sum-fifteen/sum-fifteen.tsx
+++ b/src/components/games/sum-fifteen/sum-fifteen.tsx
@@ -1,5 +1,5 @@
 import {
-  strategyGameFactory, type Events, type Ctx, type StrategyArgs, type BoardClientProps, GameBoard
+  strategyGameFactory, type MoveOutcome, type Ctx, type StrategyArgs, type BoardClientProps, GameBoard
 } from '../../strategy-game-factory';
 import { useTranslation } from '../../../language';
 import {
@@ -79,21 +79,20 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 const moves = {
   chooseNumber: {
     validate: (board: Board, _, n: number) => isChoiceAllowed(board.owner, n),
-    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, n: number) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, n: number): MoveOutcome<Board> => {
       const player = ctx.currentPlayer as 0 | 1;
       const owner = board.owner.slice() as Board['owner'];
       owner[n - 1] = player;
       const nextBoard = { owner };
 
       if (hasSum15(numbersOwnedBy(owner, player))) {
-        events.endGame(player);
-      } else if (owner.every(o => o !== null)) {
-        // All nine numbers claimed, nobody reached a triple summing to 15.
-        events.endGame(1);
-      } else {
-        events.endTurn();
+        return { nextBoard, gameEnd: { winnerIndex: player } };
       }
-      return { nextBoard };
+      if (owner.every(o => o !== null)) {
+        // All nine numbers claimed, nobody reached a triple summing to 15.
+        return { nextBoard, gameEnd: { winnerIndex: 1 } };
+      }
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/tictactoe-alikes/anti-tictactoe/anti-tictactoe.tsx
+++ b/src/components/games/tictactoe-alikes/anti-tictactoe/anti-tictactoe.tsx
@@ -1,6 +1,6 @@
 import { range, cloneDeep } from 'lodash';
 import {
-  strategyGameFactory, type Events, type BoardClientProps, type Ctx, GameBoard
+  strategyGameFactory, type MoveOutcome, type BoardClientProps, type Ctx, GameBoard
 } from '../../../strategy-game-factory';
 import { generateEmptyTicTacToeBoard, validatePlacement } from '../helpers';
 import { isGameEnd, hasFirstPlayerWon, type Board } from './helpers';
@@ -42,14 +42,13 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
 const moves = {
   placePiece: {
     validate: validatePlacement,
-    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, id) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, id): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard[id] = ctx.currentPlayer === 0 ? 'red' : 'blue';
-      events.endTurn();
       if (isGameEnd(nextBoard)) {
-        events.endGame(hasFirstPlayerWon(nextBoard) ? 0 : 1);
+        return { nextBoard, gameEnd: { winnerIndex: hasFirstPlayerWon(nextBoard) ? 0 : 1 } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 }

--- a/src/components/games/tictactoe-alikes/tictactoe-doublestart/tictactoe-doublestart.tsx
+++ b/src/components/games/tictactoe-alikes/tictactoe-doublestart/tictactoe-doublestart.tsx
@@ -1,6 +1,6 @@
 import { range, cloneDeep } from 'lodash';
 import {
-  strategyGameFactory, type Events, type BoardClientProps, type Ctx, GameBoard
+  strategyGameFactory, type MoveOutcome, type BoardClientProps, type Ctx, GameBoard
 } from '../../../strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { generateEmptyTicTacToeBoard, validatePlacement } from '../helpers';
@@ -44,18 +44,19 @@ const isDuringFirstMove = (board: Board) => board.filter(c => c).length <= 1;
 const moves = {
   placePiece: {
     validate: validatePlacement,
-    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, id) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, id): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard[id] = ctx.currentPlayer === 0 ? 'red' : 'blue';
 
-      if (!isDuringFirstMove(nextBoard)) {
-        events.endTurn();
-        if (isGameEnd(nextBoard)) {
-          events.endGame(hasFirstPlayerWon(nextBoard) ? 0 : 1);
-        }
+      // The opening turn places two pieces, so the first of them leaves the
+      // turn open: no isTurnEnd, and no game-end check either.
+      if (isDuringFirstMove(nextBoard)) {
+        return { nextBoard };
       }
-
-      return { nextBoard };
+      if (isGameEnd(nextBoard)) {
+        return { nextBoard, gameEnd: { winnerIndex: hasFirstPlayerWon(nextBoard) ? 0 : 1 } };
+      }
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/tictactoe-alikes/tictactoe/tictactoe.tsx
+++ b/src/components/games/tictactoe-alikes/tictactoe/tictactoe.tsx
@@ -1,6 +1,6 @@
 import { range, cloneDeep } from 'lodash';
 import {
-  strategyGameFactory, type Events, type BoardClientProps, type Ctx, GameBoard
+  strategyGameFactory, type MoveOutcome, type BoardClientProps, type Ctx, GameBoard
 } from '../../../strategy-game-factory';
 import { generateEmptyTicTacToeBoard, validatePlacement } from '../helpers';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
@@ -61,26 +61,24 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
 const moves = {
   placePiece: {
     validate: validatePlacement,
-    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, id) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, id): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard[id] = currentPlayerColor(ctx);
-      events.endTurn();
       if (isGameEnd(nextBoard)) {
-        events.endGame();
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   },
   whitenPiece: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, id: number) => isWhiteningAllowed(board, ctx, id),
-    legacyApply: (board: Board, { events }: { events: Events }, id) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, id): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard[id] = 'white';
-      events.endTurn();
       if (isGameEnd(nextBoard)) {
-        events.endGame();
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 }


### PR DESCRIPTION
Phase 3 of #313, batch 4 of 5. Independent of #367, #368 and #369 — no overlapping files.

## Games

- `tictactoe-alikes/tictactoe` (both moves)
- `tictactoe-alikes/anti-tictactoe`
- `tictactoe-alikes/tictactoe-doublestart`
- `magic-box/magic-box-a`
- `magic-box/magic-box-b` (both moves)
- `sum-fifteen`
- `modified-mill`
- `amor-and-cupido`

## Multi-stage turns become explicit

Two games have turns made of more than one move. Under the legacy contract a mid-turn move signalled "turn continues" by *not* calling `endTurn()` — something you can only see by noticing an `if` that wraps the call. The outcome form states it:

**tictactoe-doublestart** — the opening turn places two pieces. The first now returns a bare `{ nextBoard }`:

```js
if (isDuringFirstMove(nextBoard)) {
  return { nextBoard };
}
```

which also makes visible that the game-end check was deliberately skipped on that half-turn, not forgotten.

**magic-box-b** — `placeStone` is the open half of a place-then-designate turn, and now says so in a comment plus a bare `{ nextBoard }` return.

## One winner expression simplified

`magic-box-b`'s designation winner was written `ctx.currentPlayer === 0 ? 0 : 1` — that is `ctx.currentPlayer` spelled the long way, and it reads as if something interesting is happening. It becomes `winnerIndex: ctx.currentPlayer!`.

Worth flagging that `magic-box-a` has a superficially identical-looking `ctx.currentPlayer === 0 ? 1 : 0`, which is a *real* negation — the player whose stone breaks the box loses — and is preserved as-is. The two are one character apart in the source and mean opposite things; that is exactly the sort of thing an explicit `winnerIndex` makes easier to read.

`sum-fifteen` and `modified-mill` each had two distinct game-end branches (own triple / board full, own line / board full) in an `if … else if … else` chain; these become two early returns and a fallthrough, which drops one level of nesting.

## The `currentPlayer` no-flip check

Two BoardClients in the batch read `ctx.currentPlayer`:

- `amor-and-cupido` derives `hoverStroke` from it, but applies the class only on edges where `isMoveAllowed(edge)` holds — false everywhere once the game ends.
- `tictactoe` uses `otherPlayerColor(ctx)` in `getPlayerStepDescription` (rendered only during `phase === 'play'`) and inside `isWhiteningAllowed`, a validator reached through `isAllowed`, which folds in `ctx.isClientMoveAllowed`.

Everything else reading `ctx.currentPlayer` is a move body or a bot.

## Verification

`npm test` green: lint, typecheck, and 972 tests, same count as `main`.

Migration progress after this batch: 35 games on `apply`, 45 still on `legacyApply`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cECth7yywjvuhpXHuTgkS)_