### PR TITLE
Refactor BoardClient props: replace Events with setTurnState

### DIFF
--- a/.claude/commands/new-game.md
+++ b/.claude/commands/new-game.md
@@ -35,17 +35,18 @@ Note: written solutions typically only describe what to do from a winning positi
 
 ### 3. Pick a reference game to copy
 Choose the simplest existing game that resembles the new one structurally:
-- Number/token games with simple state: `src/components/games/plus-one-two-three/plus-one-two-three.js`
+- Number/token games with simple state: `src/components/games/single-number-increase/plus-one-two-three/plus-one-two-three.tsx`
 - Games with variants (multiple starting configs): look in `src/components/games/pile-splitting-games/`
 - Grid/board games: `src/components/games/chess-rook/` or `src/components/games/shark-chase/`
 
 Read the chosen reference file in full before writing anything.
 
 ### 4. Create the game file
-Create `src/components/games/<game-name>/<game-name>.js`. Follow the `strategyGameFactory` API from `AGENTS.md`. Key rules:
+Create `src/components/games/<game-name>/<game-name>.tsx`. Follow the `strategyGameFactory` API from `AGENTS.md`. Key rules:
 - If the user supplied the rule text, use it verbatim in `rule.hu` by default. Don't silently rephrase, correct, or abbreviate it. **Exception:** when the original wording doesn't fit the online implementation — e.g. it refers to the competition organizers/judges instead of the opponent/computer, or to physical artifacts (paper, pencil, cards on a table) that don't exist in the browser version — it's fine to reword it slightly to fit. In that case, explicitly highlight every change you made to the user (e.g. show before/after) so they can review it. For any other wording change, propose it and wait for approval before applying.
 - `board` holds only game-specific state; common state is in `ctx`
-- Every move returns `{ nextBoard }`; pass the current board when chaining moves within a turn
+- Every move is `{ apply, validate? }`. `apply` is a pure reducer returning a `MoveOutcome` (`{ nextBoard, isTurnEnd?, gameEnd?, nextTurnState?, autoEndOfTurn? }`) — it never reaches out and changes anything itself. Pass the current board when chaining moves within a turn
+- Give a move with non-trivial legality a `validate` predicate, and drive the `BoardClient`'s `disabled` state with `moves.<name>.isAllowed(board, ...args)` rather than a hand-rolled duplicate check
 - Guard all player interactions with `ctx.isClientMoveAllowed`
 - `getPlayerStepDescription` should make it obvious what the current player should do
 - For user-facing text referring to the other participant, prefer "other player" / "másik játékos" over "opponent" / "ellenfél" — the latter reads as too harsh, especially in Hungarian
