### PR TITLE
Drop the legacy move contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ strategyGameFactory({
   },
   BoardClient,                 // React component receiving { board, ctx, events, moves }
   gameplay: {
-    moves,                     // { [name]: { apply, validate? } | legacyFn | { legacyApply, validate? } } — see below
+    moves,                     // { [name]: { apply, validate? } } — see below
     endOfTurnMove?,            // optional move name auto-executed after moves with autoEndOfTurn: true
   },
   variants,                    // see below
@@ -94,34 +94,26 @@ omitted on a variant, the default variant's `botStrategy` is used as fallback.
 If multiple variants are provided, exactly one must be `isDefault: true`. A
 single-entry array needs no `isDefault` flag.
 
-**`moves`** — every move is an object pairing an optional `validate` with
-exactly one apply function. The two apply contracts are mixable within one game:
-
-- **`{ apply, validate? }` (preferred, use for new games)** — an
-  outcome-returning move `(board, { ctx }, ...args) => MoveOutcome`. It gets no
-  `events`; everything it causes is data in the returned `MoveOutcome`:
-  `{ nextBoard, isTurnEnd?, nextTurnState?, gameEnd?, autoEndOfTurn? }`.
-  `isTurnEnd: true` passes the turn (omitted = further moves follow in the same
-  turn); `gameEnd: { winnerIndex }` ends the game with an always-explicit winner
-  (`ctx.currentPlayer!` when the mover wins) and never flips `currentPlayer` —
-  `isTurnEnd`/`autoEndOfTurn` alongside it are a dev-mode error;
-  `nextTurnState` sets `ctx.turnState` (`null` clears, omitted keeps);
-  `autoEndOfTurn: true` schedules `endOfTurnMove`. Being `events`-free makes the
-  move a pure reducer — the piece a future authoritative competition server
-  and the planned external state store both need (see issue #313).
-- **`{ legacyApply, validate? }` (legacy)** — `legacyApply` has the signature
-  `(board, { ctx, events }, ...args) => { nextBoard }` and calls
-  `events.endTurn()` / `events.endGame(winnerIndex?)` imperatively
-  (bare `endGame()` credits the mover). Existing games migrate to the
-  outcome-returning `apply` one by one; don't add new legacy moves.
+**`moves`** — every move is `{ apply, validate? }`: an optional legality
+predicate paired with an outcome-returning
+`(board, { ctx }, ...args) => MoveOutcome`. A move gets no `events` —
+everything it causes is data in the returned `MoveOutcome`:
+`{ nextBoard, isTurnEnd?, nextTurnState?, gameEnd?, autoEndOfTurn? }`.
+`isTurnEnd: true` passes the turn (omitted = further moves follow in the same
+turn); `gameEnd: { winnerIndex }` ends the game with an always-explicit winner
+(`ctx.currentPlayer!` when the mover wins) and never flips `currentPlayer` —
+`isTurnEnd`/`autoEndOfTurn` alongside it are a dev-mode error;
+`nextTurnState` sets `ctx.turnState` (`null` clears, omitted keeps);
+`autoEndOfTurn: true` schedules `endOfTurnMove`. Being `events`-free makes a
+move a pure reducer, which is what lets the same function run in a future
+authoritative competition server (see issue #313).
 
 Always pass the current `board` as first arg when chaining moves within a turn.
-Neither form validates its arguments — they apply them blindly; legality is
+`apply` does not validate its arguments — it applies them blindly; legality is
 enforced by `validate` (below) and/or the `BoardClient`'s `disabled` gating.
 
 **`validate`** (optional, per move) — a pure, side-effect-free legality predicate
-`(board, { ctx }, ...args) => boolean` sitting right next to its
-`apply`/`legacyApply`. When
+`(board, { ctx }, ...args) => boolean` sitting right next to its `apply`. When
 present, the engine rejects any dispatch whose args fail it (in dev it throws
 loudly to surface the bug; in prod it warns, fires an `illegal-move` analytics
 event, and no-ops so a stray call cannot corrupt the board). Omitting it means
@@ -160,11 +152,9 @@ the raw `validate`/helpers instead.
   remembered during a turn if needed, i.e. to expose it from BoardClient to
   getPlayerStepDescription
 
-**`events`**: `endTurn()`, `endGame(winnerIndex?)`, `setTurnState(stage)`.
-`endTurn`/`endGame` are for legacy moves only (outcome-returning moves
-express both in their return value); `setTurnState` also remains current for
-`BoardClient` components that keep mid-turn UI state in `ctx.turnState`
-(several games call it from UI code — that usage does not migrate).
+**`events`**: `setTurnState(stage)`, and nothing else — it exists for
+`BoardClient` components that keep mid-turn UI state in `ctx.turnState`.
+Moves never receive it; they return `nextTurnState` instead.
 
 ### Game state architecture: synchronous store outside React
 
@@ -173,7 +163,7 @@ Authoritative game state (`board`, `phase`, `currentPlayer`, `turnState`,
 (`strategy-game-factory/engine/store.ts`); the factory component subscribes via
 `useSyncExternalStore` and renders snapshots of it. Every dispatch — from the
 `BoardClient`, a bot, or the auto `endOfTurnMove` — is validated and applied by
-a framework-free reducer (`engine/reducer.ts`, handling both move contracts)
+a framework-free reducer (`engine/reducer.ts`)
 against `store.getState()`, so bots and chained `setTimeout` dispatches can
 never observe a stale render snapshot. Validators may depend on **any** `ctx`
 field (`turnState`, `moveCount`, …); `ctx` is always derived fresh from the
@@ -206,7 +196,7 @@ in-repo.
 - Starting positions representative of the game's complexity; each player wins
   with ~50% probability across random starting boards
 - Player cannot win with a non-winning strategy (i.e. AI is truly optimal)
-- Moves use the outcome-returning `apply` form (no `events` in moves; see
+- Moves return their consequences rather than causing them (see
   `five-connected-fields`, `coins-in-3-piles`, `hunyadi-and-the-janissaries`)
 - Moves with non-trivial legality define `validate` (single source of truth for
   the engine, the `BoardClient`'s `disabled` state and the bot)

--- a/README.md
+++ b/README.md
@@ -208,9 +208,8 @@ meta object as second param and may receive any number of additional params
 (provided by the client based on player interaction or by the bot strategy).
 
 A move may result in ending the turn of the current player or ending the game or
-allow further moves within the same turn. In the preferred, outcome-returning
-form (`apply`) the move expresses all of this as data in its return value
-(a `MoveOutcome`):
+allow further moves within the same turn. The move expresses all of this as data
+in its return value (a `MoveOutcome`):
 
 - `nextBoard` (required): the board after the move
 - `isTurnEnd`: `true` passes the turn; omitted = further moves follow within
@@ -224,10 +223,7 @@ form (`apply`) the move expresses all of this as data in its return value
 
 `apply` receives `{ ctx }` and no `events` — it is a pure function, which
 is what lets the same move logic run on a possible future authoritative
-competition server. The legacy form (`legacyApply`) instead receives
-`{ ctx, events }` and calls `events.endTurn()` / `events.endGame(winnerIndex?)`
-imperatively; existing games are migrated one by one, new games should use
-`apply`.
+competition server.
 
 You must always pass `board` as a first param to all moves (meaning you must
 pass the updated board to subsequent moves in case of multiple moves within a
@@ -242,8 +238,7 @@ chaining bugs: passing a stale board to a chained move throws in development
 React](AGENTS.md#game-state-architecture-synchronous-store-outside-react).
 
 In `gameplay.moves`, each entry is an object pairing an optional `validate`
-with exactly one apply function: `{ apply, validate? }` (preferred) or
-`{ legacyApply, validate? }` (legacy):
+with the move's `apply`:
 
 ```ts
 moves: {
@@ -254,8 +249,8 @@ moves: {
 }
 ```
 
-Neither `apply` nor `legacyApply` validates its arguments — they apply them
-blindly; legality lives in `validate`, right next to them.
+`apply` does not validate its arguments — it applies them blindly; legality
+lives in `validate`, right next to it.
 
 ### validate (optional, per move)
 
@@ -328,14 +323,12 @@ framework.
   remembered during a turn, i.e. to expose it from BoardClient to
   getPlayerStepDescription
 
-`events` is an object that will contain the following (extendable):
-- `endTurn`: a function (legacy `legacyApply` moves only — outcome-returning moves
-  return `isTurnEnd: true` instead)
-- `endGame`: a function with optional winnerIndex specified, if not, last player
-  to move is the winner (legacy `legacyApply` moves only — outcome-returning moves
-  return `gameEnd: { winnerIndex }` with an explicit winner instead)
-- `setTurnState`: a function to set `turnState` — still current for
-  `BoardClient` components that keep mid-turn UI state in `ctx.turnState`
+`events` holds a single function, for `BoardClient` components that keep
+mid-turn UI state in `ctx.turnState`:
+- `setTurnState`: a function to set `turnState`
+
+Moves never receive `events`: they return `isTurnEnd`, `gameEnd` and
+`nextTurnState` instead.
 </details>
 
 ## Things to look out for

--- a/src/components/strategy-game-factory/engine/reducer.spec.ts
+++ b/src/components/strategy-game-factory/engine/reducer.spec.ts
@@ -1,6 +1,6 @@
 import { reduceMove } from './reducer';
 import { createInitialCoreState, type CoreState } from './store';
-import type { Events, EngineMove } from '../types';
+import type { MoveDefinition } from '../types';
 
 type Board = string[];
 
@@ -14,47 +14,13 @@ const playState = (overrides: Partial<CoreState<Board>> = {}): CoreState<Board> 
   ...overrides
 });
 
-const reduce = (state: CoreState<Board>, def: EngineMove<Board>, ...args: unknown[]) =>
+const reduce = (state: CoreState<Board>, def: MoveDefinition<Board>, ...args: unknown[]) =>
   reduceMove(state, def, 'testMove', args, NAMES);
 
-describe('reduceMove — legacy (events-based) contract equivalence', () => {
-  it('bare endGame() after endTurn() credits the mover, not the flipped player', () => {
-    // The one real trap of moving from async React setState to a synchronous
-    // reducer: ~40 legacy games call endTurn() first, then a bare endGame(),
-    // which must still resolve to the player at move start.
-    const def: EngineMove<Board> = {
-      legacyApply: (board, { events }: { events: Events }) => {
-        events.endTurn();
-        events.endGame();
-        return { nextBoard: board };
-      }
-    };
-    const transition = reduce(playState(), def);
-    expect(transition.state.winnerIndex).toBe(0);
-    expect(transition.gameJustEnded).toEqual({ winnerIndex: 0 });
-    expect(transition.state.phase).toBe('gameEnd');
-  });
-
-  it('endGame(winner) followed by endTurn() keeps the winner intact (thief-sheriff shape)', () => {
-    const def: EngineMove<Board> = {
-      legacyApply: (board, { events }: { events: Events }) => {
-        events.endGame(1);
-        events.endTurn();
-        return { nextBoard: board };
-      }
-    };
-    const transition = reduce(playState(), def);
-    expect(transition.state.winnerIndex).toBe(1);
-    expect(transition.state.phase).toBe('gameEnd');
-    expect(transition.state.currentPlayer).toBe(1); // trailing flip kept, inert
-  });
-
-  it('endTurn() flips the player and closes the turn', () => {
-    const def: EngineMove<Board> = {
-      legacyApply: (board, { events }: { events: Events }) => {
-        events.endTurn();
-        return { nextBoard: [...board, 'x'] };
-      }
+describe('reduceMove', () => {
+  it('isTurnEnd flips the player and closes the turn', () => {
+    const def: MoveDefinition<Board> = {
+      apply: (board) => ({ nextBoard: [...board, 'x'], isTurnEnd: true })
     };
     const transition = reduce(playState(), def);
     expect(transition.state.currentPlayer).toBe(1);
@@ -63,36 +29,22 @@ describe('reduceMove — legacy (events-based) contract equivalence', () => {
     expect(transition.state.moveCount).toBe(1);
   });
 
-  it('setTurnState writes turnState', () => {
-    const def: EngineMove<Board> = {
-      legacyApply: (board, { events }: { events: Events }) => {
-        events.setTurnState('stage2');
-        return { nextBoard: board };
-      }
-    };
-    expect(reduce(playState(), def).state.turnState).toBe('stage2');
+  it('a move that neither ends the turn nor the game leaves the turn open', () => {
+    const def: MoveDefinition<Board> = { apply: (board) => ({ nextBoard: [...board, 'x'] }) };
+    const transition = reduce(playState(), def);
+    expect(transition.state.currentPlayer).toBe(0);
+    expect(transition.state.currentTurnHasMoves).toBe(true);
   });
 
-  it('legacy autoEndOfTurn passes through', () => {
-    const def: EngineMove<Board> = {
-      legacyApply: (board) => ({ nextBoard: board, autoEndOfTurn: true })
+  it('autoEndOfTurn passes through to the shell', () => {
+    const def: MoveDefinition<Board> = {
+      apply: (board) => ({ nextBoard: board, autoEndOfTurn: true })
     };
     expect(reduce(playState(), def).autoEndOfTurn).toBe(true);
   });
-});
-
-describe('reduceMove — outcome-returning (apply) contract', () => {
-  it('isTurnEnd flips the player and closes the turn', () => {
-    const def: EngineMove<Board> = {
-      apply: (board) => ({ nextBoard: board, isTurnEnd: true })
-    };
-    const transition = reduce(playState(), def);
-    expect(transition.state.currentPlayer).toBe(1);
-    expect(transition.state.currentTurnHasMoves).toBe(false);
-  });
 
   it('gameEnd sets phase and winner without flipping the player', () => {
-    const def: EngineMove<Board> = {
+    const def: MoveDefinition<Board> = {
       apply: (board) => ({ nextBoard: board, gameEnd: { winnerIndex: 1 } })
     };
     const transition = reduce(playState(), def);
@@ -103,9 +55,9 @@ describe('reduceMove — outcome-returning (apply) contract', () => {
   });
 
   it('nextTurnState sets, undefined keeps, null clears turnState', () => {
-    const set: EngineMove<Board> = { apply: (b) => ({ nextBoard: b, nextTurnState: 's' }) };
-    const keep: EngineMove<Board> = { apply: (b) => ({ nextBoard: b }) };
-    const clear: EngineMove<Board> = { apply: (b) => ({ nextBoard: b, nextTurnState: null }) };
+    const set: MoveDefinition<Board> = { apply: (b) => ({ nextBoard: b, nextTurnState: 's' }) };
+    const keep: MoveDefinition<Board> = { apply: (b) => ({ nextBoard: b }) };
+    const clear: MoveDefinition<Board> = { apply: (b) => ({ nextBoard: b, nextTurnState: null }) };
     const afterSet = reduce(playState(), set).state;
     expect(afterSet.turnState).toBe('s');
     const afterKeep = reduce(afterSet, keep).state;
@@ -114,18 +66,18 @@ describe('reduceMove — outcome-returning (apply) contract', () => {
   });
 
   it('throws in dev when gameEnd is combined with isTurnEnd or autoEndOfTurn', () => {
-    const def: EngineMove<Board> = {
+    const def: MoveDefinition<Board> = {
       apply: (board) => ({ nextBoard: board, isTurnEnd: true, gameEnd: { winnerIndex: 0 } })
     };
     expect(() => reduce(playState(), def)).toThrow(/gameEnd together with/);
   });
 
-  it('suppresses autoEndOfTurn when a v2 move ends the game (prod path)', () => {
+  it('suppresses autoEndOfTurn when a move ends the game (prod path)', () => {
     // in dev the combination throws (see above); in prod the game end wins and
     // no endOfTurnMove may be scheduled afterwards
     vi.stubEnv('DEV', false);
     try {
-      const def: EngineMove<Board> = {
+      const def: MoveDefinition<Board> = {
         apply: (board) => ({ nextBoard: board, autoEndOfTurn: true, gameEnd: { winnerIndex: 0 } })
       };
       const transition = reduce(playState(), def);
@@ -139,7 +91,7 @@ describe('reduceMove — outcome-returning (apply) contract', () => {
 
 describe('reduceMove — shared mechanics', () => {
   it('a failing validator returns the state unchanged (same reference) and flags illegal', () => {
-    const def: EngineMove<Board> = {
+    const def: MoveDefinition<Board> = {
       validate: () => false,
       apply: (board) => ({ nextBoard: [...board, 'x'] })
     };
@@ -151,7 +103,7 @@ describe('reduceMove — shared mechanics', () => {
   });
 
   it('takes the undo snapshot on the first move of a turn only', () => {
-    const midMove: EngineMove<Board> = {
+    const midMove: MoveDefinition<Board> = {
       apply: (board) => ({ nextBoard: [...board, 'x'] })
     };
     const first = reduce(playState(), midMove);
@@ -164,7 +116,7 @@ describe('reduceMove — shared mechanics', () => {
   });
 
   it('the validator sees current turnState and moveCount through ctx', () => {
-    const def: EngineMove<Board> = {
+    const def: MoveDefinition<Board> = {
       validate: (_board, { ctx }) => ctx.turnState === 'armed' && ctx.moveCount === 3,
       apply: (board) => ({ nextBoard: board, isTurnEnd: true })
     };

--- a/src/components/strategy-game-factory/engine/reducer.ts
+++ b/src/components/strategy-game-factory/engine/reducer.ts
@@ -1,5 +1,5 @@
 import { cloneDeep } from 'lodash';
-import type { MoveOutcome, EngineMove } from '../types';
+import type { MoveOutcome, MoveDefinition } from '../types';
 import { buildCtx } from './build-ctx';
 import type { CoreState } from './store';
 
@@ -10,17 +10,17 @@ export type MoveTransition<TBoard> = {
   // the shell should schedule gameplay.endOfTurnMove
   autoEndOfTurn?: boolean
   // the shell should run its game-end side effects (dialog, stats, analytics)
-  gameJustEnded?: { winnerIndex: number | null }
+  gameJustEnded?: { winnerIndex: number }
   // what the dispatcher (bot / BoardClient) receives back
   result: MoveOutcome<TBoard>
 }
 
-// Framework-free move interpreter: validate + apply (either contract) + fold
-// the consequences into the next CoreState. Pure — the React shell decides
-// what to do with the returned transition (store write, dialog, timers).
+// Framework-free move interpreter: validate + apply + fold the consequences
+// into the next CoreState. Pure — the React shell decides what to do with the
+// returned transition (store write, dialog, timers).
 export const reduceMove = <TBoard>(
   state: CoreState<TBoard>,
-  def: EngineMove<TBoard>,
+  def: MoveDefinition<TBoard>,
   name: string,
   args: unknown[],
   resolvedPlayerNames: [string, string]
@@ -38,47 +38,22 @@ export const reduceMove = <TBoard>(
     };
     next.currentTurnHasMoves = true;
   }
-  let gameJustEnded: { winnerIndex: number | null } | undefined;
-  const endTurn = () => {
+  let gameJustEnded: { winnerIndex: number } | undefined;
+  const result: MoveOutcome<TBoard> = def.apply(state.board, { ctx }, ...args);
+  if (result.nextTurnState !== undefined) {
+    next.turnState = result.nextTurnState;
+  }
+  if (result.gameEnd) {
+    if (import.meta.env.DEV && (result.isTurnEnd || result.autoEndOfTurn)) {
+      throw new Error(`strategyGameFactory: move ${name} returned gameEnd `
+        + 'together with isTurnEnd/autoEndOfTurn');
+    }
+    next.phase = 'gameEnd';
+    next.winnerIndex = result.gameEnd.winnerIndex;
+    gameJustEnded = { winnerIndex: result.gameEnd.winnerIndex };
+  } else if (result.isTurnEnd) {
     next.currentTurnHasMoves = false;
     next.currentPlayer = 1 - next.currentPlayer!;
-  };
-  const endGame = (winnerIndex?: number | null) => {
-    // A bare legacy endGame() credits the mover — the player at MOVE START
-    // (state.currentPlayer, not next.currentPlayer: a preceding endTurn() in
-    // the same move has already flipped `next`, while today's React setState
-    // being asynchronous meant endGame always read the unflipped value).
-    const resolvedWinner = winnerIndex ?? state.currentPlayer;
-    next.phase = 'gameEnd';
-    next.winnerIndex = resolvedWinner;
-    gameJustEnded = { winnerIndex: resolvedWinner };
-  };
-  let result: MoveOutcome<TBoard>;
-  if (def.apply) {
-    result = def.apply(state.board, { ctx }, ...args);
-    if (result.nextTurnState !== undefined) {
-      next.turnState = result.nextTurnState;
-    }
-    if (result.gameEnd) {
-      if (import.meta.env.DEV && (result.isTurnEnd || result.autoEndOfTurn)) {
-        throw new Error(`strategyGameFactory: move ${name} returned gameEnd `
-          + 'together with isTurnEnd/autoEndOfTurn');
-      }
-      endGame(result.gameEnd.winnerIndex);
-    } else if (result.isTurnEnd) {
-      endTurn();
-    }
-  } else {
-    // Legacy contract: the move causes transitions by calling events, which
-    // here write into `next`. Note endGame(w) followed by endTurn() (a shape a
-    // few legacy games have) still flips currentPlayer after gameEnd — inert,
-    // and exactly what happened with React state.
-    const events = {
-      endTurn,
-      endGame,
-      setTurnState: (turnState: unknown) => { next.turnState = turnState; }
-    };
-    result = def.legacyApply!(state.board, { ctx, events }, ...args);
   }
   next.board = result.nextBoard;
   next.moveCount = state.moveCount + 1;
@@ -86,8 +61,7 @@ export const reduceMove = <TBoard>(
     state: next,
     result,
     gameJustEnded,
-    // v2 gameEnd suppresses endOfTurnMove scheduling (nothing runs after the
-    // game ends); legacy moves keep their exact pre-store behavior.
-    autoEndOfTurn: !!result.autoEndOfTurn && !(def.apply && result.gameEnd)
+    // Nothing runs after the game ends, so gameEnd suppresses the scheduling.
+    autoEndOfTurn: !!result.autoEndOfTurn && !result.gameEnd
   };
 };

--- a/src/components/strategy-game-factory/index.ts
+++ b/src/components/strategy-game-factory/index.ts
@@ -1,8 +1,8 @@
-export { strategyGameFactory, dummyEvents } from './strategy-game-factory';
+export { strategyGameFactory } from './strategy-game-factory';
 export type { Presentation, StrategyGameConfig } from './strategy-game-factory';
 export type {
   Phase, Mode, Ctx, Events,
-  MoveResult, MoveOutcome, MoveFunction, PureMoveFunction, MoveDefinition, Gameplay, GameMoves,
+  MoveOutcome, PureMoveFunction, MoveDefinition, Gameplay, GameMoves,
   StrategyArgs, BoardClientProps,
   Variant, VariantInput
 } from './types';

--- a/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
@@ -2,9 +2,7 @@
 import { render, fireEvent, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { strategyGameFactory, type StrategyGameConfig } from './strategy-game-factory';
-import type {
-  BoardClientProps, Ctx, Events, Gameplay, MoveDefinition, StrategyArgs
-} from './types';
+import type { BoardClientProps, Ctx, Gameplay, StrategyArgs } from './types';
 
 type Board = string[];
 
@@ -29,10 +27,7 @@ const CtxAwareBoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => 
 const defaultGameplay: Gameplay<Board> = {
   moves: {
     mainMove: {
-      legacyApply: (board: Board, { events }: { events: Events }) => {
-        events.endTurn();
-        return { nextBoard: board };
-      }
+      apply: (board: Board) => ({ nextBoard: board, isTurnEnd: true })
     }
   }
 };
@@ -134,12 +129,9 @@ describe('strategyGameFactory endOfTurnMove', () => {
     const autoMove = vi.fn((board: Board) => ({ nextBoard: board }));
     const moves: Gameplay<Board>['moves'] = {
       mainMove: {
-        legacyApply: (board, { events }: { events: Events }) => {
-          events.endTurn();
-          return { nextBoard: board, autoEndOfTurn: true };
-        }
+        apply: (board: Board) => ({ nextBoard: board, isTurnEnd: true, autoEndOfTurn: true })
       },
-      autoMove: { legacyApply: autoMove }
+      autoMove: { apply: autoMove }
     };
 
     const { getByTestId } = renderGame(minimalConfig({ moves, endOfTurnMove: 'autoMove' }));
@@ -157,12 +149,9 @@ describe('strategyGameFactory endOfTurnMove', () => {
     const autoMove = vi.fn((board: Board) => ({ nextBoard: board }));
     const moves: Gameplay<Board>['moves'] = {
       mainMove: {
-        legacyApply: (board, { events }: { events: Events }) => {
-          events.endTurn();
-          return { nextBoard: board };
-        }
+        apply: (board: Board) => ({ nextBoard: board, isTurnEnd: true })
       },
-      autoMove: { legacyApply: autoMove }
+      autoMove: { apply: autoMove }
     };
 
     const { getByTestId } = renderGame(minimalConfig({ moves, endOfTurnMove: 'autoMove' }));
@@ -202,10 +191,7 @@ describe('undo', () => {
       const gameplay: Gameplay<Board> = {
         moves: {
           mainMove: {
-            legacyApply: (board: Board, { events }: { events: Events }) => {
-              events.endTurn();
-              return { nextBoard: [...board, 'moved'] };
-            }
+            apply: (board: Board) => ({ nextBoard: [...board, 'moved'], isTurnEnd: true })
           }
         }
       };
@@ -245,16 +231,10 @@ describe('undo', () => {
       const gameplay: Gameplay<Board> = {
         moves: {
           mainMove: {
-            legacyApply: (board: Board, { events }: { events: Events }) => {
-              events.setTurnState('step2');
-              return { nextBoard: board };
-            }
+            apply: (board: Board) => ({ nextBoard: board, nextTurnState: 'step2' })
           },
           secondMove: {
-            legacyApply: (board: Board, { events }: { events: Events }) => {
-              events.endTurn();
-              return { nextBoard: board };
-            }
+            apply: (board: Board) => ({ nextBoard: board, isTurnEnd: true })
           }
         }
       };
@@ -307,10 +287,7 @@ describe('undo', () => {
       const gameplay: Gameplay<Board> = {
         moves: {
           mainMove: {
-            legacyApply: (board: Board, { events }: { events: Events }) => {
-              events.setTurnState('step2');
-              return { nextBoard: board };
-            }
+            apply: (board: Board) => ({ nextBoard: board, nextTurnState: 'step2' })
           }
         }
       };
@@ -377,15 +354,13 @@ const gameEndingConfig = () => makeConfig({
   gameplay: {
     moves: {
       endWin: {
-        legacyApply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }) => {
-          events.endGame(ctx.currentPlayer);
-          return { nextBoard: board };
+        apply: (board: Board, { ctx }: { ctx: Ctx }) => {
+          return { nextBoard: board, gameEnd: { winnerIndex: ctx.currentPlayer! } };
         }
       },
       endLose: {
-        legacyApply: (board: Board, { ctx, events }: { ctx: Ctx; events: Events }) => {
-          events.endGame(ctx.currentPlayer === 0 ? 1 : 0);
-          return { nextBoard: board };
+        apply: (board: Board, { ctx }: { ctx: Ctx }) => {
+          return { nextBoard: board, gameEnd: { winnerIndex: ctx.currentPlayer === 0 ? 1 : 0 } };
         }
       }
     }
@@ -540,14 +515,11 @@ describe('move validate enforcement', () => {
     gameplay: {
       moves: {
         guarded: {
-          legacyApply: (board: Board, _meta: { events: Events }, arg: string) => ({ nextBoard: [...board, arg] }),
+          apply: (board: Board, _meta, arg: string) => ({ nextBoard: [...board, arg] }),
           validate: (_board: Board, _meta: { ctx: Ctx }, arg: string) => arg === 'ok'
         },
         handOver: {
-          legacyApply: (board: Board, { events }: { events: Events }) => {
-            events.endTurn();
-            return { nextBoard: board };
-          }
+          apply: (board: Board) => ({ nextBoard: board, isTurnEnd: true })
         }
       }
     },
@@ -607,7 +579,7 @@ describe('move validate enforcement', () => {
   });
 
   it('dispatches a move with no validator unconditionally', () => {
-    // defaultGameplay's mainMove is legacyApply-only, so every dispatch applies
+    // defaultGameplay's mainMove defines no validator, so every dispatch applies
     const { getByTestId } = renderGame(ctxAwareConfig());
     fireEvent.click(getByTestId('role-btn-0'));
     fireEvent.click(getByTestId('move-btn'));
@@ -616,10 +588,11 @@ describe('move validate enforcement', () => {
 
   // Mirrors the coins-in-3-piles bots: a two-phase turn chained via setTimeout
   // on the move wrappers captured when the bot's turn started. The phase-2
-  // validator reads ctx.turnState, which phase 1 just set — the engine must
-  // judge it against the current game state, not the render the wrappers came
-  // from. The 0-delay variant (smartBotStrategy's "place back nothing" branch)
-  // is the harshest case: phase 2 dispatches before React re-renders at all.
+  // validator reads ctx.turnState, which phase 1's returned nextTurnState just
+  // set — that has to reach the authoritative store synchronously, or the
+  // engine would judge phase 2 against the render the wrappers came from. The
+  // 0-delay variant (smartBotStrategy's "place back nothing" branch) is the
+  // harshest case: phase 2 dispatches before React re-renders at all.
   const twoPhaseBotConfig = (chainDelayMs: number) => makeConfig({
     BoardClient: ({ board }: BoardClientProps<Board>) => (
       <span data-testid="board">{board.join(',')}</span>
@@ -628,18 +601,15 @@ describe('move validate enforcement', () => {
       moves: {
         phase1: {
           validate: (_board: Board, { ctx }: { ctx: Ctx }) => ctx.turnState === null,
-          legacyApply: (board: Board, { events }: { events: Events }) => {
-            events.setTurnState({ removedCoinValue: 3 });
-            return { nextBoard: [...board, 'p1'] };
-          }
+          apply: (board: Board) => ({
+            nextBoard: [...board, 'p1'], nextTurnState: { removedCoinValue: 3 }
+          })
         },
         phase2: {
           validate: (_board: Board, { ctx }: { ctx: Ctx }) => ctx.turnState !== null,
-          legacyApply: (board: Board, { events }: { events: Events }) => {
-            events.endTurn();
-            events.setTurnState(null);
-            return { nextBoard: [...board, 'p2'] };
-          }
+          apply: (board: Board) => ({
+            nextBoard: [...board, 'p2'], isTurnEnd: true, nextTurnState: null
+          })
         }
       }
     },
@@ -663,7 +633,7 @@ describe('move validate enforcement', () => {
     }
   };
 
-  it('validates a bot-chained second move against current turnState, not a stale render', () => {
+  it('validates a bot-chained second move against the returned nextTurnState', () => {
     expect(playTwoPhaseBotTurn(750)).toBe('initial,p1,p2');
   });
 
@@ -767,8 +737,8 @@ describe('outcome-returning moves (apply)', () => {
     fireEvent.click(getByTestId('role-btn-0'));
     fireEvent.click(getByTestId('win-btn'));
     expect(getByTestId('phase').textContent).toBe('gameEnd');
-    // The v2 contract never flips the player at game end (legacy games often
-    // called endTurn before endGame; nothing user-visible read the flip).
+    // gameEnd never flips the player: the move names the winner outright, so
+    // nothing has to be inferred from whose turn it would have been.
     expect(getByTestId('player').textContent).toBe('0');
     expect(JSON.parse(localStorage.getItem('stats__0')!)).toEqual({ win: 1, loss: 0 });
     expect(track).toHaveBeenCalledWith('game-finished', expect.objectContaining({ result: 'win' }));
@@ -781,19 +751,6 @@ describe('outcome-returning moves (apply)', () => {
     fireEvent.click(getByTestId('role-btn-0'));
     fireEvent.click(getByTestId('lose-btn'));
     expect(JSON.parse(localStorage.getItem('stats__0')!)).toEqual({ win: 0, loss: 1 });
-  });
-
-  it('throws at factory time when a move defines both legacyApply and apply, or neither', () => {
-    // deliberately malformed configs, cast past the compile-time guard
-    const asMove = (def: object) => def as MoveDefinition<Board>;
-    const both = asMove({
-      legacyApply: (board: Board) => ({ nextBoard: board }),
-      apply: (board: Board) => ({ nextBoard: board })
-    });
-    expect(() => strategyGameFactory(minimalConfig({ moves: { broken: both } })))
-      .toThrow(/exactly one of apply\/legacyApply/);
-    expect(() => strategyGameFactory(minimalConfig({ moves: { broken: asMove({}) } })))
-      .toThrow(/exactly one of apply\/legacyApply/);
   });
 
   it('throws in dev when a move returns gameEnd together with isTurnEnd', () => {
@@ -825,64 +782,6 @@ describe('outcome-returning moves (apply)', () => {
       vi.clearAllTimers();
       vi.useRealTimers();
     }
-  });
-
-  it('legacy and outcome-returning moves coexist within one game', () => {
-    const gameplay: Gameplay<Board> = {
-      moves: {
-        legacyMove: {
-          legacyApply: (board: Board, { events }: { events: Events }) => {
-            events.endTurn();
-            return { nextBoard: [...board, 'legacy'] };
-          }
-        },
-        v2Move: { apply: (board: Board) => ({ nextBoard: [...board, 'v2'], isTurnEnd: true }) }
-      }
-    };
-    const BoardClient = ({ board, moves }: BoardClientProps<Board>) => (
-      <>
-        <button data-testid="legacy-btn" onClick={() => moves.legacyMove(board)}>legacy</button>
-        <button data-testid="v2-btn" onClick={() => moves.v2Move(board)}>v2</button>
-        <span data-testid="board">{board.join(',')}</span>
-      </>
-    );
-    const { getByTestId } = renderGame(makeConfig({ BoardClient, gameplay }));
-    fireEvent.click(getByTestId('mode-vsHuman'));
-    fireEvent.click(getByTestId('start-hh-game-0'));
-    fireEvent.click(getByTestId('v2-btn')); // player 0, v2 contract
-    fireEvent.click(getByTestId('legacy-btn')); // player 1, legacy contract
-    expect(getByTestId('board').textContent).toBe('initial,v2,legacy');
-  });
-
-  it('extra outcome-shaped fields returned by a legacy move stay inert', () => {
-    // A legacy (events-based) game may return stray extra fields (hunyadi's
-    // old isGameEnd did) — the engine must not interpret them as v2 outcomes.
-    const gameplay: Gameplay<Board> = {
-      moves: {
-        mainMove: {
-          legacyApply: (board: Board) => {
-            // a non-fresh object dodges the excess-property check, like real
-            // legacy code returning ad-hoc extra fields did
-            const strayOutcome = {
-              nextBoard: [...board, 'x'], isTurnEnd: true, gameEnd: { winnerIndex: 0 }
-            };
-            return strayOutcome;
-          }
-        }
-      }
-    };
-    const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => (
-      <>
-        <button data-testid="move-btn" onClick={() => moves.mainMove(board)}>move</button>
-        <span data-testid="player">{String(ctx.currentPlayer)}</span>
-        <span data-testid="phase">{ctx.phase}</span>
-      </>
-    );
-    const { getByTestId } = renderGame(makeConfig({ BoardClient, gameplay }));
-    fireEvent.click(getByTestId('role-btn-0'));
-    fireEvent.click(getByTestId('move-btn'));
-    expect(getByTestId('phase').textContent).toBe('play'); // gameEnd field ignored
-    expect(getByTestId('player').textContent).toBe('0'); // isTurnEnd field ignored
   });
 
   it('autoEndOfTurn schedules an outcome-returning endOfTurnMove after 750ms', () => {
@@ -950,55 +849,6 @@ describe('outcome-returning moves (apply)', () => {
       expect(getByTestId('board').textContent).toBe('initial');
       expect(getByTestId('ts').textContent).toBe('null');
     });
-  });
-
-  // The v2 twin of the legacy two-phase regression tests: the returned
-  // nextTurnState must land in the authoritative store synchronously, or a
-  // bot's 0-delay chained dispatch would be validated against a stale turnState.
-  const twoPhaseV2BotConfig = (chainDelayMs: number) => makeConfig({
-    BoardClient: ({ board }: BoardClientProps<Board>) => (
-      <span data-testid="board">{board.join(',')}</span>
-    ),
-    gameplay: {
-      moves: {
-        phase1: {
-          validate: (_board: Board, { ctx }: { ctx: Ctx }) => ctx.turnState === null,
-          apply: (board: Board) =>
-            ({ nextBoard: [...board, 'p1'], nextTurnState: { removedCoinValue: 3 } })
-        },
-        phase2: {
-          validate: (_board: Board, { ctx }: { ctx: Ctx }) => ctx.turnState !== null,
-          apply: (board: Board) =>
-            ({ nextBoard: [...board, 'p2'], isTurnEnd: true, nextTurnState: null })
-        }
-      }
-    },
-    botStrategy: ({ board, moves }) => {
-      const { nextBoard } = moves.phase1(board);
-      setTimeout(() => { moves.phase2(nextBoard); }, chainDelayMs);
-    }
-  });
-
-  const playTwoPhaseV2BotTurn = (chainDelayMs: number) => {
-    vi.useFakeTimers();
-    try {
-      const { getByTestId } = renderGame(twoPhaseV2BotConfig(chainDelayMs));
-      fireEvent.click(getByTestId('role-btn-1')); // human is 2nd player → bot moves first
-      act(() => { vi.advanceTimersByTime(1500); }); // bot "thinking" delay → phase1
-      act(() => { vi.advanceTimersByTime(750); }); // the chained phase2 — must not be rejected
-      return getByTestId('board').textContent;
-    } finally {
-      vi.clearAllTimers();
-      vi.useRealTimers();
-    }
-  };
-
-  it('validates a bot-chained second move against the returned nextTurnState', () => {
-    expect(playTwoPhaseV2BotTurn(750)).toBe('initial,p1,p2');
-  });
-
-  it('validates a 0-delay chained second move dispatched before React re-renders', () => {
-    expect(playTwoPhaseV2BotTurn(0)).toBe('initial,p1,p2');
   });
 
   // These two tests pin what the external store fixed: validators and chained

--- a/src/components/strategy-game-factory/strategy-game-factory.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.tsx
@@ -10,7 +10,7 @@ import { useLocation } from 'react-router';
 import { useGameStats } from './hooks/use-game-stats';
 import { trackEvent } from '../../tracking';
 import type {
-  Mode, Ctx, Events, MoveOutcome, EngineMove, Gameplay, GameMoves,
+  Mode, Ctx, Events, MoveOutcome, Gameplay, GameMoves,
   BoardClientProps, Variant as DisplayVariant, VariantInput
 } from './types';
 import { resolveVariants } from './helpers/resolve-variants';
@@ -45,16 +45,6 @@ export const strategyGameFactory = <TBoard,>({
   const { rule, roleLabels, getPlayerStepDescription } = presentation;
   const { moves, endOfTurnMove } = gameplay;
   const { defaultVariantIndex, defaultVariant, resolvedVariants } = resolveVariants(variants);
-  const moveDefinitions: Record<string, EngineMove<TBoard>> = moves;
-  Object.entries(moveDefinitions).forEach(([name, def]) => {
-    if (!!def.legacyApply === !!def.apply) {
-      const message = `strategyGameFactory: move ${name} must define exactly one of apply/legacyApply`;
-      if (import.meta.env.DEV) {
-        throw new Error(message);
-      }
-      console.warn(message);
-    }
-  });
 
   return () => {
     const { t } = useTranslation();
@@ -119,7 +109,7 @@ export const strategyGameFactory = <TBoard,>({
 
     // Game-end side effects (the state transition itself already happened in
     // the reducer / store): dialog, win/loss stats, analytics.
-    const handleGameEnd = (resolvedWinner: number | null) => {
+    const handleGameEnd = (resolvedWinner: number) => {
       const s = store.getState();
       setIsGameEndDialogOpen(true);
       if (s.mode !== 'vsHuman') {
@@ -143,7 +133,7 @@ export const strategyGameFactory = <TBoard,>({
           + 'pass the latest nextBoard when chaining moves within a turn');
       }
       const transition = reduceMove(
-        store.getState(), moveDefinitions[name]!, name, args, resolvedPlayerNames
+        store.getState(), moves[name]!, name, args, resolvedPlayerNames
       );
       if (transition.illegal) {
         reportIllegalMove(name, moveBoard, args);
@@ -213,27 +203,15 @@ export const strategyGameFactory = <TBoard,>({
 
     const ctx: Ctx = buildCtx(state, resolvedPlayerNames);
 
-    // For the BoardClient (setTurnState is current usage; endTurn/endGame only
-    // remain for legacy compatibility). Moves never see this object: legacy
-    // `apply` moves get the reducer's events, outcome-returning moves get none.
+    // For the BoardClient's mid-turn UI state. Moves never see this object;
+    // they return `nextTurnState` instead.
     const events: Events = {
-      endTurn: () => {
-        store.setState({
-          currentTurnHasMoves: false,
-          currentPlayer: 1 - store.getState().currentPlayer!
-        });
-      },
-      endGame: (winnerIndex?: number | null) => {
-        const resolvedWinner = winnerIndex ?? store.getState().currentPlayer;
-        store.setState({ phase: 'gameEnd', winnerIndex: resolvedWinner });
-        handleGameEnd(resolvedWinner);
-      },
       setTurnState: (turnState) => {
         store.setState({ turnState });
       }
     };
 
-    wrappedGameMoves = mapValues(moveDefinitions, (_def, name) => {
+    wrappedGameMoves = mapValues(moves, (_def, name) => {
       const wrapped: GameMoves<TBoard>[string] = (moveBoard: TBoard, ...args: unknown[]) =>
         dispatchMove(name, moveBoard, args);
       return wrapped;
@@ -247,7 +225,7 @@ export const strategyGameFactory = <TBoard,>({
     // Bots and the auto `endOfTurnMove` dispatch use `wrappedGameMoves` instead:
     // there an illegal move is a bug, and the validator fails loudly (see
     // `reportIllegalMove`).
-    const clientGameMoves: GameMoves<TBoard> = mapValues(moveDefinitions, ({ validate }, name) => {
+    const clientGameMoves: GameMoves<TBoard> = mapValues(moves, ({ validate }, name) => {
       const isAllowed = (moveBoard: TBoard, ...args: unknown[]) => {
         const liveCtx = buildCtx(store.getState(), resolvedPlayerNames);
         return liveCtx.isClientMoveAllowed
@@ -323,14 +301,4 @@ export const strategyGameFactory = <TBoard,>({
     </main>
     );
   };
-};
-
-// No-op `events` for production code paths that call a move purely to compute
-// `nextBoard` (e.g. bot lookahead) and don't care about side effects. For tests
-// that need to assert handlers were called, use `makeEvents` from `test-utils`
-// (spies) instead — it can't be used here as it depends on vitest.
-export const dummyEvents: Events = {
-  endTurn: () => {},
-  endGame: () => {},
-  setTurnState: () => {}
 };

--- a/src/components/strategy-game-factory/types.ts
+++ b/src/components/strategy-game-factory/types.ts
@@ -15,15 +15,15 @@ export interface Ctx {
   moveCount: number
 }
 
+// Mid-turn UI state a BoardClient needs to remember (which pile is selected,
+// which slot is being edited). Moves never see this: they express turn state
+// through `nextTurnState` in their returned MoveOutcome.
 export interface Events {
-  endTurn: () => void
-  endGame: (winnerIndex?: number | null) => void
   setTurnState: (state: unknown) => void
 }
 
-// Everything a move can cause, expressed as data. Returned by outcome-returning
-// (`apply`) moves and interpreted by the engine; legacy (`legacyApply`) moves
-// return only `nextBoard`/`autoEndOfTurn` and cause the rest through `events`.
+// Everything a move can cause, expressed as data: the engine interprets what
+// the move returns, so a move never reaches out and changes anything itself.
 export type MoveOutcome<TBoard> = {
   nextBoard: TBoard
   // Turn passes to the other player. Omitted/false = turn continues (mid-turn
@@ -38,40 +38,21 @@ export type MoveOutcome<TBoard> = {
   // present (contradiction; throws in dev).
   autoEndOfTurn?: boolean
 }
-export type MoveResult<TBoard> = Pick<MoveOutcome<TBoard>, 'nextBoard' | 'autoEndOfTurn'>
-export type MoveFunction<TBoard> = (
-  board: TBoard, meta: { ctx: Ctx; events: Events }, ...args: any[]
-) => MoveResult<TBoard>
-// Outcome-returning apply: no `events` param, so purity is enforced by the
-// type system — everything the move causes is in the returned MoveOutcome.
+// A move is a pure reducer: board in, outcome out. It gets no `events`, so
+// purity is enforced by the type system rather than by convention — which is
+// what lets the same function run in a future authoritative server.
 export type PureMoveFunction<TBoard> = (
   board: TBoard, meta: { ctx: Ctx }, ...args: any[]
 ) => MoveOutcome<TBoard>
 // Pure, side-effect-free legality predicate for a single move, colocated with
-// its `apply`/`legacyApply` in the long-form move definition. Because it depends only on
-// `board` + `ctx` (no React, no `events`), the same function drives the UI
-// (button `disabled`), the engine (illegal-move enforcement) and, in the
-// future, an authoritative server-side check.
+// its `apply`. Because it depends only on `board` + `ctx` (no React), the same
+// function drives the UI (button `disabled`), the engine (illegal-move
+// enforcement) and, in the future, an authoritative server-side check.
 type MoveValidator<TBoard> = (
   board: TBoard, meta: { ctx: Ctx }, ...args: any[]
 ) => boolean
-// Every move is an object pairing an optional legality validator with exactly
-// one apply function: either a legacy `legacyApply` or — the preferred contract
-// for new games — an outcome-returning `apply` that gets no `events` and
-// instead returns turn/game consequences as data. The distinct key is the
-// contract marker: the engine interprets the returned MoveOutcome only for
-// `apply` moves, and a migrated move that still touches `events` fails to
-// compile.
-export type MoveDefinition<TBoard> =
-  | { legacyApply: MoveFunction<TBoard>; validate?: MoveValidator<TBoard> }
-  | { apply: PureMoveFunction<TBoard>; validate?: MoveValidator<TBoard> }
-// Engine-internal move shape (not re-exported from the barrel): the union above
-// collapsed to one object with both apply keys optional, which is what the
-// reducer's truthiness branch reads. Exactly one of them is present — enforced
-// at factory time, since plain JS callers can bypass MoveDefinition.
-export type EngineMove<TBoard> = {
-  legacyApply?: MoveFunction<TBoard>
-  apply?: PureMoveFunction<TBoard>
+export type MoveDefinition<TBoard> = {
+  apply: PureMoveFunction<TBoard>
   validate?: MoveValidator<TBoard>
 }
 export interface Gameplay<TBoard> {

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,14 +1,4 @@
-import type { Ctx, Events } from './components/strategy-game-factory';
-
-// Mock `events` for testing move functions. Each handler is a spy, so tests can
-// assert e.g. `expect(events.endGame).toHaveBeenCalledWith(1)`. For production
-// code that needs no-op events (e.g. bot lookahead), use `dummyEvents` instead.
-export const makeEvents = (overrides: Partial<Events> = {}): Events => ({
-  endTurn: vi.fn(),
-  endGame: vi.fn(),
-  setTurnState: vi.fn(),
-  ...overrides
-});
+import type { Ctx } from './components/strategy-game-factory';
 
 // Mock `ctx` for testing move functions and bot strategies.
 export const makeCtx = (overrides: Partial<Ctx> = {}): Ctx => ({


### PR DESCRIPTION
Closes #313.
Closes #364 

The last games moved to `apply` in #375–#378, so nothing calls `events.endTurn()` / `events.endGame()` any more. This removes the path that supported them.

**Net: −432 / +130 lines**, and roughly half of that is the two engine specs shedding their duplicated legacy halves.

## What goes

- **`engine/reducer.ts`** — the `if (def.apply) … else …` branch collapses to a straight line. The local `endTurn`/`endGame` closures existed only so legacy moves could call them imperatively; their bodies now sit inline where the outcome is read. The subtle bit that needed a comment — *a bare `endGame()` credits the player at move start, not the one a preceding `endTurn()` already flipped to* — has no reason to exist once every `gameEnd` names its winner, so the comment goes with the code.
- **`types.ts`** — `MoveDefinition` stops being a union and becomes `{ apply, validate? }`. `EngineMove` (the union flattened for the reducer), `MoveFunction` and `MoveResult` are gone. `Events` shrinks from three functions to one.
- **`strategy-game-factory.tsx`** — the factory-time guard that a move defines *exactly one* of `apply`/`legacyApply` is deleted: with a single-arm type, TypeScript covers it. `dummyEvents` (no-op events for bot lookahead) is gone, as is the shell's `events.endTurn`/`endGame`; what's left is `setTurnState`, which several BoardClients genuinely use for mid-turn UI state.
- **`test-utils.ts`** — `makeEvents` had no callers left; the last spies-on-events specs became outcome assertions during the migration.

## One thing this enables

With the winner always explicit, `gameJustEnded` narrows from `{ winnerIndex: number | null }` to `{ winnerIndex: number }`, and `handleGameEnd` takes a plain `number`. The `null` only ever existed to model "bare `endGame()`, work out the winner later".

## Tests

The two engine specs each had a legacy half and an `apply` half. Where the legacy test pinned behaviour that still exists, it merged into its `apply` twin rather than being dropped — `reduceMove`'s board/moveCount assertions moved into the `isTurnEnd` test, and a plain `autoEndOfTurn` passthrough test replaced the legacy one. Three tests are gone because what they tested is gone:

- the factory-time both/neither config guard;
- *"legacy and outcome-returning moves coexist within one game"*;
- *"extra outcome-shaped fields returned by a legacy move stay inert"* — that guarded against the engine reading stray fields (hunyadi's old ad-hoc `isGameEnd`) as outcomes; now every move's return value *is* an outcome.

The two-phase bot regression tests had become literal duplicates of each other once phase 1 was migrated, so the pair is now one.

`npm test` — lint, typecheck, 1195 tests — green.

## Docs

AGENTS.md and README lose the two-contract explanation; `moves` is now described once, in one form. The new-game checklist item is reworded from "use the outcome-returning `apply` form" to "moves return their consequences rather than causing them", since there is no longer an alternative to opt into.

---
_Generated by [Claude Code](https://claude.ai/code/session_015cECth7yywjvuhpXHuTgkS)_