### PR TITLE
Migrate the pile-splitting / matchstick games to `apply`

### DIFF
--- a/src/components/games/four-piles-spread-ahead/four-piles-spread-ahead.tsx
+++ b/src/components/games/four-piles-spread-ahead/four-piles-spread-ahead.tsx
@@ -1,6 +1,6 @@
 import { range, random, cloneDeep } from 'lodash';
 import {
-  strategyGameFactory, type BoardClientProps, type Events, GameBoard, useHoverPreview
+  strategyGameFactory, type BoardClientProps, type Ctx, type MoveOutcome, GameBoard, useHoverPreview
 } from '../../strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { useLanguage } from '../../../language';
@@ -139,18 +139,17 @@ const moves = {
   spreadPieces: {
     validate: (board: Board, _, { pileId, pieceCount }: { pileId: number; pieceCount: number }) =>
       isSpreadAllowed(board, pileId, pieceCount),
-    legacyApply: (board: Board, { events }: { events: Events }, { pileId, pieceCount }) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, { pileId, pieceCount }): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard[pileId] = board[pileId] - pieceCount;
       for (let i = pileId - pieceCount; i < pileId; i++) {
         nextBoard[i] = board[i] + 1;
       }
       const isGameEnd = nextBoard[1]===0 && nextBoard[2]===0 && nextBoard[3]===0;
-      events.endTurn();
       if (isGameEnd) {
-        events.endGame();
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/four-piles-two-grabs/four-piles-two-grabs.tsx
+++ b/src/components/games/four-piles-two-grabs/four-piles-two-grabs.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { range } from 'lodash';
 import {
   strategyGameFactory,
-  type Ctx, type Events, type StrategyArgs, type BoardClientProps,
+  type Ctx, type MoveOutcome, type StrategyArgs, type BoardClientProps,
   GameBoard
 } from '../../strategy-game-factory';
 import { useTranslation } from '../../../language';
@@ -139,15 +139,12 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 const moves = {
   takeStones: {
     validate: (board: Board, _, move: Move) => isMoveLegal(board, move),
-    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, move: Move) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, move: Move): MoveOutcome<Board> => {
       const nextBoard = applyMove(board, move);
       if (isTerminal(nextBoard)) {
-        // The opponent cannot move, so the player who just moved wins.
-        events.endGame(ctx.currentPlayer!);
-      } else {
-        events.endTurn();
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/matchstick-piles/matchstick-piles.tsx
+++ b/src/components/games/matchstick-piles/matchstick-piles.tsx
@@ -2,7 +2,7 @@ import { Fragment } from 'react';
 import { range, sample, random } from 'lodash';
 import {
   strategyGameFactory,
-  type Events, type StrategyArgs, type GameMoves, type BoardClientProps,
+  type Ctx, type MoveOutcome, type StrategyArgs, type GameMoves, type BoardClientProps,
   GameBoard, useHoverPreview
 } from '../../strategy-game-factory';
 
@@ -126,27 +126,26 @@ export const isSplitAllowed = (board: Board, pileId: number, firstPart: number):
 const moves = {
   removeMatch: {
     validate: (board: Board, _, pileId: number) => isRemovalAllowed(board, pileId),
-    legacyApply: (board: Board, { events }: { events: Events }, pileId: number) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, pileId: number): MoveOutcome<Board> => {
       const nextBoard = board
         .map((n, i) => (i === pileId ? n - 1 : n))
         .filter(n => n > 0);
-      events.endTurn();
-      // The player who takes the last match leaves the other player unable to
-      // move, and therefore wins.
-      if (nextBoard.length === 0) events.endGame();
-      return { nextBoard };
+      if (nextBoard.length === 0) {
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
+      }
+      return { nextBoard, isTurnEnd: true };
     }
   },
   splitPile: {
     validate: (board: Board, _, pileId: number, firstPart: number) =>
       isSplitAllowed(board, pileId, firstPart),
-    legacyApply: (board: Board, { events }: { events: Events }, pileId: number, firstPart: number) => {
+    apply: (board: Board, _, pileId: number, firstPart: number): MoveOutcome<Board> => {
       const size = board[pileId];
       const nextBoard = board.flatMap((n, i) =>
         i === pileId ? [firstPart, size - firstPart] : [n]
       );
-      events.endTurn();
-      return { nextBoard };
+      // A split never empties the board, so it can only ever end the turn.
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/pile-splitting-games/pile-splitter-3/pile-splitter-3.tsx
+++ b/src/components/games/pile-splitting-games/pile-splitter-3/pile-splitter-3.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { range, isEqual, random, cloneDeep } from 'lodash';
 import {
-  strategyGameFactory, type BoardClientProps, type Events, GameBoard, useHoverPreview
+  strategyGameFactory, type BoardClientProps, type Ctx, type MoveOutcome, GameBoard, useHoverPreview
 } from '../../../strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { emptiedPileId, isRemovalAllowed, isSplitAllowed, withPileRemoved } from '../helpers';
@@ -143,12 +143,15 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 const moves = {
   removePile: {
     validate: (board: Board, _, pileId: number) => isRemovalAllowed(board, pileId),
-    legacyApply: (board: Board, _, pileId: number) => ({ nextBoard: withPileRemoved(board, pileId) })
+    // First half of the turn: empty a pile, then split another into it — the
+    // turn stays open in between.
+    apply: (board: Board, _, pileId: number): MoveOutcome<Board> =>
+      ({ nextBoard: withPileRemoved(board, pileId) })
   },
   splitPile: {
     validate: (board: Board, _, { pileId, pieceCount }: { pileId: number; pieceCount: number }) =>
       isSplitAllowed(board, pileId, pieceCount),
-    legacyApply: (board: Board, { events }: { events: Events }, { pileId, pieceCount }) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, { pileId, pieceCount }): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       // the slot emptied earlier this turn takes the other half of the split
       const removedPileId = emptiedPileId(nextBoard)!;
@@ -159,11 +162,11 @@ const moves = {
         nextBoard[removedPileId] = nextBoard[pileId] - pieceCount;
         nextBoard[pileId] = pieceCount;
       }
-      events.endTurn();
+      // All piles down to a single piece: the opponent cannot split anything.
       if (isEqual(nextBoard, [1, 1, 1])) {
-        events.endGame();
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/pile-splitting-games/pile-splitter-4/pile-splitter-4.tsx
+++ b/src/components/games/pile-splitting-games/pile-splitter-4/pile-splitter-4.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { range, isEqual, cloneDeep } from 'lodash';
 import {
-  strategyGameFactory, type BoardClientProps, type Events, GameBoard, useHoverPreview
+  strategyGameFactory, type BoardClientProps, type Ctx, type MoveOutcome, GameBoard, useHoverPreview
 } from '../../../strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { emptiedPileId, isRemovalAllowed, isSplitAllowed, withPileRemoved } from '../helpers';
@@ -152,12 +152,15 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 const moves = {
   removePile: {
     validate: (board: Board, _, pileId: number) => isRemovalAllowed(board, pileId),
-    legacyApply: (board: Board, _, pileId: number) => ({ nextBoard: withPileRemoved(board, pileId) })
+    // First half of the turn: empty a pile, then split another into it — the
+    // turn stays open in between.
+    apply: (board: Board, _, pileId: number): MoveOutcome<Board> =>
+      ({ nextBoard: withPileRemoved(board, pileId) })
   },
   splitPile: {
     validate: (board: Board, _, { pileId, pieceCount }: { pileId: number; pieceCount: number }) =>
       isSplitAllowed(board, pileId, pieceCount),
-    legacyApply: (board: Board, { events }: { events: Events }, { pileId, pieceCount }) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, { pileId, pieceCount }): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       // the slot emptied earlier this turn takes the other half of the split
       const removedPileId = emptiedPileId(nextBoard)!;
@@ -168,11 +171,11 @@ const moves = {
         nextBoard[removedPileId] = nextBoard[pileId] - pieceCount;
         nextBoard[pileId] = pieceCount;
       }
-      events.endTurn();
+      // All piles down to a single piece: the opponent cannot split anything.
       if (isEqual(nextBoard, [1, 1, 1, 1])) {
-        events.endGame();
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/pile-splitting-games/pile-splitter/pile-splitter.tsx
+++ b/src/components/games/pile-splitting-games/pile-splitter/pile-splitter.tsx
@@ -1,6 +1,6 @@
 import { range, isEqual, random } from 'lodash';
 import {
-  strategyGameFactory, type BoardClientProps, type Events, GameBoard, useHoverPreview
+  strategyGameFactory, type BoardClientProps, type Ctx, type MoveOutcome, GameBoard, useHoverPreview
 } from '../../../strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { isRemovalAllowed, isSplitAllowed, withPileRemoved } from '../helpers';
@@ -98,18 +98,21 @@ const getPlayerStepDescription = () => ({
 const moves = {
   removePile: {
     validate: (board: Board, _, pileId: number) => isRemovalAllowed(board, pileId),
-    legacyApply: (board: Board, _, pileId) => ({ nextBoard: withPileRemoved(board, pileId) })
+    // First half of the turn: discard a pile, then split the other — the turn
+    // stays open in between.
+    apply: (board: Board, _, pileId): MoveOutcome<Board> =>
+      ({ nextBoard: withPileRemoved(board, pileId) })
   },
   splitPile: {
     validate: (board: Board, _, { pileId, pieceCount }: { pileId: number; pieceCount: number }) =>
       isSplitAllowed(board, pileId, pieceCount),
-    legacyApply: (board: Board, { events }: { events: Events }, { pileId, pieceCount }) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, { pileId, pieceCount }): MoveOutcome<Board> => {
       const nextBoard = [pieceCount, board[pileId] - pieceCount];
-      events.endTurn();
+      // Two single-piece piles cannot be split, so the opponent is stuck.
       if (isEqual(nextBoard, [1, 1])) {
-        events.endGame();
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/pile-union/pile-union.tsx
+++ b/src/components/games/pile-union/pile-union.tsx
@@ -1,7 +1,7 @@
 import { useState, type ComponentProps } from 'react';
 import { range, random } from 'lodash';
 import {
-  strategyGameFactory, type Events, type BoardClientProps, GameBoard, useHoverPreview
+  strategyGameFactory, type Ctx, type MoveOutcome, type BoardClientProps, GameBoard, useHoverPreview
 } from '../../strategy-game-factory';
 import { useTranslation } from '../../../language';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
@@ -190,27 +190,29 @@ export const isMergeAllowed = (board: Board, piles: number[]): boolean =>
 const moves = {
   removeOne: {
     validate: (board: Board, _, pileIndex) => isPile(board, pileIndex),
-    legacyApply: (board: Board, { events }: { events: Events }, pileIndex) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, pileIndex): MoveOutcome<Board> => {
       const newSize = board[pileIndex] - 1;
       const nextBoard = [
         ...board.slice(0, pileIndex),
         ...(newSize > 0 ? [newSize] : []),
         ...board.slice(pileIndex + 1)
       ];
-      events.endTurn();
-      if (nextBoard.length === 0) events.endGame();
-      return { nextBoard };
+      // Taking the last match leaves the opponent nothing to take.
+      if (nextBoard.length === 0) {
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
+      }
+      return { nextBoard, isTurnEnd: true };
     }
   },
   mergePiles: {
     validate: (board: Board, _, piles: number[]) => isMergeAllowed(board, piles),
-    legacyApply: (board: Board, { events }: { events: Events }, [pileIndex1, pileIndex2]) => {
+    apply: (board: Board, _, [pileIndex1, pileIndex2]): MoveOutcome<Board> => {
       const [firstIdx, secondIdx] = [pileIndex1, pileIndex2].sort((a, b) => a - b);
       const merged = board[firstIdx] + board[secondIdx];
       const nextBoard = board.filter((_, i) => i !== firstIdx && i !== secondIdx);
       nextBoard.splice(firstIdx, 0, merged);
-      events.endTurn();
-      return { nextBoard };
+      // A merge never empties the board, so it can only ever end the turn.
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/three-piles-rebuild/three-piles-rebuild.tsx
+++ b/src/components/games/three-piles-rebuild/three-piles-rebuild.tsx
@@ -2,7 +2,8 @@ import { useEffect, useState } from 'react';
 import {
   strategyGameFactory,
   type BoardClientProps,
-  type Events,
+  type Ctx,
+  type MoveOutcome,
   type StrategyArgs,
   type GameMoves,
   GameBoard
@@ -175,18 +176,20 @@ const moves = {
   // Step 1 of a turn: keep one pile, discard the other two (shown as 0).
   keepPile: {
     validate: (board: Board, _, keepId: number) => isKeepAllowed(board, keepId),
-    legacyApply: (board: Board, _, keepId: number) =>
+    // First half of the turn: keep one pile, then rebuild from it — the turn
+    // stays open in between.
+    apply: (board: Board, _, keepId: number): MoveOutcome<Board> =>
       ({ nextBoard: withOtherPilesDiscarded(board, keepId) })
   },
   // Step 2: rebuild three new piles from the kept pile's pebbles.
   splitPile: {
     validate: (board: Board, _, parts: number[]) => isSplitAllowed(board, parts),
-    legacyApply: (_board: Board, { events }: { events: Events }, parts: number[]) => {
+    apply: (_board: Board, { ctx }: { ctx: Ctx }, parts: number[]): MoveOutcome<Board> => {
       const nextBoard = [...parts];
-      events.endTurn();
-      // The opponent now faces nextBoard; if they cannot split any pile they lose.
-      if (isTerminal(nextBoard)) events.endGame();
-      return { nextBoard };
+      if (isTerminal(nextBoard)) {
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
+      }
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };


### PR DESCRIPTION
Phase 3 of #313, batch 5 of 5. Independent of #367, #368, #369 and #371 — no overlapping files.

## Games

- `pile-splitting-games/pile-splitter` (both moves)
- `pile-splitting-games/pile-splitter-3` (both moves)
- `pile-splitting-games/pile-splitter-4` (both moves)
- `three-piles-rebuild` (both moves)
- `matchstick-piles` (both moves)
- `four-piles-spread-ahead`
- `four-piles-two-grabs`
- `pile-union` (both moves)

This is the two-move-turn batch: five of the eight games have a turn made of two dispatches, so it exercises the "turn stays open" half of the contract more than any of the earlier four.

## Turn boundaries stated instead of inferred

In the pile-splitters and `three-piles-rebuild`, a turn is *discard a pile, then split another*. The first move never called `events.endTurn()`, and the only way to know that was deliberate rather than an oversight was to check the second move. Now it returns a bare `{ nextBoard }` with a comment naming the pairing:

```js
// First half of the turn: discard a pile, then split the other — the turn
// stays open in between.
apply: (board: Board, _, pileId): MoveOutcome<Board> =>
  ({ nextBoard: withPileRemoved(board, pileId) })
```

## Two moves that structurally cannot end the game

`matchstick-piles.splitPile` and `pile-union.mergePiles` had no game-end branch at all. That is not an omission — a split raises the pile count, and a merge always leaves at least one pile — so each returns a plain `isTurnEnd: true` with a comment recording the invariant. Neither reads `ctx`, so both take `_` for the meta parameter.

## The `currentPlayer` no-flip check

No BoardClient in this batch reads `ctx.currentPlayer` at all — the only occurrence anywhere in these eight games is `four-piles-two-grabs`'s own move body. So the no-flip has nothing to affect here.

## Verification

`npm test` green: lint, typecheck, and 972 tests, same count as `main`.

Migration progress after this batch: 43 games on `apply`, 37 still on `legacyApply` — a bit over halfway.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cECth7yywjvuhpXHuTgkS)_