@@ -56,10 +57,10 @@ Create `src/components/games/<game-name>/<game-name>.js`. Follow the `strategyGa
 Add one `export { YourGame } from './path/...'` line to the barrel, keyed by the
 game's `gameList` key (alias if the export name differs, e.g.
 `export { FooA as Foo } from '...'`), keeping alphabetical order. The route is the
-key, and the router in `src/components/app/app.js` derives it from `gameList`
+key, and the router in `src/components/app/app.tsx` derives it from `gameList`
 automatically — no edit is needed there.
 
-### 6. Add metadata to `src/components/games/gameList.js`
+### 6. Add metadata to `src/components/games/gameList.ts`
 Using the metadata collected in Step 1, add the entry in alphabetical order by key. Use `title` only if a longer display name is needed on the game page beyond the short name.
 
 ### 7. Run tests and verify
@@ -76,6 +77,8 @@ Before declaring the game done, verify each item:
 - [ ] Works correctly in both `vsComputer` and `vsHuman` mode
 - [ ] Starting positions are representative of the game's complexity; each player wins with ~50% probability across random starting boards
 - [ ] If optimal AI is implemented: player cannot win with a non-winning strategy
+- [ ] Moves return their consequences in the `MoveOutcome` rather than causing them
+- [ ] Moves with non-trivial legality define `validate`, and the `BoardClient` gates on `isAllowed`
 - [ ] `getPlayerStepDescription` makes the next move clear
 - [ ] Interactions disabled during the other player's turn (`ctx.isClientMoveAllowed`)
 - [ ] Mobile-friendly and keyboard-navigable
@@ -89,12 +92,12 @@ If the optimal AI strategy was implemented in step 2, ask the user:
 
 **If yes**, update the game file:
 
-1. Add a `randomBotStrategy` function — pick a random valid move, but if any move wins immediately (wins in 1 turn), pick one of those winning moves instead. Follow the pattern in `src/components/games/ten-digit-number/ten-digit-number.js`.
+1. Add a `randomBotStrategy` function — pick a random valid move, but if any move wins immediately (wins in 1 turn), pick one of those winning moves instead. Follow the pattern in `src/components/games/ten-digit-number/ten-digit-number.tsx`.
 
 2. Rename the existing optimal bot strategy to `smartBotStrategy` (or a similarly descriptive name).
 
 3. Restructure `variants` to put the test bot first and the smart bot second (marked `isDefault: true`):
-   ```javascript
+   ```typescript
    variants: [
      {
        botStrategy: randomBotStrategy,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,7 +141,11 @@ guards — keep one only when the handler couples local UI state to a successful
 move (see `cube-coloring`'s colour-selection reset). Not for bots: their
 `moves` copy carries no `isAllowed` (during the bot's turn
 `isClientMoveAllowed` is false by design), so bots enumerate legal moves via
-the raw `validate`/helpers instead.
+the raw `validate`/helpers instead. The two wrappings have two types:
+`ClientGameMoves` (what `BoardClientProps.moves` is — `isAllowed` guaranteed,
+so no `!` at the call site) and the wider `GameMoves` (what `StrategyArgs.moves`
+is — dispatch only). `ClientGameMoves` is assignable to `GameMoves`, so a
+helper shared between a `BoardClient` and a bot takes `GameMoves`.
 
 **`ctx`** fields available in moves and `BoardClient`:
 - `currentPlayer`: 0/1 — use this for game logic in both modes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ strategyGameFactory({
     roleLabels?,               // optional: [{ hu, en }, { hu, en }] — defaults to "1st/2nd player"
     getPlayerStepDescription,  // ({ board, ctx }) => { hu, en } — shown as turn instruction
   },
-  BoardClient,                 // React component receiving { board, ctx, events, moves }
+  BoardClient,                 // React component receiving { board, ctx, moves, setTurnState }
   gameplay: {
     moves,                     // { [name]: { apply, validate? } } — see below
     endOfTurnMove?,            // optional move name auto-executed after moves with autoEndOfTurn: true
@@ -96,17 +96,18 @@ single-entry array needs no `isDefault` flag.
 
 **`moves`** — every move is `{ apply, validate? }`: an optional legality
 predicate paired with an outcome-returning
-`(board, { ctx }, ...args) => MoveOutcome`. A move gets no `events` —
-everything it causes is data in the returned `MoveOutcome`:
+`(board, { ctx }, ...args) => MoveOutcome`. A move is handed nothing it could
+cause an effect through — everything it causes is data in the returned
+`MoveOutcome`:
 `{ nextBoard, isTurnEnd?, nextTurnState?, gameEnd?, autoEndOfTurn? }`.
 `isTurnEnd: true` passes the turn (omitted = further moves follow in the same
 turn); `gameEnd: { winnerIndex }` ends the game with an always-explicit winner
 (`ctx.currentPlayer!` when the mover wins) and never flips `currentPlayer` —
 `isTurnEnd`/`autoEndOfTurn` alongside it are a dev-mode error;
 `nextTurnState` sets `ctx.turnState` (`null` clears, omitted keeps);
-`autoEndOfTurn: true` schedules `endOfTurnMove`. Being `events`-free makes a
-move a pure reducer, which is what lets the same function run in a future
-authoritative competition server (see issue #313).
+`autoEndOfTurn: true` schedules `endOfTurnMove`. Causing nothing directly is
+what makes a move a pure reducer, and what lets the same function run in a
+future authoritative competition server (see issue #313).
 
 Always pass the current `board` as first arg when chaining moves within a turn.
 `apply` does not validate its arguments — it applies them blindly; legality is
@@ -156,9 +157,11 @@ helper shared between a `BoardClient` and a bot takes `GameMoves`.
   remembered during a turn if needed, i.e. to expose it from BoardClient to
   getPlayerStepDescription
 
-**`events`**: `setTurnState(stage)`, and nothing else — it exists for
-`BoardClient` components that keep mid-turn UI state in `ctx.turnState`.
-Moves never receive it; they return `nextTurnState` instead.
+**`setTurnState(stage)`** — a `BoardClient`-only prop, for components that keep
+mid-turn UI state in `ctx.turnState`. It is the one path that writes engine
+state without going through a move, deliberately: a selection is not a move, so
+it must not bump `moveCount` or take an undo snapshot. Moves never get it; they
+return `nextTurnState` instead.
 
 ### Game state architecture: synchronous store outside React
 

--- a/README.md
+++ b/README.md
@@ -221,9 +221,9 @@ in its return value (a `MoveOutcome`):
 - `autoEndOfTurn`: `true` asks the framework to auto-dispatch
   `gameplay.endOfTurnMove` after a short delay
 
-`apply` receives `{ ctx }` and no `events` — it is a pure function, which
-is what lets the same move logic run on a possible future authoritative
-competition server.
+`apply` receives `{ ctx }` and nothing it could cause an effect through — it is
+a pure function, which is what lets the same move logic run on a possible future
+authoritative competition server.
 
 You must always pass `board` as a first param to all moves (meaning you must
 pass the updated board to subsequent moves in case of multiple moves within a
@@ -295,8 +295,8 @@ Props passed by framework:
 
 - `board` (result of last move),
 - `ctx`, (i.e. to know whose turn it is)
-- `events` (i.e. to `setTurnState`) and
-- `moves`
+- `moves` and
+- `setTurnState`
 
 Additional state variables may be created within the `BoardClient` component
 that is relevant only during a turn, not between turns, such as reacting to
@@ -326,12 +326,13 @@ framework.
   remembered during a turn, i.e. to expose it from BoardClient to
   getPlayerStepDescription
 
-`events` holds a single function, for `BoardClient` components that keep
-mid-turn UI state in `ctx.turnState`:
-- `setTurnState`: a function to set `turnState`
+`setTurnState` is a `BoardClient`-only prop, for components that keep mid-turn
+UI state in `ctx.turnState`. It is the one path that writes engine state without
+going through a move, and deliberately so: a selection is not a move, so it must
+not bump `moveCount` or take an undo snapshot.
 
-Moves never receive `events`: they return `isTurnEnd`, `gameEnd` and
-`nextTurnState` instead.
+Moves never receive it: they return `isTurnEnd`, `gameEnd` and `nextTurnState`
+instead.
 </details>
 
 ## Things to look out for

--- a/README.md
+++ b/README.md
@@ -276,6 +276,9 @@ bound) for the `BoardClient`'s `disabled` state. Full contract in
   `ctx.isClientMoveAllowed` in for you.
 - `isAllowed` is not for bots: during the bot's turn `isClientMoveAllowed` is
   false by design, so bots enumerate legal moves via the raw `validate`/helpers.
+  That split is in the types too: `BoardClientProps.moves` is
+  `ClientGameMoves` (`isAllowed` guaranteed), `StrategyArgs.moves` is the wider
+  `GameMoves` (dispatch only).
 - `validate` is React-free, so a future authoritative/competition server could
   run the exact same predicate.
 - Worked examples: `coins-in-3-piles` (two-phase turn), `cube-coloring` (reuses

--- a/docs/real-competitions-plan.md
+++ b/docs/real-competitions-plan.md
@@ -46,9 +46,12 @@ a **new backend service** powers competition mode only.
 | Match state, clock, streak, retries, scoring, results | **Server** | Authoritative and tamper-proof |
 
 The existing `strategyGameFactory` API is already close to what's needed: moves
-are near-pure (`(board, { ctx, events }, ...args) => { nextBoard }`) and bot
-strategies are `(board) => nextBoard`. These can run headless in Node with
-modest refactoring.
+are pure reducers (`(board, { ctx }, ...args) => MoveOutcome`) paired with pure
+`validate` predicates, and the interpreter that runs them
+(`strategy-game-factory/engine/`) is deliberately React-free, so move legality
+and win detection already run headless in Node. Bot strategies
+(`({ board, ctx, moves }) => void`) dispatch moves instead of returning them,
+which is the part that still needs work.
 
 ## The four server-authoritative signals
 
@@ -124,6 +127,11 @@ Node**. Do it for a **pilot game first**, not the whole catalog. The smart bot
 strategy is split into a **server-only** module that the client build never
 imports. Needs test coverage.
 
+Partly done already: the move interpreter, the game store and the `ctx`
+derivation live in `strategy-game-factory/engine/`, which imports no React. What
+remains is per game — most game files still keep their moves in the same `.tsx`
+as their JSX rule text — plus the server-only split of the smart bot.
+
 ### Phase 2 — Stand up the backend
 
 Choose host + storage (a small Node service or serverless functions;
@@ -171,9 +179,10 @@ Why this is attractive:
 
 - **No new backend to design or operate.** The four server-authoritative signals
   (start board, move validation, smart bot, clock) already have a home.
-- **`strategyGameFactory` is a natural fit.** Its moves are near-pure and its bot
-  strategies are `(board) => nextBoard`; that maps onto a `boardgame.io`-style
-  engine slot more directly than onto a bespoke service.
+- **`strategyGameFactory` is a natural fit.** Its moves are pure reducers
+  returning a `MoveOutcome`, and its interpreter is already framework-free; that
+  maps onto a `boardgame.io`-style engine slot more directly than onto a bespoke
+  service.
 - **Division of labour matches reality.** This repo stays a lightweight,
   no-backend practice site (its original purpose); competition concerns live
   where competition infrastructure already exists.

--- a/src/components/games/add-reduce-double/add-reduce-double.tsx
+++ b/src/components/games/add-reduce-double/add-reduce-double.tsx
@@ -18,7 +18,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   // i.e. `board[pileId] - pieceId` pieces — so the piece is clickable exactly
   // when that is a legal transfer.
   const isDisabled = ({ pileId, pieceId }: Piece) =>
-    !moves.moveHalvedPieces.isAllowed!(board, { pileId, pieceCount: board[pileId] - pieceId });
+    !moves.moveHalvedPieces.isAllowed(board, { pileId, pieceCount: board[pileId] - pieceId });
 
   // The pieces removed by clicking the hovered piece: it and everything above it.
   const removedCount = () => (validHoveredPiece ? board[validHoveredPiece.pileId] - validHoveredPiece.pieceId : 0);

--- a/src/components/games/amor-and-cupido/board-client.tsx
+++ b/src/components/games/amor-and-cupido/board-client.tsx
@@ -14,7 +14,7 @@ const ownerStroke = (owner: number | null): string => {
 };
 
 export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
-  const isMoveAllowed = (edge: number) => moves.claimEdge.isAllowed!(board, edge);
+  const isMoveAllowed = (edge: number) => moves.claimEdge.isAllowed(board, edge);
 
   const winningEdges =
     ctx.winnerIndex !== null ? findWinningTriangle(board, ctx.winnerIndex) : null;

--- a/src/components/games/architect-and-bandits/architect-and-bandits-a/board-client.tsx
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-a/board-client.tsx
@@ -28,8 +28,8 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const gameStarted = ctx.isHumanVsHumanGame || ctx.chosenRoleIndex !== null;
 
   const isClickable = (v: number) => (ctx.currentPlayer === ARCHITECT
-    ? moves.moveArchitect.isAllowed!(board, v)
-    : moves.destroyTower.isAllowed!(board, v));
+    ? moves.moveArchitect.isAllowed(board, v)
+    : moves.destroyTower.isAllowed(board, v));
 
   const handleVertexClick = (v: number) => {
     if (ctx.currentPlayer === ARCHITECT) {
@@ -39,7 +39,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     }
   };
 
-  const canEndDay = moves.endDay.isAllowed!(board);
+  const canEndDay = moves.endDay.isAllowed(board);
 
   return (
     <GameBoard className="flex flex-col items-center">

--- a/src/components/games/architect-and-bandits/architect-and-bandits-b/board-client.tsx
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-b/board-client.tsx
@@ -27,8 +27,8 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const gameStarted = ctx.isHumanVsHumanGame || ctx.chosenRoleIndex !== null;
 
   const isClickable = (v) => (ctx.currentPlayer === ARCHITECT
-    ? moves.moveArchitect.isAllowed!(board, v)
-    : moves.destroyTower.isAllowed!(board, v));
+    ? moves.moveArchitect.isAllowed(board, v)
+    : moves.destroyTower.isAllowed(board, v));
 
   const handleVertexClick = (v) => {
     if (ctx.currentPlayer === ARCHITECT) {
@@ -38,7 +38,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     }
   };
 
-  const canEndDay = moves.endDay.isAllowed!(board);
+  const canEndDay = moves.endDay.isAllowed(board);
 
   return (
     <GameBoard className="flex flex-col items-center">

--- a/src/components/games/bacteria/bacteria.tsx
+++ b/src/components/games/bacteria/bacteria.tsx
@@ -63,7 +63,7 @@ const BoardClient = ({ board: { bacteria, goals }, ctx, moves }: BoardClientProp
     if (bacteria[row][col] === undefined) return false;
     const name = attackMoveName({ attackRow, attackCol, row, col });
     return name !== null
-      && moves[name].isAllowed!({ bacteria, goals }, { row: attackRow, col: attackCol });
+      && moves[name].isAllowed({ bacteria, goals }, { row: attackRow, col: attackCol });
   };
 
   const isGoal = ({ row, col }) => row === (bacteria.length - 1) && goals.includes(col);

--- a/src/components/games/bank-robbers/bank-robbers.tsx
+++ b/src/components/games/bank-robbers/bank-robbers.tsx
@@ -16,7 +16,7 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
   // Two different questions: `isAllowedBank` marks the banks that could be
   // robbed from this position — shown in green whoever is on turn — while
   // `isAllowedMove` additionally requires that it is this client's move.
-  const isAllowedMove = index => moves.rob.isAllowed!(board, index);
+  const isAllowedMove = index => moves.rob.isAllowed(board, index);
 
   const isAllowedBank = index => isRobbable(board, index);
 

--- a/src/components/games/chess-bishops/chess-bishops.tsx
+++ b/src/components/games/chess-bishops/chess-bishops.tsx
@@ -18,7 +18,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     if (!validHoveredField) return false;
     return isEqual(validHoveredField, field);
   };
-  const isMoveAllowed = (targetField: Field) => moves.placeBishop.isAllowed!(board, targetField);
+  const isMoveAllowed = (targetField: Field) => moves.placeBishop.isAllowed(board, targetField);
   const isForbidden = ({ row, col }: Field) => {
     return board[row][col] === FORBIDDEN;
   };

--- a/src/components/games/chess-ducks/chess-ducks.tsx
+++ b/src/components/games/chess-ducks/chess-ducks.tsx
@@ -40,7 +40,7 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
                 >
                   <button
                     className="w-full aspect-square p-[5%]"
-                    disabled={!moves.placeDuck.isAllowed!(board, { row, col })}
+                    disabled={!moves.placeDuck.isAllowed(board, { row, col })}
                     onClick={() => moves.placeDuck(board, { row, col })}
                   >
                     {isDuck({ row, col }) && (

--- a/src/components/games/chess-knight/chess-knight.tsx
+++ b/src/components/games/chess-knight/chess-knight.tsx
@@ -7,7 +7,7 @@ import { getAllowedMoves, generateStartBoard, markVisitedFields, type Board, typ
 import { ChessKnightSvg } from './chess-knight-svg';
 
 const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
-  const isMoveAllowed = (targetField: Field) => moves.moveKnight.isAllowed!(board, targetField);
+  const isMoveAllowed = (targetField: Field) => moves.moveKnight.isAllowed(board, targetField);
 
   return (
   <GameBoard>

--- a/src/components/games/chess-rook/chess-rook.tsx
+++ b/src/components/games/chess-rook/chess-rook.tsx
@@ -7,7 +7,7 @@ import { getAllowedMoves, generateStartBoard, markVisitedFields, type Board, typ
 import { RookSvg } from '../shared/rook-svg';
 
 const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
-  const isMoveAllowed = (targetField: Field) => moves.moveRook.isAllowed!(board, targetField);
+  const isMoveAllowed = (targetField: Field) => moves.moveRook.isAllowed(board, targetField);
 
   return (
   <GameBoard>

--- a/src/components/games/coins-in-3-piles/board-client.tsx
+++ b/src/components/games/coins-in-3-piles/board-client.tsx
@@ -21,9 +21,9 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 
   const wasCoinAlreadyRemovedInTurn = valueOfRemovedCoin !== null;
 
-  const isRemovalAllowed = coinValue => moves.removeCoin.isAllowed!(board, coinValue);
-  const isAddAllowed = coinValue => moves.addCoin.isAllowed!(board, coinValue);
-  const isPassAllowed = () => moves.passAddition.isAllowed!(board);
+  const isRemovalAllowed = coinValue => moves.removeCoin.isAllowed(board, coinValue);
+  const isAddAllowed = coinValue => moves.addCoin.isAllowed(board, coinValue);
+  const isPassAllowed = () => moves.passAddition.isAllowed(board);
 
 
   const shouldShowCoinToBeRemoved = (coinValue) => {

--- a/src/components/games/cube-coloring/cube-coloring.tsx
+++ b/src/components/games/cube-coloring/cube-coloring.tsx
@@ -45,7 +45,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const [x, setX] = useState(0);
   const [y, setY] = useState(0);
 
-  const isColoringAllowed = (vertex) => moves.colorVertex.isAllowed!(board, { vertex, color });
+  const isColoringAllowed = (vertex) => moves.colorVertex.isAllowed(board, { vertex, color });
 
   const pick = (pickedColor) => {
     if (!ctx.isClientMoveAllowed) return;

--- a/src/components/games/digit-subtraction/digit-subtraction.tsx
+++ b/src/components/games/digit-subtraction/digit-subtraction.tsx
@@ -29,7 +29,7 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
         {digits.map((d, i) => (
           <button
             key={i}
-            disabled={!moves.subtractDigit.isAllowed!(board, d)}
+            disabled={!moves.subtractDigit.isAllowed(board, d)}
             onClick={() => moves.subtractDigit(board, d)}
             className="secondary-button border-2 text-3xl sm:text-5xl w-12 sm:w-16 py-2 sm:py-3 font-bold"
           >

--- a/src/components/games/discs-flip-or-remove/discs-flip-or-remove.tsx
+++ b/src/components/games/discs-flip-or-remove/discs-flip-or-remove.tsx
@@ -34,7 +34,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const moveForPile = (pile: number) => (pile === 0 ? moves.removeDiscs : moves.turnDiscs);
 
   const isSelectable = (pile: number, i: number) =>
-    moveForPile(pile).isAllowed!(board, board[pile] - i);
+    moveForPile(pile).isAllowed(board, board[pile] - i);
 
   const select = (pile, i) => moveForPile(pile)(board, board[pile] - i);
 

--- a/src/components/games/distinct-squares/five-squares/five-squares.tsx
+++ b/src/components/games/distinct-squares/five-squares/five-squares.tsx
@@ -47,7 +47,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
       {range(board.length).map(id =>
         <button
           key={id}
-          disabled={!moves.addPiece.isAllowed!(board, id)}
+          disabled={!moves.addPiece.isAllowed(board, id)}
           onClick={() => moves.addPiece(board, id)}
           className="aspect-square border-r-4 border-b-4 p-[3%]"
         >

--- a/src/components/games/distinct-squares/two-times-two/two-times-two.tsx
+++ b/src/components/games/distinct-squares/two-times-two/two-times-two.tsx
@@ -30,7 +30,7 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => (
       {range(board.length).map(id =>
         <button
           key={id}
-          disabled={!moves.addPiece.isAllowed!(board, id)}
+          disabled={!moves.addPiece.isAllowed(board, id)}
           onClick={() => moves.addPiece(board, id)}
           className="aspect-square border-r-2 border-b-2 p-[4%]"
         >

--- a/src/components/games/dominoes-4x4/dominoes-4x4.tsx
+++ b/src/components/games/dominoes-4x4/dominoes-4x4.tsx
@@ -63,7 +63,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 
   // The field would complete a legal domino with the one already selected.
   const isValidPartner = (field: Field) =>
-    selectedField !== null && moves.placeDomino.isAllowed!(board, [selectedField, field]);
+    selectedField !== null && moves.placeDomino.isAllowed(board, [selectedField, field]);
 
   const hasPlaceablePartner = ({ row, col }: Field) => {
     return [[step.dRow, step.dCol], [-step.dRow, -step.dCol]].some(([dRow, dCol]) => {

--- a/src/components/games/dominoes-on-chessboard/dominoes-on-chessboard.tsx
+++ b/src/components/games/dominoes-on-chessboard/dominoes-on-chessboard.tsx
@@ -54,7 +54,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 
   // The field would complete a legal domino with the one already selected.
   const isValidPartner = (field: Field) =>
-    selectedField !== null && moves.placeDomino.isAllowed!(board, [selectedField, field]);
+    selectedField !== null && moves.placeDomino.isAllowed(board, [selectedField, field]);
 
   const isPartOfPreview = (field: Field) => {
     if (selectedField === null || validHoveredField === null) return false;

--- a/src/components/games/five-connected-fields/board-client.tsx
+++ b/src/components/games/five-connected-fields/board-client.tsx
@@ -17,7 +17,7 @@ const coords: Record<number, { cx: string; cy: string }> = {
 const edges = side1.flatMap((a) => side2.map((b) => [a, b] as const));
 
 export const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
-  const isClickable = (node: number) => moves.placeCoin.isAllowed!(board, node);
+  const isClickable = (node: number) => moves.placeCoin.isAllowed(board, node);
 
   return (
     <GameBoard>

--- a/src/components/games/five-five-card/five-five-card.tsx
+++ b/src/components/games/five-five-card/five-five-card.tsx
@@ -24,7 +24,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
         [0, 1].map(playerIdx => (
           <button
             key={`${playerIdx}-${id}`}
-            disabled={playerIdx === ctx.currentPlayer || !moves.removeCard.isAllowed!(board, id + 1)}
+            disabled={playerIdx === ctx.currentPlayer || !moves.removeCard.isAllowed(board, id + 1)}
             onClick={() => moves.removeCard(board, id + 1)}
             className={`
               ${playerIdx === 0 ? 'col-start-1' : 'col-start-4'}

