### PR TITLE
Migrate eight more single-move games to `apply`

### DIFF
--- a/src/components/games/bank-robbers/bank-robbers.tsx
+++ b/src/components/games/bank-robbers/bank-robbers.tsx
@@ -1,5 +1,5 @@
 import {
-  strategyGameFactory, type Events, type BoardClientProps, type StrategyArgs, GameBoard
+  strategyGameFactory, type Ctx, type MoveOutcome, type BoardClientProps, type StrategyArgs, GameBoard
 } from '../../strategy-game-factory';
 import { range, cloneDeep, random, sample } from 'lodash';
 import { smartBotStrategy } from './bot-strategy';
@@ -70,7 +70,7 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
 const moves = {
   rob: {
     validate: (board: Board, _, index) => isRobbable(board, index),
-    legacyApply: (board: Board, { events }: { events: Events }, index) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, index): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       // so that ai strategy can be simpler: first move is always the same
       const transformedMove = board.firstMove === null ? 0 : index;
@@ -79,11 +79,10 @@ const moves = {
       }
       nextBoard.lastMove = transformedMove;
       nextBoard.circle[transformedMove] = false;
-      events.endTurn();
       if (getAllowedBanks(nextBoard).length === 0) {
-        events.endGame();
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 }

--- a/src/components/games/chocolate-breaking/chocolate-breaking.tsx
+++ b/src/components/games/chocolate-breaking/chocolate-breaking.tsx
@@ -1,6 +1,6 @@
 import { range } from 'lodash';
 import {
-  strategyGameFactory, type BoardClientProps, type Ctx, type Events, GameBoard, useHoverPreview
+  strategyGameFactory, type BoardClientProps, type Ctx, type MoveOutcome, GameBoard, useHoverPreview
 } from '../../strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import {
@@ -117,13 +117,12 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 const moves = {
   breakPiece: {
     validate: (board: Board, _, move: Move) => isBreakAllowed(board, move),
-    legacyApply: (board: Board, { events }: { events: Events }, move: Move) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, move: Move): MoveOutcome<Board> => {
       const nextBoard = applyBreak(board, move);
-      events.endTurn();
       if (!hasSafeBreak(nextBoard.pieces)) {
-        events.endGame();
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/four-connected-fields/four-connected-fields.tsx
+++ b/src/components/games/four-connected-fields/four-connected-fields.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory, type Ctx, type Events } from "../../strategy-game-factory";
+import { strategyGameFactory, type Ctx, type MoveOutcome } from "../../strategy-game-factory";
 import { type Board, hasAnyMove, isNodePlayable } from "./helpers";
 import { randomBotStrategy, smartBotStrategy } from "./bot-strategy";
 import { BoardClient } from "./board-client";
@@ -8,17 +8,15 @@ export type { Board };
 const moves = {
   placeCoin: {
     validate: (board: Board, _, node: number) => isNodePlayable(board, node),
-    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, node: number) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, node: number): MoveOutcome<Board> => {
       const nextBoard = board.slice();
       nextBoard[node] += 1;
-      events.endTurn();
-      // The player who places the last coin wins: the game ends when no field is
-      // empty and no line has equal endpoints, i.e. when the mover just made all
-      // further moves impossible.
+      // No move remains once every field is occupied and no line has equal
+      // endpoints.
       if (!hasAnyMove(nextBoard)) {
-        events.endGame(ctx.currentPlayer);
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/matches-on-edges/matches-on-edges.tsx
+++ b/src/components/games/matches-on-edges/matches-on-edges.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory, type Ctx, type Events } from '../../strategy-game-factory';
+import { strategyGameFactory, type Ctx, type MoveOutcome } from '../../strategy-game-factory';
 import { BoardClient } from './board-client';
 import {
   type Board, applyMove, currentWindowSize, generateStartBoard, isTerminal, isWindowAllowed
@@ -11,14 +11,14 @@ const moves = {
   // turn passes.
   placeWindow: {
     validate: (board: Board, _, a: number, b: number) => isWindowAllowed(board, a, b),
-    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, a: number, b: number) => {
+    apply: (
+      board: Board, { ctx }: { ctx: Ctx }, a: number, b: number
+    ): MoveOutcome<Board> => {
       const nextBoard = applyMove(board, a, b);
       if (isTerminal(nextBoard)) {
-        events.endGame(ctx.currentPlayer!);
-      } else {
-        events.endTurn();
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/remove-divisor-multiple/remove-divisor-multiple.tsx
+++ b/src/components/games/remove-divisor-multiple/remove-divisor-multiple.tsx
@@ -1,5 +1,5 @@
 import {
-  strategyGameFactory, type Events, type BoardClientProps, type StrategyArgs, GameBoard
+  strategyGameFactory, type Ctx, type MoveOutcome, type BoardClientProps, type StrategyArgs, GameBoard
 } from '../../strategy-game-factory';
 import { range, cloneDeep, sample, random } from 'lodash';
 import { strategyDict } from './bot-strategy';
@@ -64,15 +64,14 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
 const moves = {
   removeNumber: {
     validate: (board: Board, _, n) => isAllowed(board, n),
-    legacyApply: (board: Board, { events }: { events: Events }, n) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, n): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard.numbersOnTable[n - 1] = false;
       nextBoard.previousMove = n;
-      events.endTurn();
       if (isGameEnd(nextBoard)) {
-        events.endGame();
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/six-fields-circle/six-fields-circle.tsx
+++ b/src/components/games/six-fields-circle/six-fields-circle.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory, type Ctx, type Events } from "../../strategy-game-factory";
+import { strategyGameFactory, type Ctx, type MoveOutcome } from "../../strategy-game-factory";
 import {
   type Board, type Move, hasLegalMove, generateStartBoard, isRemovalAllowed
 } from "./helpers";
@@ -10,15 +10,14 @@ export type { Board };
 const moves = {
   removeFromTwo: {
     validate: (board: Board, _, move: Move) => isRemovalAllowed(board, move),
-    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }, [i, j]: Move) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, [i, j]: Move): MoveOutcome<Board> => {
       const nextBoard = board.slice();
       nextBoard[i] -= 1;
       nextBoard[j] -= 1;
-      events.endTurn();
-      // If no move remains, the next player cannot move and loses, so the player
-      // who just moved (the current player) wins.
-      if (!hasLegalMove(nextBoard)) events.endGame(ctx.currentPlayer);
-      return { nextBoard };
+      if (!hasLegalMove(nextBoard)) {
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
+      }
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
+++ b/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
@@ -1,6 +1,6 @@
 import {
   strategyGameFactory,
-  type Ctx, type Events, type StrategyArgs, type BoardClientProps,
+  type Ctx, type MoveOutcome, type StrategyArgs, type BoardClientProps,
   GameBoard, useHoverPreview
 } from '../../strategy-game-factory';
 import { cloneDeep, isEqual, sample, random, range } from 'lodash';
@@ -73,15 +73,14 @@ const moves = {
   removeStone: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, pileId) =>
       isRemovalAllowed(board, ctx.currentPlayer!, pileId),
-    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, pileId) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, pileId): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard.piles[pileId] = board.piles[pileId] - 1;
       nextBoard.leftRestriction[ctx.currentPlayer!] = (pileId === 0);
-      events.endTurn();
       if (isGameEnd(nextBoard, ctx)) {
-        events.endGame();
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };

--- a/src/components/games/two-of-three-takeaway/two-of-three-takeaway.tsx
+++ b/src/components/games/two-of-three-takeaway/two-of-three-takeaway.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { range } from 'lodash';
 import {
   strategyGameFactory,
-  type Ctx, type Events, type StrategyArgs, type BoardClientProps,
+  type Ctx, type MoveOutcome, type StrategyArgs, type BoardClientProps,
   GameBoard
 } from '../../strategy-game-factory';
 import { useTranslation } from '../../../language';
@@ -105,15 +105,14 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 const moves = {
   takeChips: {
     validate: (board: Board, _, i: number, j: number) => isTakeAllowed(board, i, j),
-    legacyApply: (board: Board, { ctx, events }: { ctx: Ctx, events: Events }, i: number, j: number) => {
+    apply: (
+      board: Board, { ctx }: { ctx: Ctx }, i: number, j: number
+    ): MoveOutcome<Board> => {
       const nextBoard = applyMove(board, [i, j]);
       if (isTerminal(nextBoard)) {
-        // The opponent cannot move, so the player who just moved wins.
-        events.endGame(ctx.currentPlayer!);
-      } else {
-        events.endTurn();
+        return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }
-      return { nextBoard };
+      return { nextBoard, isTurnEnd: true };
     }
   }
 };


### PR DESCRIPTION
Phase 3 of #313, batch 6. The last of the straightforward ones — everything remaining after this has some wrinkle (multi-move turns, `turnState`, `autoEndOfTurn`, or a spec built on `makeEvents`).

## Games

- `bank-robbers`
- `chocolate-breaking`
- `four-connected-fields`
- `matches-on-edges`
- `remove-divisor-multiple`
- `six-fields-circle`
- `two-of-three-takeaway`
- `stones-remove-one-not-twice-from-left`

All eight are the plain "make a move; if the opponent is now stuck, you win" shape, so each collapses to one `gameEnd` branch and an `isTurnEnd` fallthrough.

## Comments, per #373

Three comments narrating who wins go with the migration:

- `six-fields-circle` — "If no move remains, the next player cannot move and loses, so the player who just moved (the current player) wins."
- `two-of-three-takeaway` — "The opponent cannot move, so the player who just moved wins."
- `four-connected-fields` — kept in part. The clause about who wins went; what stayed is the half that says what "no move remains" actually means on this board (every field occupied *and* no line with equal endpoints), which `!hasAnyMove(nextBoard)` does not tell you on its own.

## The `currentPlayer` no-flip check

Nothing to affect here: no BoardClient in the batch reads `ctx.currentPlayer`. The only uses outside the move bodies are in `stones-remove-one-not-twice-from-left`'s bot strategies and its `getOptimalMove` search, all of which run during play.

`stones-remove-one-not-twice-from-left` is the one whose game-end test itself takes `ctx` (`isGameEnd(nextBoard, ctx)` reads `1 - ctx.currentPlayer` to ask whether the *opponent* is left-restricted). That keeps working unchanged — `apply` gets the same pre-move `ctx` the legacy form did.

## Verification

`npm test` green: lint, typecheck, and 972 tests, same count as `main`.

Migration progress after this batch: 51 games on `apply`, 29 still on `legacyApply`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cECth7yywjvuhpXHuTgkS)_