### PR TITLE
Write down the comment convention, and apply it to twelve-squares

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,6 +247,29 @@ See [README.md § Internationalisation
 (i18n)](README.md#internationalisation-i18n). Use the `t()` helper from
 `translate.js`.
 
+## Comments
+
+Only write a comment when it explains something that is **not self-evident from
+the code itself** — a rule of the game the condition alone doesn't imply, why an
+apparently redundant branch exists, a non-obvious invariant, the reasoning behind
+a strategy. A comment that restates the line under it is noise; delete it.
+
+```ts
+// noise — the code already says exactly this
+// The player who takes the last match wins.
+if (nextBoard.length === 0) {
+  return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
+}
+
+// worth keeping — the return value alone doesn't say why there is no game-end branch
+// A split never empties the board, so it can only ever end the turn.
+return { nextBoard, isTurnEnd: true };
+```
+
+This applies with particular force to moves on the outcome-returning `apply`
+contract: `gameEnd: { winnerIndex }` already names the winner, so prose
+narrating who won earns nothing.
+
 ## Maintenance philosophy
 
 This is a volunteer side-project with limited time. Prefer simple, consistent,

--- a/src/components/games/twelve-squares/twelve-squares.tsx
+++ b/src/components/games/twelve-squares/twelve-squares.tsx
@@ -80,7 +80,6 @@ const moves = {
       const nextBoard = ctx.currentPlayer === 0
         ? { left: board.left + step, right: board.right }
         : { left: board.left, right: board.right - step };
-      // Jumping past the other piece wins for the player who just moved.
       if (nextBoard.right < nextBoard.left) {
         return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }


### PR DESCRIPTION
Records the rule from your review on #367 (["I do not think these comments add much value"](https://github.com/a-gondolkodas-orome/durer-jatekok/pull/367#discussion_r3699016655)) so it applies to the remaining 37 game migrations and to anything written after them.

## The rule

A new `## Comments` section in `AGENTS.md`: only write a comment when it explains something **not self-evident from the code itself** — a game rule the condition alone doesn't imply, why an apparently redundant branch exists, a non-obvious invariant, the reasoning behind a strategy. A comment restating the line under it is noise.

It includes a keep/drop pair, because the distinction is what decided the close calls while stripping the other batches:

```ts
// noise — the code already says exactly this
// The player who takes the last match wins.
if (nextBoard.length === 0) {
  return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
}

// worth keeping — the return value alone doesn't say why there is no game-end branch
// A split never empties the board, so it can only ever end the turn.
return { nextBoard, isTurnEnd: true };
```

The section calls out that this bites hardest on the outcome-returning `apply` contract: `gameEnd: { winnerIndex }` names the winner, so prose narrating who won earns nothing. Worth saying explicitly, because under the legacy contract a bare `events.endGame()` genuinely *did* hide the winner — which is why several of these comments existed in the first place, and why the migration is what turned them into noise.

## The one code change

`twelve-squares` loses `// Jumping past the other piece wins for the player who just moved.` — the only comment of this class that reached `main`, because #368 merged before the equivalent cleanup could be amended onto its branch. #369, #371 and #372 were fixed on their own branches (13 comments between them), and #367's three went in before it merged.

After this, `grep` finds no remaining "who wins" comments sitting above an explicit `winnerIndex` in any migrated game.

## Verification

`npm test` green: lint, typecheck, 972 tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cECth7yywjvuhpXHuTgkS)_