--- a/src/components/games/four-connected-fields/board-client.tsx
+++ b/src/components/games/four-connected-fields/board-client.tsx
@@ -21,7 +21,7 @@ const edges = [
 ];
 
 export const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
-  const isClickable = (node: number) => moves.placeCoin.isAllowed!(board, node);
+  const isClickable = (node: number) => moves.placeCoin.isAllowed(board, node);
 
   return (
     <GameBoard>

--- a/src/components/games/four-piles-spread-ahead/four-piles-spread-ahead.tsx
+++ b/src/components/games/four-piles-spread-ahead/four-piles-spread-ahead.tsx
@@ -22,7 +22,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   // Clicking piece `pieceId` removes it and everything above it (from the top),
   // i.e. `board[pileId] - pieceId` pieces.
   const isDisabled = ({ pileId, pieceId }: Piece) =>
-    !moves.spreadPieces.isAllowed!(board, { pileId, pieceCount: board[pileId] - pieceId });
+    !moves.spreadPieces.isAllowed(board, { pileId, pieceCount: board[pileId] - pieceId });
 
   // The pieces removed by clicking the hovered piece: it and everything above it.
   const removedCount = () => (validHoveredPiece ? board[validHoveredPiece.pileId] - validHoveredPiece.pieceId : 0);

--- a/src/components/games/four-piles-two-grabs/four-piles-two-grabs.tsx
+++ b/src/components/games/four-piles-two-grabs/four-piles-two-grabs.tsx
@@ -98,7 +98,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   }, [ctx.moveCount]);
 
   const activeCount = removals.filter(r => r > 0).length;
-  const readyToMove = moves.takeStones.isAllowed!(board, removals);
+  const readyToMove = moves.takeStones.isAllowed(board, removals);
 
   const adjust = (i: number, delta: number) => {
     if (!ctx.isClientMoveAllowed) return;

--- a/src/components/games/hunyadi-and-the-janissaries/hunyadi-and-the-janissaries.tsx
+++ b/src/components/games/hunyadi-and-the-janissaries/hunyadi-and-the-janissaries.tsx
@@ -72,8 +72,8 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
             <button
               key={pieceIndex}
               disabled={!(isPlayerSultan
-                ? moves.setGroupOfSoldiers.isAllowed!(board, [{ rowIndex, pieceIndex, group }])
-                : moves.killGroup.isAllowed!(board, group))}
+                ? moves.setGroupOfSoldiers.isAllowed(board, [{ rowIndex, pieceIndex, group }])
+                : moves.killGroup.isAllowed(board, group))}
               className="aspect-square w-[10%] mx-1"
               onClick={() => clickOnSoldier({ rowIndex, pieceIndex })}
               {...hoverProps({ rowIndex, pieceIndex })}
@@ -94,9 +94,9 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
       <button
         className={`
           primary-button w-auto m-auto mt-2
-          ${moves.finalizeSeparation.isAllowed!(board) ? '' : 'invisible'}
+          ${moves.finalizeSeparation.isAllowed(board) ? '' : 'invisible'}
         `}
-        disabled={!moves.finalizeSeparation.isAllowed!(board)}
+        disabled={!moves.finalizeSeparation.isAllowed(board)}
         onClick={() => moves.finalizeSeparation(board)}
       >
         {t({ hu: 'Befejezem a kettéosztást', en: 'Finish the split' })}

