### PR TITLE
Add end-of-game tests for the eight games migrated in #374

### DIFF
--- a/src/components/games/bank-robbers/bank-robbers.tsx
+++ b/src/components/games/bank-robbers/bank-robbers.tsx
@@ -67,7 +67,7 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
   );
 };
 
-const moves = {
+export const moves = {
   rob: {
     validate: (board: Board, _, index) => isRobbable(board, index),
     apply: (board: Board, { ctx }: { ctx: Ctx }, index): MoveOutcome<Board> => {

--- a/src/components/games/bank-robbers/end-of-game.spec.ts
+++ b/src/components/games/bank-robbers/end-of-game.spec.ts
@@ -1,0 +1,24 @@
+import { moves } from './bank-robbers';
+import { makeCtx } from '../../../test-utils';
+
+// A bank can be robbed only while at least one of its two neighbours still
+// stands, so the game ends as soon as every survivor is isolated.
+const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
+
+const board = (circle: boolean[]) => ({ circle, lastMove: 0, firstMove: 0 });
+
+describe('end of game', () => {
+  it.each([0, 1])('ends for the mover (player %i) when every standing bank is isolated', p => {
+    // robbing bank 0 leaves only bank 1, whose neighbours (3 and 2) are both gone
+    const outcome = moves.rob.apply(board([true, true, false, false]), asPlayer(p), 0);
+    expect(outcome.nextBoard.circle).toEqual([false, true, false, false]);
+    expect(outcome.gameEnd).toEqual({ winnerIndex: p });
+    expect(outcome.isTurnEnd).toBeUndefined();
+  });
+
+  it('passes the turn while some bank still has a standing neighbour', () => {
+    const outcome = moves.rob.apply(board([true, true, true, false]), asPlayer(0), 0);
+    expect(outcome.gameEnd).toBeUndefined();
+    expect(outcome.isTurnEnd).toBe(true);
+  });
+});

--- a/src/components/games/chocolate-breaking/chocolate-breaking.tsx
+++ b/src/components/games/chocolate-breaking/chocolate-breaking.tsx
@@ -114,7 +114,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   );
 };
 
-const moves = {
+export const moves = {
   breakPiece: {
     validate: (board: Board, _, move: Move) => isBreakAllowed(board, move),
     apply: (board: Board, { ctx }: { ctx: Ctx }, move: Move): MoveOutcome<Board> => {

--- a/src/components/games/chocolate-breaking/end-of-game.spec.ts
+++ b/src/components/games/chocolate-breaking/end-of-game.spec.ts
@@ -1,0 +1,28 @@
+import { moves } from './chocolate-breaking';
+import { hasSafeBreak, type Board } from './helpers';
+import { makeCtx } from '../../../test-utils';
+
+// The player forced to break off the first 1×1 loses, so the game ends on the
+// move that leaves the table with no safe break at all.
+const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
+
+const single = (w: number, h: number): Board => ({ pieces: [{ id: 0, w, h }], nextId: 1 });
+
+describe('end of game', () => {
+  it.each([0, 1])('ends for the mover (player %i) when no safe break is left', p => {
+    // 1×4 splits into two 1×2 strips, neither of which can be broken safely
+    const outcome = moves.breakPiece.apply(single(1, 4), asPlayer(p), { id: 0, dir: 'h', pos: 2 });
+    expect(outcome.nextBoard.pieces.map(({ w, h }) => [w, h])).toEqual([[1, 2], [1, 2]]);
+    expect(hasSafeBreak(outcome.nextBoard.pieces)).toBe(false);
+    expect(outcome.gameEnd).toEqual({ winnerIndex: p });
+    expect(outcome.isTurnEnd).toBeUndefined();
+  });
+
+  it('passes the turn while some piece can still be broken safely', () => {
+    // 2×4 into 2×1 and 2×3: the 2×3 is still flexible
+    const outcome = moves.breakPiece.apply(single(2, 4), asPlayer(0), { id: 0, dir: 'h', pos: 1 });
+    expect(hasSafeBreak(outcome.nextBoard.pieces)).toBe(true);
+    expect(outcome.gameEnd).toBeUndefined();
+    expect(outcome.isTurnEnd).toBe(true);
+  });
+});

--- a/src/components/games/four-connected-fields/end-of-game.spec.ts
+++ b/src/components/games/four-connected-fields/end-of-game.spec.ts
@@ -1,0 +1,25 @@
+import { moves } from './four-connected-fields';
+import { hasAnyMove, type Board } from './helpers';
+import { makeCtx } from '../../../test-utils';
+
+// The player who places the last coin wins: the game ends once no field is
+// empty and no line joins two equal counts.
+const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
+
+describe('end of game', () => {
+  it.each([0, 1])('ends for the mover (player %i) when the last move is played', p => {
+    // 0=A and 1=B hold 2 each, so B is playable; filling it leaves [1,2,3,4],
+    // where every line joins different counts
+    const outcome = moves.placeCoin.apply([1, 2, 2, 4] as Board, asPlayer(p), 2);
+    expect(outcome.nextBoard).toEqual([1, 2, 3, 4]);
+    expect(hasAnyMove(outcome.nextBoard)).toBe(false);
+    expect(outcome.gameEnd).toEqual({ winnerIndex: p });
+    expect(outcome.isTurnEnd).toBeUndefined();
+  });
+
+  it('passes the turn while a move remains', () => {
+    const outcome = moves.placeCoin.apply([0, 0, 0, 0] as Board, asPlayer(0), 0);
+    expect(outcome.gameEnd).toBeUndefined();
+    expect(outcome.isTurnEnd).toBe(true);
+  });
+});

--- a/src/components/games/four-connected-fields/four-connected-fields.tsx
+++ b/src/components/games/four-connected-fields/four-connected-fields.tsx
@@ -5,7 +5,7 @@ import { BoardClient } from "./board-client";
 
 export type { Board };
 
-const moves = {
+export const moves = {
   placeCoin: {
     validate: (board: Board, _, node: number) => isNodePlayable(board, node),
     apply: (board: Board, { ctx }: { ctx: Ctx }, node: number): MoveOutcome<Board> => {

--- a/src/components/games/matches-on-edges/end-of-game.spec.ts
+++ b/src/components/games/matches-on-edges/end-of-game.spec.ts
@@ -1,0 +1,40 @@
+import { moves } from './matches-on-edges';
+import { emptyBoard, legalMoves, isTerminal, type Board } from './helpers';
+import { makeCtx } from '../../../test-utils';
+
+// The move size is forced (always the largest legal window), so a position runs
+// out of moves on its own; the mover who leaves none wins.
+const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
+
+// Play the first legal move over and over, collecting each outcome.
+const playToTheEnd = (start: Board) => {
+  const outcomes: ReturnType<typeof moves.placeWindow.apply>[] = [];
+  let board = start;
+  let player = 0;
+  while (!isTerminal(board)) {
+    const { a, b } = legalMoves(board)[0];
+    const outcome = moves.placeWindow.apply(board, asPlayer(player), a, b);
+    outcomes.push(outcome);
+    board = outcome.nextBoard;
+    player = 1 - player;
+  }
+  return outcomes;
+};
+
+describe('end of game', () => {
+  it.each([5, 6, 8, 9])('ends exactly on the last legal move (n = %i)', n => {
+    const outcomes = playToTheEnd(emptyBoard(n));
+    expect(outcomes.length).toBeGreaterThan(0);
+
+    const last = outcomes[outcomes.length - 1];
+    expect(isTerminal(last.nextBoard)).toBe(true);
+    // outcomes alternate players starting from 0, so the last mover is known
+    expect(last.gameEnd).toEqual({ winnerIndex: (outcomes.length - 1) % 2 });
+    expect(last.isTurnEnd).toBeUndefined();
+
+    for (const outcome of outcomes.slice(0, -1)) {
+      expect(outcome.gameEnd).toBeUndefined();
+      expect(outcome.isTurnEnd).toBe(true);
+    }
+  });
+});

--- a/src/components/games/matches-on-edges/matches-on-edges.tsx
+++ b/src/components/games/matches-on-edges/matches-on-edges.tsx
@@ -5,7 +5,7 @@ import {
 } from './helpers';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 
-const moves = {
+export const moves = {
   // Place the length-k subtable [a, b]: matches go on its free bounding edges.
   // If that leaves the other player with no legal move, they lose; otherwise the
   // turn passes.

--- a/src/components/games/remove-divisor-multiple/end-of-game.spec.ts
+++ b/src/components/games/remove-divisor-multiple/end-of-game.spec.ts
@@ -1,0 +1,32 @@
+import { range } from 'lodash';
+import { moves, isAllowed } from './remove-divisor-multiple';
+import { makeCtx } from '../../../test-utils';
+
+// Each number removed must divide or be divisible by the previous one, so the
+// game ends as soon as the previous move leaves no such number on the table.
+const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
+
+const board = (size: number, removed: number[], previousMove: number | null) => ({
+  numbersOnTable: range(1, size + 1).map(n => !removed.includes(n)),
+  previousMove
+});
+
+describe('end of game', () => {
+  it.each([0, 1])('ends for the mover (player %i) when nothing may follow', p => {
+    // only 4 and 5 are left and the previous move was 4; taking 5 leaves 4,
+    // which neither divides nor is divisible by 5
+    const before = board(5, [1, 2, 3], 4);
+    const outcome = moves.removeNumber.apply(before, asPlayer(p), 5);
+    expect(range(1, 6).some(n => isAllowed(outcome.nextBoard, n))).toBe(false);
+    expect(outcome.gameEnd).toEqual({ winnerIndex: p });
+    expect(outcome.isTurnEnd).toBeUndefined();
+  });
+
+  it('passes the turn while some number still divides or is divisible', () => {
+    const outcome = moves.removeNumber.apply(board(6, [], null), asPlayer(0), 3);
+    expect(outcome.nextBoard.previousMove).toBe(3);
+    expect(isAllowed(outcome.nextBoard, 6)).toBe(true);
+    expect(outcome.gameEnd).toBeUndefined();
+    expect(outcome.isTurnEnd).toBe(true);
+  });
+});

--- a/src/components/games/remove-divisor-multiple/remove-divisor-multiple.tsx
+++ b/src/components/games/remove-divisor-multiple/remove-divisor-multiple.tsx
@@ -61,7 +61,7 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
   )
 };
 
-const moves = {
+export const moves = {
   removeNumber: {
     validate: (board: Board, _, n) => isAllowed(board, n),
     apply: (board: Board, { ctx }: { ctx: Ctx }, n): MoveOutcome<Board> => {

--- a/src/components/games/six-fields-circle/end-of-game.spec.ts
+++ b/src/components/games/six-fields-circle/end-of-game.spec.ts
@@ -1,0 +1,23 @@
+import { moves } from './six-fields-circle';
+import { hasLegalMove } from './helpers';
+import { makeCtx } from '../../../test-utils';
+
+// A move needs two non-empty fields that are not opposite each other, so two
+// survivors facing each other across the circle is a dead position.
+const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
+
+describe('end of game', () => {
+  it.each([0, 1])('ends for the mover (player %i) when only opposite fields remain', p => {
+    const outcome = moves.removeFromTwo.apply([1, 1, 0, 2, 0, 0], asPlayer(p), [1, 3]);
+    expect(outcome.nextBoard).toEqual([1, 0, 0, 1, 0, 0]);
+    expect(hasLegalMove(outcome.nextBoard)).toBe(false);
+    expect(outcome.gameEnd).toEqual({ winnerIndex: p });
+    expect(outcome.isTurnEnd).toBeUndefined();
+  });
+
+  it('passes the turn while a legal pair remains', () => {
+    const outcome = moves.removeFromTwo.apply([2, 2, 1, 0, 0, 0], asPlayer(0), [0, 1]);
+    expect(outcome.gameEnd).toBeUndefined();
+    expect(outcome.isTurnEnd).toBe(true);
+  });
+});

--- a/src/components/games/six-fields-circle/six-fields-circle.tsx
+++ b/src/components/games/six-fields-circle/six-fields-circle.tsx
@@ -7,7 +7,7 @@ import { BoardClient } from "./board-client";
 
 export type { Board };
 
-const moves = {
+export const moves = {
   removeFromTwo: {
     validate: (board: Board, _, move: Move) => isRemovalAllowed(board, move),
     apply: (board: Board, { ctx }: { ctx: Ctx }, [i, j]: Move): MoveOutcome<Board> => {

--- a/src/components/games/stones-remove-one-not-twice-from-left/end-of-game.spec.ts
+++ b/src/components/games/stones-remove-one-not-twice-from-left/end-of-game.spec.ts
@@ -1,0 +1,39 @@
+import { moves } from './stones-remove-one-not-twice-from-left';
+import { makeCtx } from '../../../test-utils';
+
+// The game ends when both piles are empty, or when the right pile is empty and
+// the player about to move may not take from the left one (they took from it
+// last time).
+const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
+
+const board = (piles: [number, number], leftRestriction: [boolean, boolean] = [false, false]) =>
+  ({ piles, leftRestriction });
+
+describe('end of game', () => {
+  it.each([0, 1])('ends for the mover (player %i) on the last stone', p => {
+    const outcome = moves.removeStone.apply(board([0, 1]), asPlayer(p), 1);
+    expect(outcome.nextBoard.piles).toEqual([0, 0]);
+    expect(outcome.gameEnd).toEqual({ winnerIndex: p });
+    expect(outcome.isTurnEnd).toBeUndefined();
+  });
+
+  it('ends when the right pile empties and the opponent is barred from the left', () => {
+    // player 1 took from the left last time, so with the right pile gone they are stuck
+    const outcome = moves.removeStone.apply(board([1, 1], [false, true]), asPlayer(0), 1);
+    expect(outcome.nextBoard.piles).toEqual([1, 0]);
+    expect(outcome.gameEnd).toEqual({ winnerIndex: 0 });
+  });
+
+  it('passes the turn when the opponent may still take from the left', () => {
+    const outcome = moves.removeStone.apply(board([1, 1], [false, false]), asPlayer(0), 1);
+    expect(outcome.nextBoard.piles).toEqual([1, 0]);
+    expect(outcome.gameEnd).toBeUndefined();
+    expect(outcome.isTurnEnd).toBe(true);
+  });
+
+  it('records that the mover just took from the left pile', () => {
+    const outcome = moves.removeStone.apply(board([2, 2]), asPlayer(1), 0);
+    expect(outcome.nextBoard.leftRestriction).toEqual([false, true]);
+    expect(outcome.isTurnEnd).toBe(true);
+  });
+});

--- a/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
+++ b/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
@@ -69,7 +69,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   );
 };
 
-const moves = {
+export const moves = {
   removeStone: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, pileId) =>
       isRemovalAllowed(board, ctx.currentPlayer!, pileId),

--- a/src/components/games/two-of-three-takeaway/end-of-game.spec.ts
+++ b/src/components/games/two-of-three-takeaway/end-of-game.spec.ts
@@ -1,0 +1,29 @@
+import { moves } from './two-of-three-takeaway';
+import { isTerminal } from './helpers';
+import { makeCtx } from '../../../test-utils';
+
+// A move takes one chip from each of two distinct non-empty piles, so a
+// position with fewer than two non-empty piles is a loss for the player to move.
+const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
+
+describe('end of game', () => {
+  it.each([0, 1])('ends for the mover (player %i) when the opponent is left stuck', p => {
+    const outcome = moves.takeChips.apply([1, 1, 0], asPlayer(p), 0, 1);
+    expect(outcome.nextBoard).toEqual([0, 0, 0]);
+    expect(isTerminal(outcome.nextBoard)).toBe(true);
+    expect(outcome.gameEnd).toEqual({ winnerIndex: p });
+    expect(outcome.isTurnEnd).toBeUndefined();
+  });
+
+  it('also ends when a single non-empty pile is left — one pile cannot be played', () => {
+    const outcome = moves.takeChips.apply([2, 1, 0], asPlayer(0), 0, 1);
+    expect(outcome.nextBoard).toEqual([1, 0, 0]);
+    expect(outcome.gameEnd).toEqual({ winnerIndex: 0 });
+  });
+
+  it('passes the turn while two piles stay non-empty', () => {
+    const outcome = moves.takeChips.apply([2, 2, 0], asPlayer(0), 0, 1);
+    expect(outcome.gameEnd).toBeUndefined();
+    expect(outcome.isTurnEnd).toBe(true);
+  });
+});

--- a/src/components/games/two-of-three-takeaway/two-of-three-takeaway.tsx
+++ b/src/components/games/two-of-three-takeaway/two-of-three-takeaway.tsx
@@ -102,7 +102,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   );
 };
 
-const moves = {
+export const moves = {
   takeChips: {
     validate: (board: Board, _, i: number, j: number) => isTakeAllowed(board, i, j),
     apply: (


### PR DESCRIPTION
Follow-up to #374, which merged before I could amend these onto it. Same idea as the tests in #378: now that the moves are pure functions, the end-of-game condition is directly assertable — no rendered game, no event spies, just call the move and look at what it returned.

## What each spec covers

One `end-of-game.spec.ts` per game: the branch that returns `gameEnd` (parameterised over both player indices, since the winner is `ctx.currentPlayer`), plus a non-terminal control asserting the turn merely passes — so a future change that ends the game *too eagerly* fails as well.

Two endings were worth pinning specifically because they are easy to get wrong:

- **`two-of-three-takeaway`** ends as soon as a *single* non-empty pile remains, not only on an empty board — a move needs two distinct non-empty piles. There is now a test for `[2,1,0] → [1,0,0]` ending the game.
- **`stones-remove-one-not-twice-from-left`** has a second, asymmetric ending: the right pile empties while the opponent may not take from the left one, because they took from it last turn. That branch reads `1 - ctx.currentPlayer` and had no coverage at all.

## Where a hand-written terminal position would obscure things

`matches-on-edges` picks its window size by rule (always the largest legal one), so a terminal board is tedious to write down and unilluminating once written. Instead the test plays the first legal move to exhaustion and asserts the shape of the whole sequence: exactly the last outcome carries `gameEnd`, with the right winner for the alternating turn order, and every earlier one carries `isTurnEnd`. Run across four board sizes.

`chocolate-breaking` and `remove-divisor-multiple` take the middle road — a hand-picked position one move from the end, with the game's own predicate (`hasSafeBreak`, `isAllowed`) asserted on the result so the test says *why* that position is terminal rather than just that it is.

## Mechanical bit

Eight `moves` objects gained an `export` so the specs can reach them, matching how `ten-coins`, `number-pyramid` and others already do it. No other production change.

## Verification

`npm test` green: lint, typecheck, 1000 tests — 28 more than `main`, all new coverage.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cECth7yywjvuhpXHuTgkS)_