--- a/src/components/games/latin-square-filling/latin-square-filling.tsx
+++ b/src/components/games/latin-square-filling/latin-square-filling.tsx
@@ -37,7 +37,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   // Which digits the selected cell will accept — asked of the move itself, so
   // the keypad and the engine cannot disagree.
   const allowed = [1, 2, 3].filter(
-    digit => selectedCell !== null && moves.placeDigit.isAllowed!(board, selectedCell, digit)
+    digit => selectedCell !== null && moves.placeDigit.isAllowed(board, selectedCell, digit)
   );
 
   return (

--- a/src/components/games/magic-box/magic-box-a/magic-box-a.tsx
+++ b/src/components/games/magic-box/magic-box-a/magic-box-a.tsx
@@ -11,7 +11,7 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => (
       {range(9).map(id => (
         <button
           key={id}
-          disabled={!moves.placeStone.isAllowed!(board, id)}
+          disabled={!moves.placeStone.isAllowed(board, id)}
           onClick={() => moves.placeStone(board, id)}
           className="aspect-square p-[25%] bg-surface-elevated"
         >

--- a/src/components/games/magic-box/magic-box-b/board-client.tsx
+++ b/src/components/games/magic-box/magic-box-b/board-client.tsx
@@ -25,7 +25,7 @@ export const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
             {range(9).map(id => (
               <button
                 key={id}
-                disabled={!moves.placeStone.isAllowed!(board, id)}
+                disabled={!moves.placeStone.isAllowed(board, id)}
                 onClick={() => moves.placeStone(board, id)}
                 className={`p-[20%] ${
                   isCellHighlighted(id) ? 'bg-amber-200 dark:bg-amber-700' : 'bg-surface-elevated'
@@ -42,7 +42,7 @@ export const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
             {range(3).map(row => (
               <button
                 key={row}
-                disabled={!moves.designateLine.isAllowed!(board, row)}
+                disabled={!moves.designateLine.isAllowed(board, row)}
                 onClick={() => moves.designateLine(board, row)}
                 title={t(LINE_LABELS[row])}
                 aria-label={t(LINE_LABELS[row])}
@@ -58,7 +58,7 @@ export const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
           {range(3).map(col => (
             <button
               key={col}
-              disabled={!moves.designateLine.isAllowed!(board, 3 + col)}
+              disabled={!moves.designateLine.isAllowed(board, 3 + col)}
               onClick={() => moves.designateLine(board, 3 + col)}
               title={t(LINE_LABELS[3 + col])}
               aria-label={t(LINE_LABELS[3 + col])}

--- a/src/components/games/matches-on-edges/board-client.tsx
+++ b/src/components/games/matches-on-edges/board-client.tsx
@@ -33,7 +33,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   // A cell is a valid start exactly when the window it would open is a legal
   // move — asked of the move itself rather than of the generator directly.
   const isValidStart = (a: number) =>
-    k !== null && moves.placeWindow.isAllowed!(board, a, a + k - 1);
+    k !== null && moves.placeWindow.isAllowed(board, a, a + k - 1);
 
   const [selectedStart, setSelectedStart] = useState<number | null>(null);
   const { value: hoverStart, hoverProps } = useHoverPreview<number>(ctx.moveCount);

--- a/src/components/games/matchstick-piles/matchstick-piles.tsx
+++ b/src/components/games/matchstick-piles/matchstick-piles.tsx
@@ -30,7 +30,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { value: activeHover, hoverProps } = useHoverPreview<Hover>(ctx.moveCount);
 
   const canSplit = (pileId: number, splitAfter: number) =>
-    moves.splitPile.isAllowed!(board, pileId, splitAfter + 1);
+    moves.splitPile.isAllowed(board, pileId, splitAfter + 1);
 
   const pileDescription = (pileId: number, size: number) => {
     if (!activeHover || activeHover.pileId !== pileId) return `${size}`;
@@ -88,14 +88,14 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
                   <button
                     type="button"
                     aria-label="remove a match from this pile"
-                    disabled={!moves.removeMatch.isAllowed!(board, pileId)}
+                    disabled={!moves.removeMatch.isAllowed(board, pileId)}
                     className={`
                       p-1 rounded-sm
                       enabled:hover:bg-slate-200 dark:enabled:hover:bg-slate-700
                       enabled:focus:bg-slate-200 dark:enabled:focus:bg-slate-700
                     `}
                     onClick={() => moves.removeMatch(board, pileId)}
-                    {...(moves.removeMatch.isAllowed!(board, pileId) ? hoverProps({ pileId, kind: 'remove' }) : {})}
+                    {...(moves.removeMatch.isAllowed(board, pileId) ? hoverProps({ pileId, kind: 'remove' }) : {})}
                   >
                     <Matchstick removed={isMatchRemoved(pileId, matchId, size)} />
                   </button>

--- a/src/components/games/modified-mill/board-client.tsx
+++ b/src/components/games/modified-mill/board-client.tsx
@@ -12,7 +12,7 @@ const pos = COORDS.map(([x, y]) => ({ cx: px(x), cy: px(y) }));
 const segments = LINES.flatMap(([a, b, c]) => [[a, b], [b, c]] as const);
 
 export const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
-  const isClickable = (node: number) => moves.placePiece.isAllowed!(board, node);
+  const isClickable = (node: number) => moves.placePiece.isAllowed(board, node);
 
   const handleClick = (node: number) => {
     if (!isClickable(node)) return;

--- a/src/components/games/number-covering/number-covering.tsx
+++ b/src/components/games/number-covering/number-covering.tsx
@@ -25,7 +25,7 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
       {range(board.length).map(i => (
         <button
           key={i}
-          disabled={!moves.coverNumber.isAllowed!(board, i + 1)}
+          disabled={!moves.coverNumber.isAllowed(board, i + 1)}
           className={`secondary-button w-auto text-2xl min-w-[3ch]`}
           onClick={() => moves.coverNumber(board, i + 1)}
         >

--- a/src/components/games/number-pyramid/board-client.tsx
+++ b/src/components/games/number-pyramid/board-client.tsx
@@ -29,7 +29,7 @@ const ActiveSlot = ({ value, isSelected, isDisabled, onClick }) => (
   </button>
 );
 
-export const BoardClient = ({ board, ctx, events, moves }: BoardClientProps<Board>) => {
+export const BoardClient = ({ board, ctx, setTurnState, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
   const turnState = ctx.turnState as TurnState;
 
@@ -40,11 +40,11 @@ export const BoardClient = ({ board, ctx, events, moves }: BoardClientProps<Boar
 
     if (turnState === null) {
       if (!hasActivePair(board.levels[levelIdx])) return;
-      events.setTurnState({ levelIdx, slotIdx });
+      setTurnState({ levelIdx, slotIdx });
       return;
     }
     if (isEqual(turnState, { levelIdx, slotIdx })) {
-      events.setTurnState(null);
+      setTurnState(null);
       return;
     }
 

--- a/src/components/games/pile-splitting-games/pile-splitter-3/pile-splitter-3.tsx
+++ b/src/components/games/pile-splitting-games/pile-splitter-3/pile-splitter-3.tsx
@@ -21,7 +21,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { value: validHoveredPileId, hoverProps: pileHoverProps } = useHoverPreview<number>(ctx.moveCount);
 
   const canSelectPile = (pileId: number) =>
-    removedPileId === null && moves.removePile.isAllowed!(board, pileId);
+    removedPileId === null && moves.removePile.isAllowed(board, pileId);
 
   const isDisabled = ({ pileId, pieceId }: Piece) => {
     if (!ctx.isClientMoveAllowed) return true;

--- a/src/components/games/pile-splitting-games/pile-splitter-4/pile-splitter-4.tsx
+++ b/src/components/games/pile-splitting-games/pile-splitter-4/pile-splitter-4.tsx
@@ -16,7 +16,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { value: validHoveredPileId, hoverProps: pileHoverProps } = useHoverPreview<number>(ctx.moveCount);
 
   const canSelectPile = (pileId: number) =>
-    removedPileId === null && moves.removePile.isAllowed!(board, pileId);
+    removedPileId === null && moves.removePile.isAllowed(board, pileId);
 
   const isDisabled = ({ pileId, pieceId }: Piece) => {
     if (!ctx.isClientMoveAllowed) return true;

--- a/src/components/games/pile-splitting-games/pile-splitter/pile-splitter.tsx
+++ b/src/components/games/pile-splitting-games/pile-splitter/pile-splitter.tsx
@@ -14,7 +14,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   // One click performs the whole turn, so a piece is clickable only if both
   // halves are legal: discarding the other pile, then splitting this one here.
   const isDisabled = ({ pileId, pieceId }: Piece) =>
-    !moves.removePile.isAllowed!(board, 1 - pileId)
+    !moves.removePile.isAllowed(board, 1 - pileId)
       || !isSplitAllowed(withPileRemoved(board, 1 - pileId), pileId, pieceId + 1);
 
   const clickPiece = ({ pileId, pieceId }: Piece) => {

--- a/src/components/games/pile-union/pile-union.tsx
+++ b/src/components/games/pile-union/pile-union.tsx
@@ -10,7 +10,7 @@ export type Board = number[]
 export type MoveType = 'remove' | 'merge'
 type TurnState = { firstSelectedPile: number } | null
 
-const BoardClient = ({ board, ctx, events, moves }: BoardClientProps<Board>) => {
+const BoardClient = ({ board, ctx, setTurnState, moves }: BoardClientProps<Board>) => {
   const [moveType, setMoveType] = useState<MoveType>('remove');
   const { value: hoveredPile, hoverProps } = useHoverPreview<number>(ctx.moveCount);
   const turnState = ctx.turnState as TurnState;
@@ -24,12 +24,12 @@ const BoardClient = ({ board, ctx, events, moves }: BoardClientProps<Board>) => 
       moves.removeOne(board, pileIndex);
     } else {
       if (turnState === null) {
-        events.setTurnState({ firstSelectedPile: pileIndex });
+        setTurnState({ firstSelectedPile: pileIndex });
       } else if (turnState.firstSelectedPile === pileIndex) {
-        events.setTurnState(null);
+        setTurnState(null);
       } else {
         moves.mergePiles(board, [turnState.firstSelectedPile, pileIndex]);
-        events.setTurnState(null);
+        setTurnState(null);
         setMoveType('remove');
       }
     }
@@ -42,7 +42,7 @@ const BoardClient = ({ board, ctx, events, moves }: BoardClientProps<Board>) => 
           moveType={moveType}
           isClientMoveAllowed={ctx.isClientMoveAllowed}
           canMerge={board.length >= 2}
-          onSelect={(type) => { setMoveType(type); events.setTurnState(null); }}
+          onSelect={(type) => { setMoveType(type); setTurnState(null); }}
         />
       )}
 

--- a/src/components/games/policeman-thief/policeman-thief-ab/board-client.tsx
+++ b/src/components/games/policeman-thief/policeman-thief-ab/board-client.tsx
@@ -24,7 +24,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 
   const handleCircleClick = (vertex: number) => activeMove()(board, vertex);
 
-  const isClickable = (vertex: number) => activeMove().isAllowed!(board, vertex);
+  const isClickable = (vertex: number) => activeMove().isAllowed(board, vertex);
 
   const getColor = (vertex: number) => {
     if (isClickable(vertex)) {

--- a/src/components/games/policeman-thief/policeman-thief-ab/helpers.ts
+++ b/src/components/games/policeman-thief/policeman-thief-ab/helpers.ts
@@ -21,5 +21,5 @@ export const isNeighbour = (from: number, to: number): boolean =>
   isVertex(from) && isVertex(to) && neighbours[from].includes(to);
 
 // Player 0 chases, player 1 runs. Both indices appear in move legality, in the
-// winner handed to endGame and in the board client, so they get names.
+// `gameEnd` winner a move returns and in the board client, so they get names.
 export const [POLICE, THIEF] = [0, 1];

--- a/src/components/games/policeman-thief/policeman-thief-c/board-client.tsx
+++ b/src/components/games/policeman-thief/policeman-thief-c/board-client.tsx
@@ -23,7 +23,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     return ctx.currentPlayer === POLICE ? moves.moveCop : moves.moveThief;
   };
 
-  const isClickable = (vertex: number) => activeMove().isAllowed!(board, vertex);
+  const isClickable = (vertex: number) => activeMove().isAllowed(board, vertex);
 
   const handleClick = (vertex: number) => activeMove()(board, vertex);
 

--- a/src/components/games/policeman-thief/policeman-thief-c/helpers.ts
+++ b/src/components/games/policeman-thief/policeman-thief-c/helpers.ts
@@ -87,5 +87,5 @@ export const isNeighbour = (from: number, to: number): boolean =>
   isVertex(from) && isVertex(to) && neighbours[from].includes(to);
 
 // Player 0 chases, player 1 runs. Both indices appear in move legality, in the
-// winner handed to endGame and in the board client, so they get names.
+// `gameEnd` winner a move returns and in the board client, so they get names.
 export const [POLICE, THIEF] = [0, 1];

--- a/src/components/games/polynomial-building/board-client.tsx
+++ b/src/components/games/polynomial-building/board-client.tsx
@@ -81,7 +81,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
               />
               <button
                 disabled={!isValidValue(inputs[coef])
-                  || !moves.setCoefficient.isAllowed!(board, coef, parseInt(inputs[coef], 10))}
+                  || !moves.setCoefficient.isAllowed(board, coef, parseInt(inputs[coef], 10))}
                 onClick={() => submit(coef)}
                 className="rounded-md border-2 px-3 py-1.5 font-bold
                   enabled:hocus:bg-blue-100 dark:enabled:hocus:bg-blue-900

--- a/src/components/games/recolouring-discs/board-client.tsx
+++ b/src/components/games/recolouring-discs/board-client.tsx
@@ -67,11 +67,11 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   // Every "may I?" question the board asks goes through the moves' own
   // validators, so the highlighting and the engine agree by construction.
   const isTarget = (to: number) =>
-    selectedFrom !== null && moves.moveDisc.isAllowed!(board, selectedFrom, to);
-  const isPlaceable = (at: number) => moves.placeDisc.isAllowed!(board, at);
+    selectedFrom !== null && moves.moveDisc.isAllowed(board, selectedFrom, to);
+  const isPlaceable = (at: number) => moves.placeDisc.isAllowed(board, at);
   // A disc is worth picking up only if it has somewhere to go; being of the
   // player's own colour is already implied by `moveDisc`'s validator.
-  const isMovable = (from: number) => range(cells.length).some(to => moves.moveDisc.isAllowed!(board, from, to));
+  const isMovable = (from: number) => range(cells.length).some(to => moves.moveDisc.isAllowed(board, from, to));
 
   const clickCell = (i: number) => {
     if (!canInteract || myColor === null) return;

--- a/src/components/games/remove-divisor-multiple/remove-divisor-multiple.tsx
+++ b/src/components/games/remove-divisor-multiple/remove-divisor-multiple.tsx
@@ -41,7 +41,7 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
         {range(1, board.numbersOnTable.length + 1).map(num =>
           <button
             key={num}
-            disabled={!moves.removeNumber.isAllowed!(board, num)}
+            disabled={!moves.removeNumber.isAllowed(board, num)}
             onClick={() => removeNumber(num)}
             className={`
               m-1 min-h-28 w-18 border-4 rounded-lg shadow-md text-4xl font-bold

--- a/src/components/games/remove-row-or-column/board-client.tsx
+++ b/src/components/games/remove-row-or-column/board-client.tsx
@@ -10,7 +10,7 @@ import {
 
 type Selected = { r: number; c: number } | null
 
-export const BoardClient = ({ board, ctx, events, moves }: BoardClientProps<Board>) => {
+export const BoardClient = ({ board, ctx, setTurnState, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
   const { grid } = board;
   const selected = ctx.turnState as Selected;
@@ -22,7 +22,7 @@ export const BoardClient = ({ board, ctx, events, moves }: BoardClientProps<Boar
     // Picking another disc keeps moveCount unchanged, so drop the hover
     // preview explicitly — it belonged to the previous selection.
     clearHover();
-    events.setTurnState(selected && selected.r === r && selected.c === c ? null : { r, c });
+    setTurnState(selected && selected.r === r && selected.c === c ? null : { r, c });
   };
 
   const discClass = (r: number, c: number) => {

--- a/src/components/games/rock-paper-scissor/rock-paper-scissor.tsx
+++ b/src/components/games/rock-paper-scissor/rock-paper-scissor.tsx
@@ -26,7 +26,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
         return [0, 1].map(playerIdx => (
           <button
             key={`${playerIdx}-${symbolIdx}`}
-            disabled={playerIdx === ctx.currentPlayer || !moves.removeSymbol.isAllowed!(board, symbolIdx)}
+            disabled={playerIdx === ctx.currentPlayer || !moves.removeSymbol.isAllowed(board, symbolIdx)}
             onClick={() => moves.removeSymbol(board, symbolIdx)}
             className={`
               ${playerIdx === 0 ? 'col-start-1' : 'col-start-3'}

--- a/src/components/games/rook-to-corner/rook-to-corner.tsx
+++ b/src/components/games/rook-to-corner/rook-to-corner.tsx
@@ -7,7 +7,7 @@ import { getAllowedMoves, generateStartBoard, isTarget, boardSize, type Board, t
 import { RookSvg } from '../shared/rook-svg';
 
 const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
-  const isMoveAllowed = (targetField: Field) => moves.moveRook.isAllowed!(board, targetField);
+  const isMoveAllowed = (targetField: Field) => moves.moveRook.isAllowed(board, targetField);
 
   return (
   <GameBoard>

--- a/src/components/games/shark-chase/shark-4-by-4/board-client.tsx
+++ b/src/components/games/shark-chase/shark-4-by-4/board-client.tsx
@@ -21,8 +21,8 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   };
 
   const isAllowed_movePiece = (id: number): boolean => (isCurrentPlayerShark
-    ? moves.moveShark.isAllowed!(board, id)
-    : chosenPiece !== null && moves.moveSubmarine.isAllowed!(board, { from: chosenPiece, to: id }));
+    ? moves.moveShark.isAllowed(board, id)
+    : chosenPiece !== null && moves.moveSubmarine.isAllowed(board, { from: chosenPiece, to: id }));
 
   const possibleMoves = range(board.submarines.length).filter(isAllowed_movePiece);
 

--- a/src/components/games/shark-chase/shark-5-by-5/board-client.tsx
+++ b/src/components/games/shark-chase/shark-5-by-5/board-client.tsx
@@ -21,8 +21,8 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   };
 
   const isAllowed_movePiece = (id: number): boolean => (isCurrentPlayerShark
-    ? moves.moveShark.isAllowed!(board, id)
-    : chosenPiece !== null && moves.moveSubmarine.isAllowed!(board, { from: chosenPiece, to: id }));
+    ? moves.moveShark.isAllowed(board, id)
+    : chosenPiece !== null && moves.moveSubmarine.isAllowed(board, { from: chosenPiece, to: id }));
 
   const possibleMoves = range(board.submarines.length).filter(isAllowed_movePiece);
 

--- a/src/components/games/single-number-increase/increment-or-double/increment-or-double.tsx
+++ b/src/components/games/single-number-increase/increment-or-double/increment-or-double.tsx
@@ -29,8 +29,8 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
     <GameBoard>
       <h2 className="text-center text-5xl font-bold my-4">{board}</h2>
       <div className="flex flex-wrap gap-2">
-        {actionButton('x+1', incResult, () => moves.increment(board), !moves.increment.isAllowed!(board))}
-        {actionButton('2x', dblResult, () => moves.double(board), !moves.double.isAllowed!(board))}
+        {actionButton('x+1', incResult, () => moves.increment(board), !moves.increment.isAllowed(board))}
+        {actionButton('2x', dblResult, () => moves.double(board), !moves.double.isAllowed(board))}
       </div>
     </GameBoard>
   );

--- a/src/components/games/single-number-increase/plus-one-two-three/plus-one-two-three.tsx
+++ b/src/components/games/single-number-increase/plus-one-two-three/plus-one-two-three.tsx
@@ -19,7 +19,7 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
       {range(target + maxStep + 1).map(i =>
         <button
           key={i}
-          disabled={!moves.increaseTo.isAllowed!(board, i)}
+          disabled={!moves.increaseTo.isAllowed(board, i)}
           onClick={() => moves.increaseTo(board, i)}
           className={`
             border-2 rounded-sm text-2xl min-w-[4ch] p-1 my-1 font-bold

--- a/src/components/games/single-number-increase/superstitious-counting/superstitious-counting.tsx
+++ b/src/components/games/single-number-increase/superstitious-counting/superstitious-counting.tsx
@@ -37,7 +37,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
       {fields.map(i =>
         <button
           key={i}
-          disabled={!moves.step.isAllowed!(board, i - board.current)}
+          disabled={!moves.step.isAllowed(board, i - board.current)}
           onClick={() => moves.step(board, i - board.current)}
           className={`
             border-2 rounded-sm text-2xl min-w-[4ch] py-1 font-bold

--- a/src/components/games/single-pile-removal/pebble-pile.tsx
+++ b/src/components/games/single-pile-removal/pebble-pile.tsx
@@ -67,7 +67,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
       </p>
       <StonePile
         board={board}
-        isTakeAllowed={count => moves.take.isAllowed!(board, count)}
+        isTakeAllowed={count => moves.take.isAllowed(board, count)}
         onTake={count => moves.take(board, count)}
         moveCount={ctx.moveCount}
       />

--- a/src/components/games/single-pile-removal/prime-exponentials/prime-exponentials.tsx
+++ b/src/components/games/single-pile-removal/prime-exponentials/prime-exponentials.tsx
@@ -108,7 +108,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { value: hovered, hoverProps } = useHoverPreview<typeof allPrimePowers[0]>(ctx.moveCount);
   const [visiblePowers] = useState(() => allPrimePowers.filter(e => e.value <= board));
   const isEntryAllowed = (entry: typeof allPrimePowers[0]) =>
-    moves.subtractPrimeExponent.isAllowed!(board, entry);
+    moves.subtractPrimeExponent.isAllowed(board, entry);
 
   const chooseEntry = ({ prime, exponent }) => {
     moves.subtractPrimeExponent(board, { prime, exponent });

--- a/src/components/games/single-pile-removal/primely-to-zero/primely-to-zero.tsx
+++ b/src/components/games/single-pile-removal/primely-to-zero/primely-to-zero.tsx
@@ -26,7 +26,7 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
         {range(maxStart + 1).map(i =>
           <button
             key={i}
-            disabled={!moves.moveTo.isAllowed!(board, i)}
+            disabled={!moves.moveTo.isAllowed(board, i)}
             onClick={() => moves.moveTo(board, i)}
             className={`
               border-2 rounded-sm text-2xl min-w-[4ch] p-1 my-1 font-bold

--- a/src/components/games/single-pile-removal/take-1-or-halve/take-1-or-halve.tsx
+++ b/src/components/games/single-pile-removal/take-1-or-halve/take-1-or-halve.tsx
@@ -29,8 +29,8 @@ const CoinPile = ({ count, hoveredAction }: { count: number, hoveredAction: Hove
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
   const { value: hoveredAction, hoverProps } = useHoverPreview<'take1' | 'halve'>(ctx.moveCount);
-  const canTake1 = moves.take1.isAllowed!(board);
-  const canHalve = moves.halve.isAllowed!(board);
+  const canTake1 = moves.take1.isAllowed(board);
+  const canHalve = moves.halve.isAllowed(board);
   return(
     <GameBoard>
       <h2 className="text-center">{board}</h2>

--- a/src/components/games/single-pile-removal/take-power-of-two/take-power-of-two.tsx
+++ b/src/components/games/single-pile-removal/take-power-of-two/take-power-of-two.tsx
@@ -51,7 +51,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     <GameBoard>
       <p className='w-full text-8xl font-bold text-center mb-4'>{board}</p>
       <ExponentsTable
-        isPowerAllowed={(e: number) => moves.subtractPowerOfTwo.isAllowed!(board, e)}
+        isPowerAllowed={(e: number) => moves.subtractPowerOfTwo.isAllowed(board, e)}
         board={board}
         choosePower={(e: number) => moves.subtractPowerOfTwo(board, e)}
         hovered={hoveredPower}

--- a/src/components/games/six-fields-circle/board-client.tsx
+++ b/src/components/games/six-fields-circle/board-client.tsx
@@ -13,8 +13,7 @@ const coords: { cx: number; cy: number }[] = range(FIELD_COUNT).map((i) => {
   };
 });
 
-export const BoardClient = ({ board, ctx, events, moves }: BoardClientProps<Board>) => {
-  const { setTurnState } = events;
+export const BoardClient = ({ board, ctx, setTurnState, moves }: BoardClientProps<Board>) => {
   const turnState = ctx.turnState as TurnState;
   const first = turnState?.first ?? null;
 

--- a/src/components/games/six-fields-circle/board-client.tsx
+++ b/src/components/games/six-fields-circle/board-client.tsx
@@ -1,5 +1,5 @@
 import { range } from "lodash";
-import { GameBoard, type BoardClientProps, type Events } from "../../strategy-game-factory";
+import { GameBoard, type BoardClientProps } from "../../strategy-game-factory";
 import { type Board, FIELD_COUNT, OPPOSITE_PAIRS } from "./helpers";
 
 type TurnState = { first: number } | null
@@ -14,7 +14,7 @@ const coords: { cx: number; cy: number }[] = range(FIELD_COUNT).map((i) => {
 });
 
 export const BoardClient = ({ board, ctx, events, moves }: BoardClientProps<Board>) => {
-  const setTurnState = events.setTurnState as Events["setTurnState"];
+  const { setTurnState } = events;
   const turnState = ctx.turnState as TurnState;
   const first = turnState?.first ?? null;
 
@@ -23,7 +23,7 @@ export const BoardClient = ({ board, ctx, events, moves }: BoardClientProps<Boar
     if (first === null) return board[node] > 0;
     // A field is selected: allow clicking it again to deselect, or any field
     // that would complete a legal move.
-    return node === first || moves.removeFromTwo.isAllowed!(board, [first, node]);
+    return node === first || moves.removeFromTwo.isAllowed(board, [first, node]);
   };
 
   const handleClick = (node: number) => {

--- a/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
+++ b/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
@@ -43,7 +43,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
   const { value: hoveredPile, hoverProps } = useHoverPreview<number>(ctx.moveCount);
 
-  const isMoveAllowed = pileId => moves.removeStone.isAllowed!(board, pileId);
+  const isMoveAllowed = pileId => moves.removeStone.isAllowed(board, pileId);
 
   return (
     <GameBoard>

--- a/src/components/games/sum-fifteen/sum-fifteen.tsx
+++ b/src/components/games/sum-fifteen/sum-fifteen.tsx
@@ -58,7 +58,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
         {allNumbers.map(n => (
           <button
             key={n}
-            disabled={!moves.chooseNumber.isAllowed!(board, n)}
+            disabled={!moves.chooseNumber.isAllowed(board, n)}
             onClick={(e) => { moves.chooseNumber(board, n); e.currentTarget.blur(); }}
             className={numberClass(n)}
           >

--- a/src/components/games/take-and-point/board-client.tsx
+++ b/src/components/games/take-and-point/board-client.tsx
@@ -66,7 +66,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 
   const canInteract = ctx.isClientMoveAllowed;
   const pointCount = requiredPointCount(piles);
-  const pointingReady = moves.pointPiles.isAllowed!(board, selectedForPoint);
+  const pointingReady = moves.pointPiles.isAllowed(board, selectedForPoint);
 
   const togglePoint = (i: number) => {
     if (!canInteract || stage !== 'point' || piles[i] === 0) return;
@@ -89,7 +89,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   };
 
   const removalReady = removal !== null
-    && moves.takeStones.isAllowed!(board, removal.index, removal.amount);
+    && moves.takeStones.isAllowed(board, removal.index, removal.amount);
 
   const submitRemoval = () => {
     if (!removal) return;
@@ -146,7 +146,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
                     label={t({ hu: `+1 a(z) ${i + 1}. kupacból`, en: `+1 from pile ${i + 1}` })}
                     // One more stone must itself be a legal take; the second
                     // clause is local UI state (only one pile per turn).
-                    disabled={!moves.takeStones.isAllowed!(board, i, removeCount + 1)
+                    disabled={!moves.takeStones.isAllowed(board, i, removeCount + 1)
                       || (removal !== null && removal.index !== i)}
                     onClick={() => adjustRemoval(i, 1)}
                   >+</Stepper>

--- a/src/components/games/ten-coins/ten-coins.tsx
+++ b/src/components/games/ten-coins/ten-coins.tsx
@@ -55,7 +55,7 @@ const playerToMoveWins = (set: number[]): boolean => {
 // {1,2,3}, {1,4,5}, {2,3,4,5}, {1,2,3,4,5} for values 1..5. Everything else is a
 // first-player win, driven towards one of these (or merged to a single value).
 
-const BoardClient = ({ board, ctx, events, moves }: BoardClientProps<Board>) => {
+const BoardClient = ({ board, ctx, setTurnState, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
   const selectedValue = ctx.turnState as number | null;
   const presentValues = distinctValues(board);
@@ -64,12 +64,12 @@ const BoardClient = ({ board, ctx, events, moves }: BoardClientProps<Board>) => 
   // most generous target, so value-1 coins fall out as unselectable.
   const selectValue = (v: number) => {
     if (!moves.convert.isAllowed(board, v, 1)) return;
-    events.setTurnState(selectedValue === v ? null : v);
+    setTurnState(selectedValue === v ? null : v);
   };
 
   const chooseTarget = (l: number) => {
     moves.convert(board, selectedValue, l);
-    events.setTurnState(null);
+    setTurnState(null);
   };
 
   return (

--- a/src/components/games/ten-coins/ten-coins.tsx
+++ b/src/components/games/ten-coins/ten-coins.tsx
@@ -63,7 +63,7 @@ const BoardClient = ({ board, ctx, events, moves }: BoardClientProps<Board>) => 
   // Asking about L = 1 asks whether these coins can be changed at all: it is the
   // most generous target, so value-1 coins fall out as unselectable.
   const selectValue = (v: number) => {
-    if (!moves.convert.isAllowed!(board, v, 1)) return;
+    if (!moves.convert.isAllowed(board, v, 1)) return;
     events.setTurnState(selectedValue === v ? null : v);
   };
 
@@ -81,7 +81,7 @@ const BoardClient = ({ board, ctx, events, moves }: BoardClientProps<Board>) => 
           return (
             <button
               key={v}
-              disabled={!moves.convert.isAllowed!(board, v, 1)}
+              disabled={!moves.convert.isAllowed(board, v, 1)}
               onClick={() => selectValue(v)}
               aria-pressed={isSelected}
               aria-label={t({
@@ -123,7 +123,7 @@ const BoardClient = ({ board, ctx, events, moves }: BoardClientProps<Board>) => 
           {range(1, selectedValue).map(l => (
             <button
               key={l}
-              disabled={!moves.convert.isAllowed!(board, selectedValue, l)}
+              disabled={!moves.convert.isAllowed(board, selectedValue, l)}
               onClick={() => chooseTarget(l)}
               aria-label={t({ hu: `${l} értékű érme`, en: `value ${l} coin` })}
               className="rounded-full transition-transform enabled:hocus:scale-110

--- a/src/components/games/ten-digit-number/ten-digit-number.tsx
+++ b/src/components/games/ten-digit-number/ten-digit-number.tsx
@@ -77,7 +77,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
         {availableDigits.map(d => (
           <button
             key={d}
-            disabled={!moves.chooseDigit.isAllowed!(board, d)}
+            disabled={!moves.chooseDigit.isAllowed(board, d)}
             onClick={(e) => { moves.chooseDigit(board, d); e.currentTarget.blur(); }}
             className="rounded-lg border-2 text-2xl w-12 py-2 font-bold
               enabled:hocus:bg-blue-100 dark:enabled:hocus:bg-blue-900

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/thief-sheriff-mean-7.tsx
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/thief-sheriff-mean-7.tsx
@@ -22,7 +22,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
         {range(1, CARD_COUNT + 1).map(num =>
         <button
           key={num}
-          disabled={!moves.takeCard.isAllowed!(board, [num])}
+          disabled={!moves.takeCard.isAllowed(board, [num])}
           onClick={() => moves.takeCard(board, [num])}
           className={`
             m-1 min-h-28 w-18 border-2 rounded-lg shadow-md border-slate-900 dark:border-slate-400 text-4xl font-bold

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/thief-sheriff-mean-9.tsx
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/thief-sheriff-mean-9.tsx
@@ -22,7 +22,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
         {range(1, CARD_COUNT + 1).map(num =>
         <button
           key={num}
-          disabled={!moves.takeCard.isAllowed!(board, num)}
+          disabled={!moves.takeCard.isAllowed(board, num)}
           onClick={() => moves.takeCard(board, num)}
           className={`
             m-1 min-h-28 w-18 border-2 rounded-lg shadow-md border-slate-900 dark:border-slate-400 text-4xl font-bold

--- a/src/components/games/three-piles-rebuild/three-piles-rebuild.tsx
+++ b/src/components/games/three-piles-rebuild/three-piles-rebuild.tsx
@@ -48,7 +48,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   // A rejected click must leave the local selection alone, so this keeps a guard
   // rather than relying on the engine silently ignoring the dispatch.
   const clickPile = (pileId: number) => {
-    if (!moves.keepPile.isAllowed!(board, pileId)) return;
+    if (!moves.keepPile.isAllowed(board, pileId)) return;
     setInputs({ p1: '', p2: '' });
     setKeepId(prev => (prev === pileId ? null : pileId));
   };
@@ -90,7 +90,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
           return (
             <button
               key={pileId}
-              disabled={!moves.keepPile.isAllowed!(board, pileId)}
+              disabled={!moves.keepPile.isAllowed(board, pileId)}
               onClick={() => clickPile(pileId)}
               className={`
                 flex-1 max-w-32 rounded-lg border-2 p-3 sm:p-4 flex flex-col items-center gap-1

--- a/src/components/games/tictactoe-alikes/anti-tictactoe/anti-tictactoe.tsx
+++ b/src/components/games/tictactoe-alikes/anti-tictactoe/anti-tictactoe.tsx
@@ -23,7 +23,7 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
       {range(9).map(id => (
         <button
           key={id}
-          disabled={!moves.placePiece.isAllowed!(board, id)}
+          disabled={!moves.placePiece.isAllowed(board, id)}
           onClick={() => moves.placePiece(board, id)}
           className="aspect-square p-[25%] bg-surface-elevated"
         >

--- a/src/components/games/tictactoe-alikes/tictactoe-doublestart/tictactoe-doublestart.tsx
+++ b/src/components/games/tictactoe-alikes/tictactoe-doublestart/tictactoe-doublestart.tsx
@@ -23,7 +23,7 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
       {range(9).map(id => (
         <button
         key={id}
-        disabled={!moves.placePiece.isAllowed!(board, id)}
+        disabled={!moves.placePiece.isAllowed(board, id)}
         onClick={() => moves.placePiece(board, id)}
         className="aspect-square p-[25%] bg-surface-elevated"
         >

--- a/src/components/games/tictactoe-alikes/tictactoe/tictactoe.tsx
+++ b/src/components/games/tictactoe-alikes/tictactoe/tictactoe.tsx
@@ -18,8 +18,8 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
     }
   };
   const isMoveAllowed = (id) => gameIsInPlacingPhase
-    ? moves.placePiece.isAllowed!(board, id)
-    : moves.whitenPiece.isAllowed!(board, id);
+    ? moves.placePiece.isAllowed(board, id)
+    : moves.whitenPiece.isAllowed(board, id);
   const pieceColor = (id) => {
     const colorCode = board[id];
     if (colorCode === 'red') return 'bg-red-800';

--- a/src/components/games/totem-poles/triangular-grid-ropes-10/triangular-grid-ropes-10.tsx
+++ b/src/components/games/totem-poles/triangular-grid-ropes-10/triangular-grid-ropes-10.tsx
@@ -21,13 +21,13 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     } else if (node === firstNode) {
       setFirstNode(null);
     } else {
-      if (!moves.stretchRope.isAllowed!(board, { from: firstNode, to: node })) return;
+      if (!moves.stretchRope.isAllowed(board, { from: firstNode, to: node })) return;
       moves.stretchRope(board, { from: firstNode, to: node });
       setFirstNode(null);
     }
   };
 
-  const isCandidateAllowed = moves.stretchRope.isAllowed!(board, { from: firstNode, to: validHoveredNode });
+  const isCandidateAllowed = moves.stretchRope.isAllowed(board, { from: firstNode, to: validHoveredNode });
 
   const candidateEdge = getAllowedSuperset(board, { from: firstNode, to: validHoveredNode });
   const candidateFromV = candidateEdge ? vertices[candidateEdge.from] : null;
@@ -68,7 +68,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
       const isClickable = ctx.isClientMoveAllowed && (
         firstNode === null ||
         vertex.id === firstNode ||
-        moves.stretchRope.isAllowed!(board, { from: firstNode, to: vertex.id })
+        moves.stretchRope.isAllowed(board, { from: firstNode, to: vertex.id })
       );
       const isInvalidHover = firstNode !== null &&
         vertex.id === validHoveredNode &&

--- a/src/components/games/totem-poles/triangular-grid-ropes-15/triangular-grid-ropes-15.tsx
+++ b/src/components/games/totem-poles/triangular-grid-ropes-15/triangular-grid-ropes-15.tsx
@@ -21,13 +21,13 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     } else if (node === firstNode) {
       setFirstNode(null);
     } else {
-      if (!moves.stretchRope.isAllowed!(board, { from: firstNode, to: node })) return;
+      if (!moves.stretchRope.isAllowed(board, { from: firstNode, to: node })) return;
       moves.stretchRope(board, { from: firstNode, to: node });
       setFirstNode(null);
     }
   };
 
-  const isCandidateAllowed = moves.stretchRope.isAllowed!(board, { from: firstNode, to: validHoveredNode });
+  const isCandidateAllowed = moves.stretchRope.isAllowed(board, { from: firstNode, to: validHoveredNode });
 
   const candidateEdge = getAllowedSuperset(board, { from: firstNode, to: validHoveredNode });
   const candidateFromV = candidateEdge ? vertices[candidateEdge.from] : null;
@@ -68,7 +68,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
       const isClickable = ctx.isClientMoveAllowed && (
         firstNode === null ||
         vertex.id === firstNode ||
-        moves.stretchRope.isAllowed!(board, { from: firstNode, to: vertex.id })
+        moves.stretchRope.isAllowed(board, { from: firstNode, to: vertex.id })
       );
       const isInvalidHover = firstNode !== null &&
         vertex.id === validHoveredNode &&

--- a/src/components/games/triangle-circle-game/board-client.tsx
+++ b/src/components/games/triangle-circle-game/board-client.tsx
@@ -26,7 +26,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     setHoveredEdge(null);
   }, [ctx.moveCount]);
 
-  const triangleClickable = (t: number) => moves.placeCircle.isAllowed!(board, t);
+  const triangleClickable = (t: number) => moves.placeCircle.isAllowed(board, t);
 
   const triangleClass = (t: number) => {
     if (board.circles[t]) return 'fill-slate-900/5 dark:fill-white/5';
@@ -124,7 +124,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
         {/* Invisible wide hit targets for edges — only on the line player's turn,
             where the move's own validator is what makes the list non-empty. */}
         <g>
-          {EDGES.filter(edge => moves.shadeEdge.isAllowed!(board, edge.id)).map(edge => (
+          {EDGES.filter(edge => moves.shadeEdge.isAllowed(board, edge.id)).map(edge => (
             <line
               key={`hit-${edge.id}`}
               x1={edge.x1} y1={edge.y1} x2={edge.x2} y2={edge.y2}

--- a/src/components/games/triangle-coloring/triangle-coloring.tsx
+++ b/src/components/games/triangle-coloring/triangle-coloring.tsx
@@ -66,7 +66,7 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
     return `${v0.cx},${v0.cy} ${v1.cx},${v1.cy} ${v2.cx},${v2.cy}`
   }
 
-  const isClickable = i => moves.colorTriangle.isAllowed!(board, i);
+  const isClickable = i => moves.colorTriangle.isAllowed(board, i);
 
   const colorTriangle = i => moves.colorTriangle(board, i);
 

--- a/src/components/games/twelve-squares/twelve-squares.tsx
+++ b/src/components/games/twelve-squares/twelve-squares.tsx
@@ -22,7 +22,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const cellBackground = (i) => {
     if (i === board.left) return 'bg-green-400';
     if (i === board.right) return 'bg-purple-400';
-    if (moves.step.isAllowed!(board, potentialStep(i))) {
+    if (moves.step.isAllowed(board, potentialStep(i))) {
       return ctx.currentPlayer === 0
         ? 'bg-green-200 dark:bg-green-700 enabled:hocus:bg-green-400 dark:enabled:hocus:bg-green-600'
         : 'bg-purple-200 dark:bg-purple-700 enabled:hocus:bg-purple-400 dark:enabled:hocus:bg-purple-600';
@@ -41,7 +41,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
               w-full aspect-square text-xl font-bold rounded-sm drop-shadow-sm p-[10%]
               ${cellBackground(i)}
             `}
-            disabled={!moves.step.isAllowed!(board, potentialStep(i))}
+            disabled={!moves.step.isAllowed(board, potentialStep(i))}
             onClick={() => moves.step(board, potentialStep(i))}
           >{ i === board.left || i === board.right
             ? <svg className="w-full aspect-square">

--- a/src/components/strategy-game-factory/index.ts
+++ b/src/components/strategy-game-factory/index.ts
@@ -1,7 +1,7 @@
 export { strategyGameFactory } from './strategy-game-factory';
 export type { Presentation, StrategyGameConfig } from './strategy-game-factory';
 export type {
-  Phase, Mode, Ctx, Events,
+  Phase, Mode, Ctx,
   MoveOutcome, MoveFunction, MoveDefinition, Gameplay, GameMoves, ClientGameMoves,
   StrategyArgs, BoardClientProps,
   Variant, VariantInput

--- a/src/components/strategy-game-factory/index.ts
+++ b/src/components/strategy-game-factory/index.ts
@@ -2,7 +2,7 @@ export { strategyGameFactory } from './strategy-game-factory';
 export type { Presentation, StrategyGameConfig } from './strategy-game-factory';
 export type {
   Phase, Mode, Ctx, Events,
-  MoveOutcome, PureMoveFunction, MoveDefinition, Gameplay, GameMoves,
+  MoveOutcome, MoveFunction, MoveDefinition, Gameplay, GameMoves, ClientGameMoves,
   StrategyArgs, BoardClientProps,
   Variant, VariantInput
 } from './types';

--- a/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
@@ -867,6 +867,29 @@ describe('outcome-returning moves (apply)', () => {
       expect(getByTestId('board').textContent).toBe('initial');
       expect(getByTestId('ts').textContent).toBe('null');
     });
+
+    // The BoardClient's own path to turnState, next to the move-returned one
+    // above. It must not count as a move: an undo taken right after it has to
+    // find no snapshot to restore.
+    it('the setTurnState prop writes turnState without registering a move', () => {
+      const { getByTestId } = renderGame(makeConfig({
+        BoardClient: ({ ctx, setTurnState }: BoardClientProps<Board>) => (
+          <>
+            <button data-testid="select-btn" onClick={() => setTurnState({ pile: 2 })}>select</button>
+            <button data-testid="deselect-btn" onClick={() => setTurnState(null)}>deselect</button>
+            <span data-testid="ts">{JSON.stringify(ctx.turnState)}</span>
+            <span data-testid="moves">{ctx.moveCount}</span>
+          </>
+        )
+      }));
+      fireEvent.click(getByTestId('role-btn-0'));
+      fireEvent.click(getByTestId('select-btn'));
+      expect(getByTestId('ts').textContent).toBe('{"pile":2}');
+      expect(getByTestId('moves').textContent).toBe('0');
+      expect((getByTestId('undo-btn') as HTMLButtonElement).disabled).toBe(true);
+      fireEvent.click(getByTestId('deselect-btn'));
+      expect(getByTestId('ts').textContent).toBe('null');
+    });
   });
 
   // These two tests pin what the external store fixed: validators and chained

--- a/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
@@ -508,8 +508,8 @@ describe('move validate enforcement', () => {
         <button data-testid="illegal-btn" onClick={() => moves.guarded(board, 'bad')}>illegal</button>
         <button data-testid="hand-over-btn" onClick={() => moves.handOver(board)}>hand over</button>
         <span data-testid="board">{board.join(',')}</span>
-        <span data-testid="can-ok">{String(moves.guarded.isAllowed!(board, 'ok'))}</span>
-        <span data-testid="can-bad">{String(moves.guarded.isAllowed!(board, 'bad'))}</span>
+        <span data-testid="can-ok">{String(moves.guarded.isAllowed(board, 'ok'))}</span>
+        <span data-testid="can-bad">{String(moves.guarded.isAllowed(board, 'bad'))}</span>
       </>
     ),
     gameplay: {
@@ -576,6 +576,24 @@ describe('move validate enforcement', () => {
     fireEvent.click(getByTestId('role-btn-0'));
     expect(getByTestId('can-ok').textContent).toBe('true');
     expect(getByTestId('can-bad').textContent).toBe('false');
+  });
+
+  // The bot's wrapping deliberately omits isAllowed (it would be false all
+  // through the bot's turn), which is what lets ClientGameMoves type it as
+  // required and BoardClients call it without a non-null assertion.
+  it('does not expose isAllowed on the moves a bot receives', () => {
+    vi.useFakeTimers();
+    try {
+      const botStrategy = vi.fn();
+      const { getByTestId } = renderGame(guardedConfig(botStrategy));
+      fireEvent.click(getByTestId('role-btn-0'));
+      fireEvent.click(getByTestId('hand-over-btn')); // → bot's turn
+      act(() => { vi.advanceTimersByTime(1500); });
+      expect(botStrategy.mock.calls[0]![0].moves.guarded.isAllowed).toBeUndefined();
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
   });
 
   it('dispatches a move with no validator unconditionally', () => {

--- a/src/components/strategy-game-factory/strategy-game-factory.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.tsx
@@ -10,7 +10,7 @@ import { useLocation } from 'react-router';
 import { useGameStats } from './hooks/use-game-stats';
 import { trackEvent } from '../../tracking';
 import type {
-  Mode, Ctx, Events, MoveOutcome, Gameplay, GameMoves,
+  Mode, Ctx, Events, MoveOutcome, Gameplay, GameMoves, ClientGameMoves,
   BoardClientProps, Variant as DisplayVariant, VariantInput
 } from './types';
 import { resolveVariants } from './helpers/resolve-variants';
@@ -225,17 +225,19 @@ export const strategyGameFactory = <TBoard,>({
     // Bots and the auto `endOfTurnMove` dispatch use `wrappedGameMoves` instead:
     // there an illegal move is a bug, and the validator fails loudly (see
     // `reportIllegalMove`).
-    const clientGameMoves: GameMoves<TBoard> = mapValues(moves, ({ validate }, name) => {
+    const clientGameMoves: ClientGameMoves<TBoard> = mapValues(moves, ({ validate }, name) => {
       const isAllowed = (moveBoard: TBoard, ...args: unknown[]) => {
         const liveCtx = buildCtx(store.getState(), resolvedPlayerNames);
         return liveCtx.isClientMoveAllowed
           && (!validate || validate(moveBoard, { ctx: liveCtx }, ...args));
       };
-      const clientWrapped: GameMoves<TBoard>[string] = (moveBoard: TBoard, ...args: unknown[]) =>
-        isAllowed(moveBoard, ...args)
-          ? wrappedGameMoves[name]!(moveBoard, ...args)
-          : { nextBoard: moveBoard };
-      clientWrapped.isAllowed = isAllowed;
+      const clientWrapped: ClientGameMoves<TBoard>[string] = Object.assign(
+        (moveBoard: TBoard, ...args: unknown[]) =>
+          isAllowed(moveBoard, ...args)
+            ? wrappedGameMoves[name]!(moveBoard, ...args)
+            : { nextBoard: moveBoard },
+        { isAllowed }
+      );
       return clientWrapped;
     });
 

--- a/src/components/strategy-game-factory/strategy-game-factory.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.tsx
@@ -10,7 +10,7 @@ import { useLocation } from 'react-router';
 import { useGameStats } from './hooks/use-game-stats';
 import { trackEvent } from '../../tracking';
 import type {
-  Mode, Ctx, Events, MoveOutcome, Gameplay, GameMoves, ClientGameMoves,
+  Mode, Ctx, MoveOutcome, Gameplay, GameMoves, ClientGameMoves,
   BoardClientProps, Variant as DisplayVariant, VariantInput
 } from './types';
 import { resolveVariants } from './helpers/resolve-variants';
@@ -203,12 +203,10 @@ export const strategyGameFactory = <TBoard,>({
 
     const ctx: Ctx = buildCtx(state, resolvedPlayerNames);
 
-    // For the BoardClient's mid-turn UI state. Moves never see this object;
-    // they return `nextTurnState` instead.
-    const events: Events = {
-      setTurnState: (turnState) => {
-        store.setState({ turnState });
-      }
+    // For the BoardClient's mid-turn UI state. Moves never get this; they
+    // return `nextTurnState` instead.
+    const setTurnState = (turnState: unknown) => {
+      store.setState({ turnState });
     };
 
     wrappedGameMoves = mapValues(moves, (_def, name) => {
@@ -266,7 +264,7 @@ export const strategyGameFactory = <TBoard,>({
               key={gameUuid}
               board={board}
               ctx={ctx}
-              events={events}
+              setTurnState={setTurnState}
               moves={clientGameMoves}
             />
             <GameSidebar

--- a/src/components/strategy-game-factory/types.ts
+++ b/src/components/strategy-game-factory/types.ts
@@ -31,8 +31,8 @@ export type MoveOutcome<TBoard> = {
   isTurnEnd?: boolean
   // undefined = turnState unchanged; null = cleared; anything else = new value.
   nextTurnState?: unknown
-  // Terminal: the game is over. The winner is always explicit — there is no
-  // "omitted = mover wins" shorthand in this contract.
+  // Terminal: the game is over, naming the winner explicitly (use
+  // `ctx.currentPlayer!` when the mover wins).
   gameEnd?: { winnerIndex: number }
   // Schedule gameplay.endOfTurnMove after a delay. Ignored when `gameEnd` is
   // present (contradiction; throws in dev).
@@ -41,7 +41,7 @@ export type MoveOutcome<TBoard> = {
 // A move is a pure reducer: board in, outcome out. It gets no `events`, so
 // purity is enforced by the type system rather than by convention — which is
 // what lets the same function run in a future authoritative server.
-export type PureMoveFunction<TBoard> = (
+export type MoveFunction<TBoard> = (
   board: TBoard, meta: { ctx: Ctx }, ...args: any[]
 ) => MoveOutcome<TBoard>
 // Pure, side-effect-free legality predicate for a single move, colocated with
@@ -52,7 +52,7 @@ type MoveValidator<TBoard> = (
   board: TBoard, meta: { ctx: Ctx }, ...args: any[]
 ) => boolean
 export type MoveDefinition<TBoard> = {
-  apply: PureMoveFunction<TBoard>
+  apply: MoveFunction<TBoard>
   validate?: MoveValidator<TBoard>
 }
 export interface Gameplay<TBoard> {
@@ -60,21 +60,29 @@ export interface Gameplay<TBoard> {
   // move name auto-executed (after a delay) following moves returning autoEndOfTurn: true
   endOfTurnMove?: string
 }
-// Engine-wrapped moves as seen by BoardClient and bots: callable to dispatch.
-// The BoardClient's copy exposes `isAllowed(board, ...args)` on every move —
-// `ctx.isClientMoveAllowed` (turn ownership) AND the move's `validate`, with
-// `ctx` already bound — which is what its `disabled` state should ask; the
-// same check silently gates every client dispatch, so handlers need no
-// `if (!allowed) return` guards. Not for bots: their copy carries no
-// `isAllowed` (during the bot's turn `isClientMoveAllowed` is false), so bots
-// use the raw `validate`/helpers to enumerate legal moves.
+// Engine-wrapped moves, callable to dispatch. This is the bot's view: a bot
+// enumerates legal moves through the raw `validate`/its own helpers, because
+// `isAllowed` would be false throughout its turn anyway (see below).
 export type GameMoves<TBoard> = Record<
   string,
+  (board: TBoard, ...args: any[]) => MoveOutcome<TBoard>
+>
+// The BoardClient's view: the same dispatchers, plus `isAllowed(board, ...args)`
+// on every move — `ctx.isClientMoveAllowed` (turn ownership) AND the move's
+// `validate`, with `ctx` already bound. That is what a `disabled` state should
+// ask; the same check silently gates every client dispatch, so handlers need no
+// `if (!allowed) return` guards. Assignable to GameMoves, so helpers shared with
+// a bot keep taking the wider type.
+export type ClientGameMoves<TBoard> = Record<
+  string,
   ((board: TBoard, ...args: any[]) => MoveOutcome<TBoard>)
-    & { isAllowed?: (board: TBoard, ...args: any[]) => boolean }
+    & { isAllowed: (board: TBoard, ...args: any[]) => boolean }
 >
 export type StrategyArgs<TBoard> = { board: TBoard; ctx: Ctx; moves: GameMoves<TBoard> }
-export type BoardClientProps<TBoard> = StrategyArgs<TBoard> & { events: Events }
+export type BoardClientProps<TBoard> = Omit<StrategyArgs<TBoard>, 'moves'> & {
+  moves: ClientGameMoves<TBoard>
+  events: Events
+}
 
 export interface Variant {
   originalIndex: number

--- a/src/components/strategy-game-factory/types.ts
+++ b/src/components/strategy-game-factory/types.ts
@@ -15,13 +15,6 @@ export interface Ctx {
   moveCount: number
 }
 
-// Mid-turn UI state a BoardClient needs to remember (which pile is selected,
-// which slot is being edited). Moves never see this: they express turn state
-// through `nextTurnState` in their returned MoveOutcome.
-export interface Events {
-  setTurnState: (state: unknown) => void
-}
-
 // Everything a move can cause, expressed as data: the engine interprets what
 // the move returns, so a move never reaches out and changes anything itself.
 export type MoveOutcome<TBoard> = {
@@ -38,9 +31,10 @@ export type MoveOutcome<TBoard> = {
   // present (contradiction; throws in dev).
   autoEndOfTurn?: boolean
 }
-// A move is a pure reducer: board in, outcome out. It gets no `events`, so
-// purity is enforced by the type system rather than by convention — which is
-// what lets the same function run in a future authoritative server.
+// A move is a pure reducer: board in, outcome out. It is handed nothing it
+// could cause an effect through, so purity is enforced by the type system
+// rather than by convention — which is what lets the same function run in a
+// future authoritative server.
 export type MoveFunction<TBoard> = (
   board: TBoard, meta: { ctx: Ctx }, ...args: any[]
 ) => MoveOutcome<TBoard>
@@ -81,7 +75,12 @@ export type ClientGameMoves<TBoard> = Record<
 export type StrategyArgs<TBoard> = { board: TBoard; ctx: Ctx; moves: GameMoves<TBoard> }
 export type BoardClientProps<TBoard> = Omit<StrategyArgs<TBoard>, 'moves'> & {
   moves: ClientGameMoves<TBoard>
-  events: Events
+  // Writes the mid-turn UI state a BoardClient needs to remember (which pile is
+  // selected, which slot is being edited), read back as `ctx.turnState`. The one
+  // path that writes engine state without going through a move: a selection is
+  // not a move, so it must not bump `moveCount` or take an undo snapshot. Moves
+  // never get this — they return `nextTurnState` in their MoveOutcome instead.
+  setTurnState: (state: unknown) => void
 }
 
 export interface Variant {


### PR DESCRIPTION
## Summary

This PR refactors the `BoardClientProps` interface to replace the `Events` object with a direct `setTurnState` function prop. The change simplifies the API surface while maintaining the same functionality and improving type safety for move dispatchers.

## Key Changes

- **Removed `Events` interface** from `types.ts` — it only contained `setTurnState`, which is now passed directly as a prop
- **Renamed `PureMoveFunction` to `MoveFunction`** for clarity and updated its documentation to emphasize that moves receive nothing they could cause effects through
- **Split move types into two variants**:
  - `GameMoves<TBoard>`: Bot's view — dispatchers only, no `isAllowed` (since it would be false during bot's turn)
  - `ClientGameMoves<TBoard>`: BoardClient's view — dispatchers with required `isAllowed` method, eliminating the need for non-null assertions (`!`)
- **Updated `BoardClientProps<TBoard>`** to:
  - Accept `setTurnState` as a direct prop instead of via `events`
  - Use `ClientGameMoves` for the `moves` prop (with guaranteed `isAllowed`)
  - Added documentation explaining that `setTurnState` is the one path that writes engine state without going through a move
- **Updated `StrategyArgs<TBoard>`** to use the wider `GameMoves` type for bot compatibility
- **Removed non-null assertions** (`!`) from all `isAllowed` calls throughout the codebase, since the type system now guarantees its presence in `ClientGameMoves`
- **Updated documentation** in `AGENTS.md`, `README.md`, and `real-competitions-plan.md` to reflect the new API and clarify the purity constraints on moves

## Implementation Details

- The refactoring maintains backward compatibility in behavior while improving type safety
- Bots receive unwrapped `GameMoves` (no `isAllowed`), while BoardClients receive `ClientGameMoves` (with `isAllowed` guaranteed)
- Added test coverage for the new behavior, including verification that bots don't receive `isAllowed` and that `setTurnState` doesn't register as a move
- All 50+ game files updated to use the new prop name and remove non-null assertions

https://claude.ai/code/session_01FMtkvckMGGPi4tHh9CYoDm