### PR TITLE
Pin every game's bots to its own move names

### DIFF
--- a/.claude/commands/new-game.md
+++ b/.claude/commands/new-game.md
@@ -51,7 +51,7 @@ Create `src/components/games/<game-name>/<game-name>.tsx`. Follow the `strategyG
 - `getPlayerStepDescription` should make it obvious what the current player should do
 - For user-facing text referring to the other participant, prefer "other player" / "másik játékos" over "opponent" / "ellenfél" — the latter reads as too harsh, especially in Hungarian
 - A `botStrategy` is a pure function of the position: it *names* the move it wants — `({ board, ctx }) => ({ move, args })` — rather than playing it, and never schedules anything. When a turn is one decision made of several moves, name them all (`({ board, ctx }) => [{ move, args }, …]`); the engine plays them out with a pause between them so the bot appears to think. Naming only the first move is equally fine: while the turn is still the bot's, the engine asks again with the updated `board`/`ctx`
-- Pin the move names to the game's own moves so a typo is a typecheck error rather than a runtime one: `type Bot = BotStrategy<Board, keyof typeof moves>` with `import type { Board, moves } from './helpers'` (see `remove-row-or-column`)
+- Pin the move names to the game's own moves, as every game does, so a typo is a typecheck error rather than a runtime one: `type MoveName = keyof typeof moves` and `type Bot = BotStrategy<Board, MoveName>`, with `moves` imported as a type (see `chess-knight`)
 - Pull `name`, `title`, `credit` from `gameList` rather than hardcoding them
 
 ### 5. Re-export the component from `src/components/games/index.ts`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,20 +164,22 @@ headless match — and asks the strategy again while the turn is still its own.
 Naming a move after the turn ended is a bug (dev: throw); naming moves the
 game-winning move made moot is fine (they are dropped).
 
-`BotMove.move` is a plain string by default, so a mistyped name only surfaces
-when the bot plays it (dev: throw, naming the move names the game does have).
-Have the compiler catch it instead by pinning the union to the game's own moves
-— worth it wherever the game exports them:
+`BotMove.move` is a string, so a mistyped name would only surface when the bot
+plays it (dev: throw, naming the move names the game does have). Every game
+therefore pins the union to its own moves, which turns a typo into a typecheck
+error — follow suit in a new game:
 
 ```ts
 import type { Board, moves } from './helpers';
-type Bot = BotStrategy<Board, keyof typeof moves>;
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 export const smartBotStrategy: Bot = ({ board }) => ({ move: 'removeLine', args: [choice] });
 ```
 
-See `remove-row-or-column` and `coins-in-3-piles` (whose `asTurn` helper returns
-`BotMove<MoveName>[]`).
+A helper that builds the moves narrows with them: `BotMove<MoveName>[]` (see
+`coins-in-3-piles`'s `asTurn`).
 
 **`ctx`** fields available in moves and `BoardClient`:
 - `currentPlayer`: 0/1 — use this for game logic in both modes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,14 +178,14 @@ error — follow suit in a new game:
 ```ts
 import type { Board, moves } from './helpers';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 export const smartBotStrategy: Bot = ({ board }) => ({ move: 'removeLine', args: [choice] });
 ```
 
-A helper that builds the moves narrows with them: `BotMove<MoveName>[]` (see
-`coins-in-3-piles`'s `asTurn`).
+Give the union its own `type MoveName = keyof typeof moves` alias only where
+something else names it too — a helper that builds a turn's moves returns
+`BotMove<MoveName>[]` (see `coins-in-3-piles`'s `asTurn`).
 
 **`ctx`** fields available in moves and `BoardClient`:
 - `currentPlayer`: 0/1 — use this for game logic in both modes

--- a/README.md
+++ b/README.md
@@ -318,13 +318,16 @@ If the named moves leave the turn unfinished, the bot is simply asked again with
 the updated `board` and `ctx`, so naming one move at a time is equally fine —
 see `magic-box` (named as a whole) and `take-and-point` (asked again).
 
-A move name is a string, so by default a typo is caught only when the bot plays
-it (in development the engine throws, listing the move names the game does
-have). Pin the names to the game's own moves to get a typecheck error instead:
+A move name is a string, so a typo would be caught only when the bot plays it
+(in development the engine throws, listing the move names the game does have).
+Every game pins the names to its own moves, which makes a typo a typecheck
+error instead:
 
 ```ts
 import type { Board, moves } from './helpers';
-type Bot = BotStrategy<Board, keyof typeof moves>;
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 export const smartBotStrategy: Bot = ({ board }) =>
   ({ move: 'removeLine', args: [chooseLine(board)] });

--- a/src/components/games/add-reduce-double/bot-strategy.ts
+++ b/src/components/games/add-reduce-double/bot-strategy.ts
@@ -1,8 +1,11 @@
 import { random, sample, range } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
-import type { Board } from './add-reduce-double';
+import type { Board, moves } from './add-reduce-double';
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+export const randomBotStrategy: Bot = ({ board }) => {
   const validMoves: { pileId: number; pieceCount: number }[] = [];
   for (const pileId of [0, 1]) {
     for (const pieceCount of range(2, board[pileId] + 1, 2)) {
@@ -26,5 +29,5 @@ export const getSmartBotStep = (board: Board): { pileId: number; pieceCount: num
   return { pileId, pieceCount };
 };
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board }) =>
+export const smartBotStrategy: Bot = ({ board }) =>
   ({ move: 'moveHalvedPieces', args: [getSmartBotStep(board)] });

--- a/src/components/games/add-reduce-double/bot-strategy.ts
+++ b/src/components/games/add-reduce-double/bot-strategy.ts
@@ -2,8 +2,7 @@ import { random, sample, range } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
 import type { Board, moves } from './add-reduce-double';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 export const randomBotStrategy: Bot = ({ board }) => {
   const validMoves: { pileId: number; pieceCount: number }[] = [];

--- a/src/components/games/amor-and-cupido/bot-strategy.ts
+++ b/src/components/games/amor-and-cupido/bot-strategy.ts
@@ -5,8 +5,7 @@ import {
 } from './helpers';
 import type { moves } from './amor-and-cupido';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 // Game value of a position, memoised by canonical (isomorphism-reduced) key.
 // Shared across calls/tests: the value depends only on the position and who is

--- a/src/components/games/amor-and-cupido/bot-strategy.ts
+++ b/src/components/games/amor-and-cupido/bot-strategy.ts
@@ -3,6 +3,10 @@ import type { BotStrategy } from '../../strategy-game-factory';
 import {
   type Board, getAllowedMoves, completesTriangle, canonicalKey
 } from './helpers';
+import type { moves } from './amor-and-cupido';
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 // Game value of a position, memoised by canonical (isomorphism-reduced) key.
 // Shared across calls/tests: the value depends only on the position and who is
@@ -39,7 +43,7 @@ const negamax = (board: Board, toMove: number): number => {
 
 export const getBotScore = (board: Board, toMove: number): number => negamax(board, toMove);
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const smartBotStrategy: Bot = ({ board, ctx }) => {
   const me = ctx.currentPlayer!;
   const empties = getAllowedMoves(board);
 

--- a/src/components/games/architect-and-bandits/architect-and-bandits-a/bot-strategy.ts
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-a/bot-strategy.ts
@@ -1,6 +1,10 @@
 import { maxBy } from 'lodash';
 import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
 import type { Board } from '../helpers';
+import type { moves } from './architect-and-bandits-a';
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 // Vertices A(0)..H(7) clockwise. Each edge = 10 km, max 4 edges/day.
 // Architect wins by visiting all 8 vertices over 4 days despite 3 nightly destructions.
@@ -15,7 +19,7 @@ import type { Board } from '../helpers';
 //   Day 3: rebuild remaining missing towers from night 2, position for day 4
 //   Day 4: visit any towers destroyed on night 3 (always reachable ≤ 4 edges)
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const smartBotStrategy: Bot = ({ board, ctx }) => {
   if (ctx.currentPlayer === 0) {
     return asArchitectDay(getOptimalArchitectPath(board));
   }
@@ -24,8 +28,8 @@ export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
 
 // The architect's whole day is planned as one route (see the strategy above),
 // so its steps are named together, with the day closed at the end of them.
-const asArchitectDay = (path: number[]): BotMove[] => [
-  ...path.map(vertex => ({ move: 'moveArchitect', args: [vertex] })),
+const asArchitectDay = (path: number[]): BotMove<MoveName>[] => [
+  ...path.map((vertex): BotMove<MoveName> => ({ move: 'moveArchitect', args: [vertex] })),
   { move: 'endDay' }
 ];
 
@@ -106,7 +110,7 @@ export const getOptimalArchitectPath = (board: Board) => {
 // Bandit heuristic: pick the tower that maximises the
 // minimum path the architect needs to cover all missing+newly-destroyed vertices.
 // Destroying the architect's current position is excluded: startNextDay rebuilds it for free.
-const banditMove = (board: Board): BotMove => {
+const banditMove = (board: Board): BotMove<MoveName> => {
   const pos = board.architectPosition;
   const candidates = board.towers
     .map((t, i) => (t && i !== pos ? i : null))

--- a/src/components/games/architect-and-bandits/architect-and-bandits-b/bot-strategy.ts
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-b/bot-strategy.ts
@@ -1,6 +1,10 @@
 import { maxBy, sample } from 'lodash';
 import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
 import type { Board } from '../helpers';
+import type { moves } from './architect-and-bandits-b';
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 // Vertices A(0)..J(9) clockwise. Each edge = 10 km, max 5 edges/day.
 // Architect wins by visiting all 10 vertices over 4 days despite 3 nightly destructions.
@@ -15,7 +19,7 @@ import type { Board } from '../helpers';
 //   Day 3: cover remaining missing, position for day 4
 //   Day 4: visit any towers destroyed on night 3 (always reachable ≤5 edges)
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const smartBotStrategy: Bot = ({ board, ctx }) => {
   if (ctx.currentPlayer === 0) {
     return asArchitectDay(getOptimalArchitectPath(board));
   }
@@ -24,8 +28,8 @@ export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
 
 // The architect's whole day is planned as one route (see the strategy above),
 // so its steps are named together, with the day closed at the end of them.
-const asArchitectDay = (path: number[]): BotMove[] => [
-  ...path.map(vertex => ({ move: 'moveArchitect', args: [vertex] })),
+const asArchitectDay = (path: number[]): BotMove<MoveName>[] => [
+  ...path.map((vertex): BotMove<MoveName> => ({ move: 'moveArchitect', args: [vertex] })),
   { move: 'endDay' }
 ];
 
@@ -108,7 +112,7 @@ export const getOptimalArchitectPath = (board: Board) => {
 // Bandit heuristic: day 1 random; later days pick the tower that maximises the
 // minimum path the architect needs to cover all missing+newly-destroyed vertices.
 // Destroying the architect's current position is excluded: startNextDay rebuilds it for free.
-const banditMove = (board: Board): BotMove => {
+const banditMove = (board: Board): BotMove<MoveName> => {
   const pos = board.architectPosition;
   const candidates = board.towers
     .map((t, i) => (t && i !== pos ? i : null))

--- a/src/components/games/bacteria/bot-strategy.ts
+++ b/src/components/games/bacteria/bot-strategy.ts
@@ -13,8 +13,12 @@ import {
   isGoalCell,
   topRowIdx,
   ATTACKER,
-  DEFENDER
+  DEFENDER,
+  type moves
 } from "./helpers";
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 export type { AttackMove };
 
@@ -120,7 +124,7 @@ export const defenderMove = (board: Board): { row: number; col: number } => {
   return { row, col };
 };
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const smartBotStrategy: Bot = ({ board, ctx }) => {
   if (ctx.chosenRoleIndex === ATTACKER) {
     const { row, col } = defenderMove(board);
     return { move: 'defend', args: [{ row, col }] };
@@ -131,7 +135,7 @@ export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
 };
 
 // Test bot: plays randomly, but takes an immediate winning move when offered.
-export const randomBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const randomBotStrategy: Bot = ({ board, ctx }) => {
   const coords = bacteriaCoords(board);
 
   if (ctx.currentPlayer === DEFENDER) {

--- a/src/components/games/bacteria/bot-strategy.ts
+++ b/src/components/games/bacteria/bot-strategy.ts
@@ -17,8 +17,7 @@ import {
   type moves
 } from "./helpers";
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 export type { AttackMove };
 

--- a/src/components/games/bank-robbers/bank-robbers.tsx
+++ b/src/components/games/bank-robbers/bank-robbers.tsx
@@ -100,7 +100,10 @@ const getAllowedBanks = (board: Board) => {
   })
 }
 
-const randomBotStrategy: BotStrategy<Board> = ({ board }) =>
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'rob', args: [sample(getAllowedBanks(board))!] });
 
 const rule = {

--- a/src/components/games/bank-robbers/bank-robbers.tsx
+++ b/src/components/games/bank-robbers/bank-robbers.tsx
@@ -100,8 +100,7 @@ const getAllowedBanks = (board: Board) => {
   })
 }
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'rob', args: [sample(getAllowedBanks(board))!] });

--- a/src/components/games/bank-robbers/bot-strategy.ts
+++ b/src/components/games/bank-robbers/bot-strategy.ts
@@ -2,8 +2,7 @@ import { random, sample } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
 import type { Board, moves } from './bank-robbers';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 export const smartBotStrategy: Bot = ({ board }) => {
   let bankIndex = 0;

--- a/src/components/games/bank-robbers/bot-strategy.ts
+++ b/src/components/games/bank-robbers/bot-strategy.ts
@@ -1,8 +1,11 @@
 import { random, sample } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
-import type { Board } from './bank-robbers';
+import type { Board, moves } from './bank-robbers';
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+export const smartBotStrategy: Bot = ({ board }) => {
   let bankIndex = 0;
   if (board.lastMove === null) {
     bankIndex = random(board.circle.length - 1);

--- a/src/components/games/chess-bishops/bot-strategy.ts
+++ b/src/components/games/chess-bishops/bot-strategy.ts
@@ -1,16 +1,20 @@
 import { sample, cloneDeep, random, shuffle } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
 import { markForbiddenFields, getAllowedMoves, boardIndices, BISHOP, type Board, type Field } from './helpers';
+import type { moves } from './chess-bishops';
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 const HORIZONTAL = "h" as const;
 const VERTICAL = "v" as const;
 type Axis = typeof HORIZONTAL | typeof VERTICAL;
 let axis: Axis | null = null;
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) =>
+export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'placeBishop', args: [sample(getAllowedMoves(board))] });
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+export const smartBotStrategy: Bot = ({ board }) => {
   const botMove = getOptimalSmartBotMove(board);
   return { move: 'placeBishop', args: [botMove] };
 };

--- a/src/components/games/chess-bishops/bot-strategy.ts
+++ b/src/components/games/chess-bishops/bot-strategy.ts
@@ -3,8 +3,7 @@ import type { BotStrategy } from '../../strategy-game-factory';
 import { markForbiddenFields, getAllowedMoves, boardIndices, BISHOP, type Board, type Field } from './helpers';
 import type { moves } from './chess-bishops';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 const HORIZONTAL = "h" as const;
 const VERTICAL = "v" as const;

--- a/src/components/games/chess-ducks/bot-strategy.ts
+++ b/src/components/games/chess-ducks/bot-strategy.ts
@@ -1,15 +1,18 @@
-import { getBoardIndices, withDuckPlaced, getAllowedMoves, type Board, type Field } from "./helpers";
+import { getBoardIndices, withDuckPlaced, getAllowedMoves, type Board, type Field, type moves } from "./helpers";
 import { type BotStrategy } from "../../strategy-game-factory";
 import { shuffle, sample } from "lodash";
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 /* This strategy file is relevant for the 4x7 case */
 const [ROWS, COLS] = [4, 7];
 const [DUCK] = [1];
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) =>
+export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'placeDuck', args: [sample(getAllowedMoves(board))] });
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+export const smartBotStrategy: Bot = ({ board }) => {
   const botMove = getOptimalSmartBotMove(board);
   return { move: 'placeDuck', args: [botMove] };
 };

--- a/src/components/games/chess-ducks/bot-strategy.ts
+++ b/src/components/games/chess-ducks/bot-strategy.ts
@@ -2,8 +2,7 @@ import { getBoardIndices, withDuckPlaced, getAllowedMoves, type Board, type Fiel
 import { type BotStrategy } from "../../strategy-game-factory";
 import { shuffle, sample } from "lodash";
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 /* This strategy file is relevant for the 4x7 case */
 const [ROWS, COLS] = [4, 7];

--- a/src/components/games/chess-knight/bot-strategy.ts
+++ b/src/components/games/chess-knight/bot-strategy.ts
@@ -3,8 +3,7 @@ import type { BotStrategy } from '../../strategy-game-factory';
 import { getAllowedMoves, type Board, type Field } from './helpers';
 import type { moves } from './chess-knight';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'moveKnight', args: [sample(getAllowedMoves(board))] });

--- a/src/components/games/chess-knight/bot-strategy.ts
+++ b/src/components/games/chess-knight/bot-strategy.ts
@@ -1,11 +1,15 @@
 import { sample } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
 import { getAllowedMoves, type Board, type Field } from './helpers';
+import type { moves } from './chess-knight';
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) =>
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'moveKnight', args: [sample(getAllowedMoves(board))] });
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+export const smartBotStrategy: Bot = ({ board }) => {
   const botMove = getOptimalSmartBotMove(board);
   return { move: 'moveKnight', args: [botMove] };
 };

--- a/src/components/games/chess-rook/bot-strategy.ts
+++ b/src/components/games/chess-rook/bot-strategy.ts
@@ -1,11 +1,15 @@
 import { last, random, sample } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
 import { getAllowedMoves, type Board, type Field } from './helpers';
+import type { moves } from './chess-rook';
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) =>
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'moveRook', args: [sample(getAllowedMoves(board))] });
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+export const smartBotStrategy: Bot = ({ board }) => {
   const botMove = getOptimalSmartBotMove(board);
   return { move: 'moveRook', args: [botMove] };
 };

--- a/src/components/games/chess-rook/bot-strategy.ts
+++ b/src/components/games/chess-rook/bot-strategy.ts
@@ -3,8 +3,7 @@ import type { BotStrategy } from '../../strategy-game-factory';
 import { getAllowedMoves, type Board, type Field } from './helpers';
 import type { moves } from './chess-rook';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'moveRook', args: [sample(getAllowedMoves(board))] });

--- a/src/components/games/chocolate-breaking/bot-strategy.ts
+++ b/src/components/games/chocolate-breaking/bot-strategy.ts
@@ -1,6 +1,10 @@
 import { sample } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
 import { allMoves, applyBreak, totalGrundy, hasSafeBreak, type Board, type Move } from './helpers';
+import type { moves } from './chocolate-breaking';
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 const winningMoves = (board: Board): Move[] =>
   allMoves(board.pieces).filter(m => totalGrundy(applyBreak(board, m).pieces) === 0);
@@ -28,8 +32,8 @@ export const getRandomBotMove = (board: Board): Move => {
   return sample(immediateWins.length > 0 ? immediateWins : moves)!;
 };
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board }) =>
+export const smartBotStrategy: Bot = ({ board }) =>
   ({ move: 'breakPiece', args: [getSmartBotMove(board)] });
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) =>
+export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'breakPiece', args: [getRandomBotMove(board)] });

--- a/src/components/games/chocolate-breaking/bot-strategy.ts
+++ b/src/components/games/chocolate-breaking/bot-strategy.ts
@@ -3,8 +3,7 @@ import type { BotStrategy } from '../../strategy-game-factory';
 import { allMoves, applyBreak, totalGrundy, hasSafeBreak, type Board, type Move } from './helpers';
 import type { moves } from './chocolate-breaking';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 const winningMoves = (board: Board): Move[] =>
   allMoves(board.pieces).filter(m => totalGrundy(applyBreak(board, m).pieces) === 0);

--- a/src/components/games/coins-in-3-piles/bot-strategy.ts
+++ b/src/components/games/coins-in-3-piles/bot-strategy.ts
@@ -2,7 +2,6 @@ import { findIndex, sample, range } from 'lodash';
 import type { BotMove, BotStrategy } from '../../strategy-game-factory';
 import type { Board, moves } from './helpers';
 
-// Naming the game's own move names makes a typo in a bot a typecheck error.
 type MoveName = keyof typeof moves
 type Bot = BotStrategy<Board, MoveName>
 

--- a/src/components/games/cube-coloring/bot-strategy.ts
+++ b/src/components/games/cube-coloring/bot-strategy.ts
@@ -1,8 +1,12 @@
 import { difference, range, shuffle, sample } from 'lodash';
 import { isAllowedStep, isColored, neighbours, colors, type Board } from './helpers';
 import type { BotStrategy } from '../../strategy-game-factory';
+import type { moves } from './cube-coloring';
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+export const randomBotStrategy: Bot = ({ board }) => {
   const validMoves: { vertex: number, color: string }[] = [];
   for (const vertex of range(0, 8)) {
     if (isColored(board, vertex)) continue;
@@ -15,7 +19,7 @@ export const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
   return { move: 'colorVertex', args: [sample(validMoves)] };
 };
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const smartBotStrategy: Bot = ({ board, ctx }) => {
   const { vertex, color } = ctx.chosenRoleIndex === 0
     ? makeOptimalStepAsSecond(board)!
     : makeOptimalStepAsFirst(board);

--- a/src/components/games/cube-coloring/bot-strategy.ts
+++ b/src/components/games/cube-coloring/bot-strategy.ts
@@ -3,8 +3,7 @@ import { isAllowedStep, isColored, neighbours, colors, type Board } from './help
 import type { BotStrategy } from '../../strategy-game-factory';
 import type { moves } from './cube-coloring';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 export const randomBotStrategy: Bot = ({ board }) => {
   const validMoves: { vertex: number, color: string }[] = [];

--- a/src/components/games/digit-subtraction/digit-subtraction.tsx
+++ b/src/components/games/digit-subtraction/digit-subtraction.tsx
@@ -54,8 +54,7 @@ export const moves = {
   }
 };
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 const randomBotStrategy: Bot = ({ board }) => {
   const digits = uniqueNonZeroDigits(board);

--- a/src/components/games/digit-subtraction/digit-subtraction.tsx
+++ b/src/components/games/digit-subtraction/digit-subtraction.tsx
@@ -54,13 +54,16 @@ export const moves = {
   }
 };
 
-const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+const randomBotStrategy: Bot = ({ board }) => {
   const digits = uniqueNonZeroDigits(board);
   const winningDigits = digits.filter(d => board - d === 0);
   return { move: 'subtractDigit', args: [sample(winningDigits.length > 0 ? winningDigits : digits)!] };
 };
 
-const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+const smartBotStrategy: Bot = ({ board }) => {
   if (board % 10 !== 0) {
     return { move: 'subtractDigit', args: [board % 10] };
   } else {

--- a/src/components/games/discs-flip-or-remove/discs-flip-or-remove.tsx
+++ b/src/components/games/discs-flip-or-remove/discs-flip-or-remove.tsx
@@ -134,7 +134,10 @@ export const moves = {
   }
 };
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+export const smartBotStrategy: Bot = ({ board }) => {
   const rem = board[0] % 3;
   if (rem === 0) {
     const randomNonEmptyPile = sample(filter([0, 1], (i) => board[i] > 0))!;
@@ -154,8 +157,8 @@ export const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
   }
 };
 
-const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
-  const validMoves: BotMove[] = [];
+const randomBotStrategy: Bot = ({ board }) => {
+  const validMoves: BotMove<MoveName>[] = [];
   if (board[0] >= 1) validMoves.push({ move: 'removeDiscs', args: [1] });
   if (board[0] >= 2) validMoves.push({ move: 'removeDiscs', args: [2] });
   if (board[1] >= 1) validMoves.push({ move: 'turnDiscs', args: [1] });

--- a/src/components/games/distinct-squares/five-squares/bot-strategy.ts
+++ b/src/components/games/distinct-squares/five-squares/bot-strategy.ts
@@ -1,16 +1,19 @@
 import { sum, isEqual, sample, range } from 'lodash';
 import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
-import type { Board } from './five-squares';
+import type { Board, moves } from './five-squares';
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 // The second player places two squares per turn, chosen together (see
 // bestPairs), so the turn is named as a whole.
-const asTurn = (squares: (number | undefined)[]): BotMove[] =>
+const asTurn = (squares: (number | undefined)[]): BotMove<MoveName>[] =>
   squares.map(square => ({ move: 'addPiece', args: [square] }));
 
-export const randomBotStrategy: BotStrategy<Board> = ({ ctx }) =>
+export const randomBotStrategy: Bot = ({ ctx }) =>
   asTurn(ctx.currentPlayer === 1 ? [sample(range(5)), sample(range(5))] : [sample(range(5))]);
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const smartBotStrategy: Bot = ({ board, ctx }) => {
   const botPlayerIndex = ctx.currentPlayer!;
   if (botPlayerIndex === 1) {
     return asTurn(sample(bestPairs(board, botPlayerIndex))!);

--- a/src/components/games/distinct-squares/two-times-two/bot-strategy.ts
+++ b/src/components/games/distinct-squares/two-times-two/bot-strategy.ts
@@ -1,11 +1,14 @@
 import { sum, isEqual, sample, range } from 'lodash';
 import type { BotStrategy } from '../../../strategy-game-factory';
-import type { Board } from './two-times-two';
+import type { Board, moves } from './two-times-two';
 
-export const randomBotStrategy: BotStrategy<Board> = () =>
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+export const randomBotStrategy: Bot = () =>
   ({ move: 'addPiece', args: [sample(range(0, 4))] });
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const smartBotStrategy: Bot = ({ board, ctx }) => {
   const botPlayerIndex = ctx.currentPlayer!;
   const scores = range(0, 4).map(i => {
     const next = [...board] as Board;

--- a/src/components/games/distinct-squares/two-times-two/bot-strategy.ts
+++ b/src/components/games/distinct-squares/two-times-two/bot-strategy.ts
@@ -2,8 +2,7 @@ import { sum, isEqual, sample, range } from 'lodash';
 import type { BotStrategy } from '../../../strategy-game-factory';
 import type { Board, moves } from './two-times-two';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 export const randomBotStrategy: Bot = () =>
   ({ move: 'addPiece', args: [sample(range(0, 4))] });

--- a/src/components/games/dominoes-4x4/bot-strategy.ts
+++ b/src/components/games/dominoes-4x4/bot-strategy.ts
@@ -1,6 +1,9 @@
 import { sample } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
-import { type Board, type Domino, BOARDSIZE } from './dominoes-4x4';
+import { type Board, type Domino, BOARDSIZE, type moves } from './dominoes-4x4';
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 // This game is Domineering on a 4x4 board: player 0 (Árgyélus) only ever places
 // vertical dominoes, player 1 (Félix) only horizontal ones. It is a partizan game
@@ -65,7 +68,7 @@ const canWin = (mask: number, player: number): boolean => {
 export const isWinningForPlayerToMove = (board: Board, player: number): boolean =>
   canWin(boardToMask(board), player);
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const smartBotStrategy: Bot = ({ board, ctx }) => {
   const player = ctx.currentPlayer!;
   const mask = boardToMask(board);
   const candidates = movesForPlayer(mask, player);
@@ -94,7 +97,7 @@ export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
 
 // Test bot: plays randomly, but grabs an immediate win (a move after which the other
 // player has no legal placement) whenever one is available.
-export const randomBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const randomBotStrategy: Bot = ({ board, ctx }) => {
   const player = ctx.currentPlayer!;
   const mask = boardToMask(board);
   const candidates = movesForPlayer(mask, player);

--- a/src/components/games/dominoes-4x4/bot-strategy.ts
+++ b/src/components/games/dominoes-4x4/bot-strategy.ts
@@ -2,8 +2,7 @@ import { sample } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
 import { type Board, type Domino, BOARDSIZE, type moves } from './dominoes-4x4';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 // This game is Domineering on a 4x4 board: player 0 (Árgyélus) only ever places
 // vertical dominoes, player 1 (Félix) only horizontal ones. It is a partizan game

--- a/src/components/games/dominoes-on-chessboard/bot-strategy.ts
+++ b/src/components/games/dominoes-on-chessboard/bot-strategy.ts
@@ -4,8 +4,7 @@ import {
   type Board, type Domino, type Field, type moves, ALL_FIELDS, BOARDSIZE, getPossibleMoves
 } from './dominoes-on-chessboard';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'placeDomino', args: [sample(getPossibleMoves(board))] });

--- a/src/components/games/dominoes-on-chessboard/bot-strategy.ts
+++ b/src/components/games/dominoes-on-chessboard/bot-strategy.ts
@@ -1,13 +1,18 @@
 import { sample, last } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
-import { type Board, type Domino, type Field, ALL_FIELDS, BOARDSIZE, getPossibleMoves } from './dominoes-on-chessboard';
+import {
+  type Board, type Domino, type Field, type moves, ALL_FIELDS, BOARDSIZE, getPossibleMoves
+} from './dominoes-on-chessboard';
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) =>
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'placeDomino', args: [sample(getPossibleMoves(board))] });
 
 const mirror = ({ row, col }: Field): Field => ({ row: BOARDSIZE - 1 - row, col: BOARDSIZE - 1 - col });
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const smartBotStrategy: Bot = ({ board, ctx }) => {
   if (ctx.chosenRoleIndex === 0) {
     // Bot plays second: mirroring the opponent's last move through the board's center
     // is unconditionally optimal on this even-sized board (no cell maps to itself), so

--- a/src/components/games/five-connected-fields/bot-strategy.ts
+++ b/src/components/games/five-connected-fields/bot-strategy.ts
@@ -1,6 +1,10 @@
 import { sample } from "lodash";
 import { type BotStrategy } from "../../strategy-game-factory";
 import { type Board, legalNodes } from "./helpers";
+import type { moves } from './five-connected-fields';
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 // Every move raises the total coin count by exactly 1, so the game is a
 // strictly monotonic DAG: it always terminates and can be solved exactly by a
@@ -43,5 +47,5 @@ export const getBotMove = (board: Board): number => {
   return sample(nodes.filter((node) => trapCount(node) === fewestReplies))!;
 };
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board }) =>
+export const smartBotStrategy: Bot = ({ board }) =>
   ({ move: 'placeCoin', args: [getBotMove(board)] });

--- a/src/components/games/five-connected-fields/bot-strategy.ts
+++ b/src/components/games/five-connected-fields/bot-strategy.ts
@@ -3,8 +3,7 @@ import { type BotStrategy } from "../../strategy-game-factory";
 import { type Board, legalNodes } from "./helpers";
 import type { moves } from './five-connected-fields';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 // Every move raises the total coin count by exactly 1, so the game is a
 // strictly monotonic DAG: it always terminates and can be solved exactly by a

--- a/src/components/games/five-five-card/bot-strategy.ts
+++ b/src/components/games/five-five-card/bot-strategy.ts
@@ -2,8 +2,7 @@ import { sample, range } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
 import { type Board, getWinnerIndex, type moves } from './five-five-card';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 export const randomBotStrategy: Bot = ({ board, ctx }) => {
   const opponentIdx = ctx.chosenRoleIndex!;

--- a/src/components/games/five-five-card/bot-strategy.ts
+++ b/src/components/games/five-five-card/bot-strategy.ts
@@ -1,14 +1,17 @@
 import { sample, range } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
-import { type Board, getWinnerIndex } from './five-five-card';
+import { type Board, getWinnerIndex, type moves } from './five-five-card';
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+export const randomBotStrategy: Bot = ({ board, ctx }) => {
   const opponentIdx = ctx.chosenRoleIndex!;
   const validIds = range(1, 6).filter(id => board[opponentIdx][id - 1] !== null);
   return { move: 'removeCard', args: [sample(validIds)] };
 };
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const smartBotStrategy: Bot = ({ board, ctx }) => {
   const botPlayerIndex = ctx.currentPlayer!;
   const opponentIdx = 1 - botPlayerIndex;
 

--- a/src/components/games/four-connected-fields/bot-strategy.ts
+++ b/src/components/games/four-connected-fields/bot-strategy.ts
@@ -1,6 +1,10 @@
 import { sample } from "lodash";
 import { type BotStrategy } from "../../strategy-game-factory";
 import { type Board, legalNodes, hasAnyMove } from "./helpers";
+import type { moves } from './four-connected-fields';
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 // Every move raises the total coin count by exactly 1, so the game is a strictly
 // monotonic DAG: it always terminates and can be solved exactly by a memoized
@@ -36,7 +40,7 @@ const winningInOneMove = (board: Board): number[] =>
 
 // Test bot: plays a random legal move, but grabs an immediate one-move win if one
 // is available.
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
+export const randomBotStrategy: Bot = ({ board }) => {
   const instantWins = winningInOneMove(board);
   const node = instantWins.length > 0 ? sample(instantWins)! : sample(legalNodes(board))!;
   return { move: 'placeCoin', args: [node] };
@@ -56,5 +60,5 @@ export const getBotMove = (board: Board): number => {
   return sample(nodes.filter((node) => trapCount(node) === fewestReplies))!;
 };
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board }) =>
+export const smartBotStrategy: Bot = ({ board }) =>
   ({ move: 'placeCoin', args: [getBotMove(board)] });

--- a/src/components/games/four-connected-fields/bot-strategy.ts
+++ b/src/components/games/four-connected-fields/bot-strategy.ts
@@ -3,8 +3,7 @@ import { type BotStrategy } from "../../strategy-game-factory";
 import { type Board, legalNodes, hasAnyMove } from "./helpers";
 import type { moves } from './four-connected-fields';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 // Every move raises the total coin count by exactly 1, so the game is a strictly
 // monotonic DAG: it always terminates and can be solved exactly by a memoized

--- a/src/components/games/four-piles-spread-ahead/bot-strategy.ts
+++ b/src/components/games/four-piles-spread-ahead/bot-strategy.ts
@@ -2,8 +2,7 @@ import { random, sample, range } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
 import type { Board, moves } from './four-piles-spread-ahead';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 export const randomBotStrategy: Bot = ({ board }) => {
   const validMoves: { pileId: number; pieceCount: number }[] = [];

--- a/src/components/games/four-piles-spread-ahead/bot-strategy.ts
+++ b/src/components/games/four-piles-spread-ahead/bot-strategy.ts
@@ -1,8 +1,11 @@
 import { random, sample, range } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
-import type { Board } from './four-piles-spread-ahead';
+import type { Board, moves } from './four-piles-spread-ahead';
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+export const randomBotStrategy: Bot = ({ board }) => {
   const validMoves: { pileId: number; pieceCount: number }[] = [];
   for (const pileId of [1, 2, 3]) {
     for (const pieceCount of range(1, Math.min(pileId, board[pileId]) + 1)) {
@@ -12,7 +15,7 @@ export const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
   return { move: 'spreadPieces', args: [sample(validMoves)] };
 };
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+export const smartBotStrategy: Bot = ({ board }) => {
   const { pileId, pieceId } = getSmartBotStep(board);
   return { move: 'spreadPieces', args: [{ pileId, pieceCount: pieceId + 1 }] };
 };

--- a/src/components/games/four-piles-two-grabs/four-piles-two-grabs.tsx
+++ b/src/components/games/four-piles-two-grabs/four-piles-two-grabs.tsx
@@ -149,10 +149,13 @@ export const moves = {
   }
 };
 
-const smartBotStrategy: BotStrategy<Board> = ({ board }) =>
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+const smartBotStrategy: Bot = ({ board }) =>
   ({ move: 'takeStones', args: [getSmartBotMove(board)] });
 
-const randomBotStrategy: BotStrategy<Board> = ({ board }) =>
+const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'takeStones', args: [getRandomBotMove(board)] });
 
 const rule = {

--- a/src/components/games/four-piles-two-grabs/four-piles-two-grabs.tsx
+++ b/src/components/games/four-piles-two-grabs/four-piles-two-grabs.tsx
@@ -149,8 +149,7 @@ export const moves = {
   }
 };
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 const smartBotStrategy: Bot = ({ board }) =>
   ({ move: 'takeStones', args: [getSmartBotMove(board)] });

--- a/src/components/games/hunyadi-and-the-janissaries/bot-strategy.ts
+++ b/src/components/games/hunyadi-and-the-janissaries/bot-strategy.ts
@@ -1,8 +1,11 @@
 import { random } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
-import { SULTAN, type Board, type SoldierColor, type Soldier } from './helpers';
+import { SULTAN, type Board, type SoldierColor, type Soldier, type moves } from './helpers';
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+export const smartBotStrategy: Bot = ({ board, ctx }) => {
   if (ctx.chosenRoleIndex === SULTAN) {
     const optimalGroupToKill = getOptimalGroupToKill(board);
     return { move: 'killGroup', args: [optimalGroupToKill] };

--- a/src/components/games/hunyadi-and-the-janissaries/bot-strategy.ts
+++ b/src/components/games/hunyadi-and-the-janissaries/bot-strategy.ts
@@ -2,8 +2,7 @@ import { random } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
 import { SULTAN, type Board, type SoldierColor, type Soldier, type moves } from './helpers';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 export const smartBotStrategy: Bot = ({ board, ctx }) => {
   if (ctx.chosenRoleIndex === SULTAN) {

--- a/src/components/games/latin-square-filling/latin-square-filling.tsx
+++ b/src/components/games/latin-square-filling/latin-square-filling.tsx
@@ -126,8 +126,7 @@ export const moves = {
   }
 };
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 const smartBotStrategy: Bot = ({ board }) => {
   const { cell, digit } = getSmartBotStep(board);

--- a/src/components/games/latin-square-filling/latin-square-filling.tsx
+++ b/src/components/games/latin-square-filling/latin-square-filling.tsx
@@ -126,12 +126,15 @@ export const moves = {
   }
 };
 
-const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+const smartBotStrategy: Bot = ({ board }) => {
   const { cell, digit } = getSmartBotStep(board);
   return { move: 'placeDigit', args: [cell, digit] };
 };
 
-const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
+const randomBotStrategy: Bot = ({ board }) => {
   const { cell, digit } = getRandomBotStep(board);
   return { move: 'placeDigit', args: [cell, digit] };
 };

--- a/src/components/games/magic-box/magic-box-a/bot-strategy.ts
+++ b/src/components/games/magic-box/magic-box-a/bot-strategy.ts
@@ -3,8 +3,7 @@ import { isGameEnd, placeStone, type Board } from './helpers';
 import type { BotStrategy } from '../../../strategy-game-factory';
 import type { moves } from './magic-box-a';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'placeStone', args: [sample(emptyCells(board))] });

--- a/src/components/games/magic-box/magic-box-a/bot-strategy.ts
+++ b/src/components/games/magic-box/magic-box-a/bot-strategy.ts
@@ -1,11 +1,15 @@
 import { range, sample } from 'lodash';
 import { isGameEnd, placeStone, type Board } from './helpers';
 import type { BotStrategy } from '../../../strategy-game-factory';
+import type { moves } from './magic-box-a';
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) =>
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'placeStone', args: [sample(emptyCells(board))] });
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const smartBotStrategy: Bot = ({ board, ctx }) => {
   const id = getOptimalPlacingPosition(board, ctx.chosenRoleIndex);
   return { move: 'placeStone', args: [id] };
 };

--- a/src/components/games/magic-box/magic-box-b/bot-strategy.ts
+++ b/src/components/games/magic-box/magic-box-b/bot-strategy.ts
@@ -1,15 +1,19 @@
 import { range, sample } from 'lodash';
 import { isLineFull, emptyCellsInLine, placeStoneAt, LINES, type Board } from './helpers';
 import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
+import type { moves } from './magic-box-b';
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 // A turn is one decision — where to place, then which line to hand over — so it
 // is named as a whole. The opening turn has no pending line to place into.
-const asTurn = (pendingLine: number | null, cell: number | undefined, line: number): BotMove[] =>
+const asTurn = (pendingLine: number | null, cell: number | undefined, line: number): BotMove<MoveName>[] =>
   pendingLine === null
     ? [{ move: 'designateLine', args: [line] }]
     : [{ move: 'placeStone', args: [cell] }, { move: 'designateLine', args: [line] }];
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
+export const randomBotStrategy: Bot = ({ board }) => {
   const { stones, pendingLine } = board;
   return asTurn(
     pendingLine,
@@ -18,7 +22,7 @@ export const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
   );
 };
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const smartBotStrategy: Bot = ({ board, ctx }) => {
   const { cell, line } = getOptimalAction(board, ctx.chosenRoleIndex);
   return asTurn(board.pendingLine, cell, line);
 };

--- a/src/components/games/matches-on-edges/bot-strategy.ts
+++ b/src/components/games/matches-on-edges/bot-strategy.ts
@@ -11,8 +11,7 @@ import {
 } from './helpers';
 import type { moves } from './matches-on-edges';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 // A move is winning if it leaves the other player (who moves next) in a losing
 // position.

--- a/src/components/games/matches-on-edges/bot-strategy.ts
+++ b/src/components/games/matches-on-edges/bot-strategy.ts
@@ -9,6 +9,10 @@ import {
   legalMoves,
   moverWins
 } from './helpers';
+import type { moves } from './matches-on-edges';
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 // A move is winning if it leaves the other player (who moves next) in a losing
 // position.
@@ -26,7 +30,7 @@ const opponentWinningReplies = (board: Board, move: Move, memo: Map<string, bool
 // Optimal bot: verified against the official characterisation (see
 // bot-strategy.spec.ts). Plays a winning move when one exists, otherwise sets
 // the hardest possible trap.
-export const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+export const smartBotStrategy: Bot = ({ board }) => {
   const memo = new Map<string, boolean>();
   const legal = legalMoves(board);
   const winning = winningMoves(board, legal, memo);
@@ -44,7 +48,7 @@ export const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
 
 // Test bot: plays at random, but takes an immediately winning move (one that
 // leaves the other player unable to move) when one is available.
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
+export const randomBotStrategy: Bot = ({ board }) => {
   const legal = legalMoves(board);
   const immediateWin = legal.find(m => isTerminal(applyMove(board, m.a, m.b)));
   const chosen = immediateWin ?? sample(legal)!;

--- a/src/components/games/matchstick-piles/matchstick-piles.tsx
+++ b/src/components/games/matchstick-piles/matchstick-piles.tsx
@@ -188,12 +188,15 @@ const applyMove = (board: Board, move: Move): Board => {
   );
 };
 
-const asBotMove = (move: Move): BotMove =>
+const asBotMove = (move: Move): BotMove<MoveName> =>
   move.type === 'remove'
     ? { move: 'removeMatch', args: [move.pileId] }
     : { move: 'splitPile', args: [move.pileId, move.firstPart] };
 
-const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+const smartBotStrategy: Bot = ({ board }) => {
   const candidates = legalMoves(board);
   const winningMove = candidates.find(move => xorSum(applyMove(board, move)) === 0);
   // In a losing position no move wins against optimal play, so play a random
@@ -201,7 +204,7 @@ const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
   return asBotMove(winningMove ?? sample(candidates)!);
 };
 
-const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
+const randomBotStrategy: Bot = ({ board }) => {
   const candidates = legalMoves(board);
   // Grab an immediately winning move (one that empties the board) if there is
   // one; otherwise just play a random legal move.

--- a/src/components/games/modified-mill/bot-strategy.ts
+++ b/src/components/games/modified-mill/bot-strategy.ts
@@ -4,6 +4,10 @@ import { SYMMETRIES } from './board-data';
 import {
   type Board, CELL_COUNT, boardMasks, emptyCells, completesLine, linesThrough
 } from './helpers';
+import type { moves } from './modified-mill';
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 import strategyTable from './strategy.json';
 
 const STRATEGY: Record<string, number> = strategyTable;
@@ -92,7 +96,7 @@ const countBits = (mask: number): number => {
   return count;
 };
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const smartBotStrategy: Bot = ({ board, ctx }) => {
   const { red, blue } = boardMasks(board);
   const node = ctx.currentPlayer === 0
     ? firstPlayerMove(red, blue)
@@ -102,7 +106,7 @@ export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
 
 // Test bot: plays a random empty cell, but grabs an immediate line-completing
 // win when one is available.
-export const randomBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const randomBotStrategy: Bot = ({ board, ctx }) => {
   const { red, blue } = boardMasks(board);
   const myMask = ctx.currentPlayer === 0 ? red : blue;
   const empties = emptyCells(red, blue);

--- a/src/components/games/modified-mill/bot-strategy.ts
+++ b/src/components/games/modified-mill/bot-strategy.ts
@@ -6,8 +6,7 @@ import {
 } from './helpers';
 import type { moves } from './modified-mill';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 import strategyTable from './strategy.json';
 
 const STRATEGY: Record<string, number> = strategyTable;

--- a/src/components/games/number-covering/number-covering.tsx
+++ b/src/components/games/number-covering/number-covering.tsx
@@ -41,8 +41,7 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
   );
 };
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'coverNumber', args: [sample(getRemaining(board))] });

--- a/src/components/games/number-covering/number-covering.tsx
+++ b/src/components/games/number-covering/number-covering.tsx
@@ -41,10 +41,13 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
   );
 };
 
-const randomBotStrategy: BotStrategy<Board> = ({ board }) =>
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'coverNumber', args: [sample(getRemaining(board))] });
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const smartBotStrategy: Bot = ({ board, ctx }) => {
   const botMove = getOptimalSmartBotMove({ board, currentPlayer: ctx.currentPlayer });
   return { move: 'coverNumber', args: [botMove] };
 };

--- a/src/components/games/number-pyramid/strategy.ts
+++ b/src/components/games/number-pyramid/strategy.ts
@@ -1,5 +1,9 @@
 import { orderBy, random, range, sample, sampleSize, shuffle, sum } from 'lodash';
 import type { BotMove, BotStrategy } from '../../strategy-game-factory';
+import type { moves } from './number-pyramid';
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 export type Slot = { value: number; state: 'active' | 'consumed' };
 export type Level = (Slot | null)[];
@@ -9,7 +13,7 @@ export type Board = {
   sortedInitial: number[];
 };
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
+export const randomBotStrategy: Bot = ({ board }) => {
   const win = findImmediateWin(board);
   if (win) return { move: 'combineTwo', args: [win] };
 
@@ -19,13 +23,13 @@ export const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
   return { move: 'combineTwo', args: [{ levelIdx: li, indices: sampleSize(actives, 2) }] };
 };
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const smartBotStrategy: Bot = ({ board, ctx }) => {
   const win = findImmediateWin(board);
   if (win) return { move: 'combineTwo', args: [win] };
 
   const botIsWinner = isP2WinningPosition(board) === (ctx.currentPlayer === 1);
 
-  const tryLevel = (levelIdx, order: 'asc' | 'desc' = 'desc'): BotMove | null => {
+  const tryLevel = (levelIdx, order: 'asc' | 'desc' = 'desc'): BotMove<MoveName> | null => {
     if (!hasActivePair(board.levels[levelIdx])) return null;
     const level = board.levels[levelIdx];
     const indices = orderBy(activeSlotIndices(level), (i) => level[i]!.value, order).slice(0, 2);

--- a/src/components/games/pairs-of-numbers/pairs-of-numbers.tsx
+++ b/src/components/games/pairs-of-numbers/pairs-of-numbers.tsx
@@ -53,8 +53,7 @@ export const moves = {
   }
 };
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 const randomBotStrategy: Bot = () =>
   random(0, 1) === 0 ? { move: 'add1' } : { move: 'subtract' };

--- a/src/components/games/pairs-of-numbers/pairs-of-numbers.tsx
+++ b/src/components/games/pairs-of-numbers/pairs-of-numbers.tsx
@@ -53,10 +53,13 @@ export const moves = {
   }
 };
 
-const randomBotStrategy: BotStrategy<Board> = () =>
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+const randomBotStrategy: Bot = () =>
   random(0, 1) === 0 ? { move: 'add1' } : { move: 'subtract' };
 
-const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+const smartBotStrategy: Bot = ({ board }) => {
   const [a, b] = board;
   if (a <= b) {
     return { move: 'subtract' };

--- a/src/components/games/pile-splitting-games/pile-splitter-3/bot-strategy.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter-3/bot-strategy.ts
@@ -1,16 +1,19 @@
 import { random, sample } from 'lodash';
 import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
-import type { Board } from './pile-splitter-3';
+import type { Board, moves } from './pile-splitter-3';
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 type BotStep = { removedPileId: number; pileId: number; pieceCount: number };
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board }) => asTurn(getSmartBotStep(board));
+export const smartBotStrategy: Bot = ({ board }) => asTurn(getSmartBotStep(board));
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) => asTurn(getRandomStep(board));
+export const randomBotStrategy: Bot = ({ board }) => asTurn(getRandomStep(board));
 
 // A turn is one decision expressed as two moves: which pile to discard, and
 // where to cut one of those left.
-const asTurn = ({ removedPileId, pileId, pieceCount }: BotStep): BotMove[] => [
+const asTurn = ({ removedPileId, pileId, pieceCount }: BotStep): BotMove<MoveName>[] => [
   { move: 'removePile', args: [removedPileId] },
   { move: 'splitPile', args: [{ pileId, pieceCount }] }
 ];

--- a/src/components/games/pile-splitting-games/pile-splitter-4/bot-strategy.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter-4/bot-strategy.ts
@@ -1,16 +1,19 @@
 import { random, range, sample } from 'lodash';
 import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
-import type { Board } from './pile-splitter-4';
+import type { Board, moves } from './pile-splitter-4';
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 type BotStep = { removedPileId: number; pileId: number; pieceCount: number };
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board }) => asTurn(getSmartBotStep(board));
+export const smartBotStrategy: Bot = ({ board }) => asTurn(getSmartBotStep(board));
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) => asTurn(getRandomStep(board));
+export const randomBotStrategy: Bot = ({ board }) => asTurn(getRandomStep(board));
 
 // A turn is one decision expressed as two moves: which pile to discard, and
 // where to cut one of those left.
-const asTurn = ({ removedPileId, pileId, pieceCount }: BotStep): BotMove[] => [
+const asTurn = ({ removedPileId, pileId, pieceCount }: BotStep): BotMove<MoveName>[] => [
   { move: 'removePile', args: [removedPileId] },
   { move: 'splitPile', args: [{ pileId, pieceCount }] }
 ];

--- a/src/components/games/pile-splitting-games/pile-splitter/bot-strategy.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter/bot-strategy.ts
@@ -1,20 +1,23 @@
 import { random, sample } from 'lodash';
 import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
-import type { Board } from './pile-splitter';
+import type { Board, moves } from './pile-splitter';
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 // A turn is one decision expressed as two moves: which pile to keep, and where
 // to cut it.
-const asTurn = (pileId: number, pieceCount: number): BotMove[] => [
+const asTurn = (pileId: number, pieceCount: number): BotMove<MoveName>[] => [
   { move: 'removePile', args: [1 - pileId] },
   { move: 'splitPile', args: [{ pileId, pieceCount }] }
 ];
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+export const smartBotStrategy: Bot = ({ board }) => {
   const pileId = getPileToSplit(board);
   return asTurn(pileId, getOptimalDivision(board[pileId]));
 };
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
+export const randomBotStrategy: Bot = ({ board }) => {
   const pileId = sample([0, 1].filter(i => board[i] >= 2))!;
   return asTurn(pileId, random(1, board[pileId] - 1));
 };

--- a/src/components/games/pile-union/bot-strategy.ts
+++ b/src/components/games/pile-union/bot-strategy.ts
@@ -1,6 +1,9 @@
 import { sample, sortBy, sum } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
-import type { Board } from './pile-union';
+import type { Board, moves } from './pile-union';
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 type MoveAction = { type: 'remove'; i: number } | { type: 'merge'; i: number; j: number }
 
@@ -32,7 +35,7 @@ const isLosing = (board: Board) => {
 P = Previous player wins (the player who just moved wins)
 N = Next player wins — the current player to move has a winning move available
 */
-export const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+export const smartBotStrategy: Bot = ({ board }) => {
   const T = sum(board) + board.length;
 
   if (T % 2 === 0) {
@@ -80,7 +83,7 @@ export const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
   }
 };
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
+export const randomBotStrategy: Bot = ({ board }) => {
   const winIn1: MoveAction[] = [];
   board.forEach((_, i) => {
     const next = board.filter((_, idx) => idx !== i);

--- a/src/components/games/pile-union/bot-strategy.ts
+++ b/src/components/games/pile-union/bot-strategy.ts
@@ -2,8 +2,7 @@ import { sample, sortBy, sum } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
 import type { Board, moves } from './pile-union';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 type MoveAction = { type: 'remove'; i: number } | { type: 'merge'; i: number; j: number }
 

--- a/src/components/games/policeman-thief/policeman-thief-ab/bot-strategy.ts
+++ b/src/components/games/policeman-thief/policeman-thief-ab/bot-strategy.ts
@@ -1,14 +1,17 @@
 import { random } from "lodash";
 import { neighbours, POLICE } from "./helpers";
-import type { Board } from "./policeman-thief-ab";
+import type { Board, moves } from "./policeman-thief-ab";
 import type { BotMove, BotStrategy } from "../../../strategy-game-factory";
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) =>
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+export const smartBotStrategy: Bot = ({ board, ctx }) =>
   ctx.chosenRoleIndex === POLICE ? thiefMove(board) : policemenMoves(board);
 
 // Both policemen step in the same turn, planned together from the position they
 // start in, so the turn is named as a whole.
-const policemenMoves = (board: Board): BotMove[] => {
+const policemenMoves = (board: Board): BotMove<MoveName>[] => {
   //policeman0 Step
   let index0 = board.policemen[0];
   // where it would catch the thief outright, which overrides any later choice
@@ -62,7 +65,7 @@ const policemenMoves = (board: Board): BotMove[] => {
   ];
 };
 
-const thiefMove = (board: Board): BotMove => {
+const thiefMove = (board: Board): BotMove<MoveName> => {
   let index = board.thief;
   for (let i = 0; i < 3; i++) {
     if (

--- a/src/components/games/policeman-thief/policeman-thief-c/bot-strategy.ts
+++ b/src/components/games/policeman-thief/policeman-thief-c/bot-strategy.ts
@@ -1,7 +1,10 @@
 import { sample, random, range } from "lodash";
 import { neighbours, VERTEX_COUNT, dist, minDistToSet, THIEF } from "./helpers";
-import type { Board } from "./policeman-thief-c";
+import type { Board, moves } from "./policeman-thief-c";
 import type { BotMove, BotStrategy } from "../../../strategy-game-factory";
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 // ---------------------------------------------------------------------------
 // Minimax core (exhaustive; the graph and rules are fixed so the memo below is
@@ -119,13 +122,13 @@ const chooseCopPlacement = (copCount: number): number[] => {
 // Every policeman is placed (or stepped) in the same turn, from a plan made for
 // the position the turn starts in, so a turn is named as a whole. A step onto
 // the thief ends the game there and then, leaving the rest of the plan moot.
-const asCopMoves = (move: string, target: number[]): BotMove[] =>
+const asCopMoves = (move: MoveName, target: number[]): BotMove<MoveName>[] =>
   target.map(vertex => ({ move, args: [vertex] }));
 
-const placeCopsOptimally = (board: Board): BotMove[] =>
+const placeCopsOptimally = (board: Board): BotMove<MoveName>[] =>
   asCopMoves('placeCop', chooseCopPlacement(board.copCount));
 
-const placeThiefOptimally = (board: Board): BotMove => {
+const placeThiefOptimally = (board: Board): BotMove<MoveName> => {
   const cops = board.policemen;
   const candidates = range(VERTEX_COUNT).filter((v) => !cops.includes(v));
   const surviving = candidates.filter((v) => thiefSurvives(cops, v, 3));
@@ -144,10 +147,10 @@ export const chooseCopMove = (cops: number[], thief: number, movesLeft: number):
   return sample(argExtreme(pool, totalDistToThief, false))!;
 };
 
-const moveCopsOptimally = (board: Board): BotMove[] =>
+const moveCopsOptimally = (board: Board): BotMove<MoveName>[] =>
   asCopMoves('moveCop', chooseCopMove(board.policemen, board.thief!, 3 - board.thiefMoveCount));
 
-const moveThiefOptimally = (board: Board): BotMove => {
+const moveThiefOptimally = (board: Board): BotMove<MoveName> => {
   const { policemen: cops, thief } = board;
   const movesLeft = 3 - board.thiefMoveCount;
   const safe = neighbours[thief!].filter((t) => !cops.includes(t));
@@ -158,7 +161,7 @@ const moveThiefOptimally = (board: Board): BotMove => {
   return { move: 'moveThief', args: [sample(best)!] };
 };
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const smartBotStrategy: Bot = ({ board, ctx }) => {
   if (ctx.chosenRoleIndex === THIEF) {
     return board.phase === 'placingCops' ? placeCopsOptimally(board) : moveCopsOptimally(board);
   }
@@ -171,10 +174,10 @@ export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
 // human thief realistically win, unlike the optimal bot.
 // ---------------------------------------------------------------------------
 
-const placeCopsRandom = (board: Board): BotMove[] =>
+const placeCopsRandom = (board: Board): BotMove<MoveName>[] =>
   asCopMoves('placeCop', range(board.copCount).map(() => random(0, VERTEX_COUNT - 1)));
 
-const moveCopsRandom = (board: Board): BotMove[] => {
+const moveCopsRandom = (board: Board): BotMove<MoveName>[] => {
   const thief = board.thief!;
   return asCopMoves('moveCop', board.policemen.map((c) => {
     const nbs = neighbours[c];
@@ -182,17 +185,17 @@ const moveCopsRandom = (board: Board): BotMove[] => {
   }));
 };
 
-const placeThiefRandom = (board: Board): BotMove => {
+const placeThiefRandom = (board: Board): BotMove<MoveName> => {
   const candidates = range(VERTEX_COUNT).filter((v) => !board.policemen.includes(v));
   return { move: 'placeThief', args: [sample(candidates)!] };
 };
 
-const moveThiefRandom = (board: Board): BotMove => {
+const moveThiefRandom = (board: Board): BotMove<MoveName> => {
   const safe = neighbours[board.thief!].filter((t) => !board.policemen.includes(t));
   return { move: 'moveThief', args: [sample(safe.length ? safe : neighbours[board.thief!])!] };
 };
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const randomBotStrategy: Bot = ({ board, ctx }) => {
   if (ctx.chosenRoleIndex === THIEF) {
     return board.phase === 'placingCops' ? placeCopsRandom(board) : moveCopsRandom(board);
   }

--- a/src/components/games/polynomial-building/bot-strategy.ts
+++ b/src/components/games/polynomial-building/bot-strategy.ts
@@ -3,10 +3,14 @@ import type { BotStrategy } from '../../strategy-game-factory';
 import {
   type Board, type Coef, COEFS, rootTriplesWithProduct, completionValue, canComplete
 } from './helpers';
+import type { moves } from './polynomial-building';
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 // Weak bot: plays a random legal move, but completes to a win on the last move
 // when it can (only the first player, who always makes the final move, can win in 1).
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
+export const randomBotStrategy: Bot = ({ board }) => {
   const empties = COEFS.filter(k => board[k] === null);
   const coef = sample(empties)!;
   if (empties.length === 1) {
@@ -58,7 +62,7 @@ const blockingMove = (board: Board): [Coef, number] | null => {
 // 3 empty → first player's move 1, 2 empty → second player's move 2,
 // 1 empty → first player's move 3. The first player has the last move and always
 // wins with correct play.
-export const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+export const smartBotStrategy: Bot = ({ board }) => {
   const empties = COEFS.filter(k => board[k] === null);
 
   // First player, move 1: pick randomly between the two winning first moves —

--- a/src/components/games/polynomial-building/bot-strategy.ts
+++ b/src/components/games/polynomial-building/bot-strategy.ts
@@ -5,8 +5,7 @@ import {
 } from './helpers';
 import type { moves } from './polynomial-building';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 // Weak bot: plays a random legal move, but completes to a win on the last move
 // when it can (only the first player, who always makes the final move, can win in 1).

--- a/src/components/games/recolouring-discs/bot-strategy.ts
+++ b/src/components/games/recolouring-discs/bot-strategy.ts
@@ -11,6 +11,10 @@ import {
   majorityWinner
 } from './helpers';
 import { solveForN } from './solver';
+import type { moves } from './recolouring-discs';
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 interface Option {
   move: Move;
@@ -20,7 +24,7 @@ interface Option {
 const optionsFor = (cells: Cell[], player: number): Option[] =>
   legalMoves(cells, player).map(move => ({ move, cells: applyMove(cells, player, move) }));
 
-const asBotMove = (move: Move): BotMove => {
+const asBotMove = (move: Move): BotMove<MoveName> => {
   if (move.type === 'move') return { move: 'moveDisc', args: [move.from, move.to] };
   if (move.type === 'place') return { move: 'placeDisc', args: [move.to] };
   return { move: 'pass' };
@@ -37,7 +41,7 @@ const opponentInstantWins = (cells: Cell[], opponent: number): number =>
 // Optimal bot. Verified in bot-strategy.spec.ts: from the winning role it never
 // loses; its moves keep the position in its own attractor and strictly reduce
 // the rank, so it always reaches its majority (well within the 200-ply cap).
-export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const smartBotStrategy: Bot = ({ board, ctx }) => {
   const cells = board.cells;
   const n = cells.length;
   const me = ctx.currentPlayer!;
@@ -85,7 +89,7 @@ export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
 };
 
 // Test bot: plays at random, but takes an immediate win when one is available.
-export const randomBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const randomBotStrategy: Bot = ({ board, ctx }) => {
   const cells = board.cells;
   const me = ctx.currentPlayer!;
   const options = optionsFor(cells, me);

--- a/src/components/games/remove-divisor-multiple/remove-divisor-multiple.tsx
+++ b/src/components/games/remove-divisor-multiple/remove-divisor-multiple.tsx
@@ -82,13 +82,16 @@ const isGameEnd = (board: Board) => {
   return possibleMoves.length === 0;
 }
 
-const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+const randomBotStrategy: Bot = ({ board }) => {
   const possibleMoves = range(1, board.numbersOnTable.length + 1)
     .filter(n => isAllowed(board, n));
   return { move: 'removeNumber', args: [sample(possibleMoves)] };
 };
 
-const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+const smartBotStrategy: Bot = ({ board }) => {
   const numCount = board.numbersOnTable.length;
   const stateId = generateStateID(board);
   const optimalMoves = strategyDict[numCount]

--- a/src/components/games/remove-divisor-multiple/remove-divisor-multiple.tsx
+++ b/src/components/games/remove-divisor-multiple/remove-divisor-multiple.tsx
@@ -82,8 +82,7 @@ const isGameEnd = (board: Board) => {
   return possibleMoves.length === 0;
 }
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 const randomBotStrategy: Bot = ({ board }) => {
   const possibleMoves = range(1, board.numbersOnTable.length + 1)

--- a/src/components/games/remove-row-or-column/bot-strategy.ts
+++ b/src/components/games/remove-row-or-column/bot-strategy.ts
@@ -4,8 +4,7 @@ import {
   type Board, type Grid, type moves, getRectangles, getAllMoves, applyMove, isEmpty
 } from './helpers';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 // Sprague–Grundy value of a single a×b rectangle. A move removes a full row
 // (splitting a×b into (i-1)×b and (a-i)×b) or a full column (a×(j-1) and

--- a/src/components/games/remove-row-or-column/bot-strategy.ts
+++ b/src/components/games/remove-row-or-column/bot-strategy.ts
@@ -4,8 +4,8 @@ import {
   type Board, type Grid, type moves, getRectangles, getAllMoves, applyMove, isEmpty
 } from './helpers';
 
-// Naming the game's own move names makes a typo in a bot a typecheck error.
-type Bot = BotStrategy<Board, keyof typeof moves>;
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 // Sprague–Grundy value of a single a×b rectangle. A move removes a full row
 // (splitting a×b into (i-1)×b and (a-i)×b) or a full column (a×(j-1) and

--- a/src/components/games/rock-paper-scissor/bot-strategy.ts
+++ b/src/components/games/rock-paper-scissor/bot-strategy.ts
@@ -2,8 +2,7 @@ import { random } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
 import type { Board, moves } from './rock-paper-scissor';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 export const smartBotStrategy: Bot = ({ board, ctx }) => {
   const idx = getOptimalSmartBotMove(board, ctx.currentPlayer!);

--- a/src/components/games/rock-paper-scissor/bot-strategy.ts
+++ b/src/components/games/rock-paper-scissor/bot-strategy.ts
@@ -1,8 +1,11 @@
 import { random } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
-import type { Board } from './rock-paper-scissor';
+import type { Board, moves } from './rock-paper-scissor';
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+export const smartBotStrategy: Bot = ({ board, ctx }) => {
   const idx = getOptimalSmartBotMove(board, ctx.currentPlayer!);
   return { move: 'removeSymbol', args: [idx] };
 };

--- a/src/components/games/rook-to-corner/bot-strategy.ts
+++ b/src/components/games/rook-to-corner/bot-strategy.ts
@@ -3,8 +3,7 @@ import type { BotStrategy } from '../../strategy-game-factory';
 import { getAllowedMoves, isTarget, type Board, type Field } from './helpers';
 import type { moves } from './rook-to-corner';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'moveRook', args: [getRandomBotMove(board)] });

--- a/src/components/games/rook-to-corner/bot-strategy.ts
+++ b/src/components/games/rook-to-corner/bot-strategy.ts
@@ -1,8 +1,12 @@
 import { sample } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
 import { getAllowedMoves, isTarget, type Board, type Field } from './helpers';
+import type { moves } from './rook-to-corner';
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) =>
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'moveRook', args: [getRandomBotMove(board)] });
 
 // Random play, but grab an immediate win (moving onto the bottom-right square)
@@ -13,7 +17,7 @@ export const getRandomBotMove = (board: Board): Field => {
   return winningMove ?? sample(allowedMoves)!;
 };
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board }) =>
+export const smartBotStrategy: Bot = ({ board }) =>
   ({ move: 'moveRook', args: [getOptimalSmartBotMove(board)] });
 
 // The game is 2-heap Nim: the distances to the right and bottom edges are the

--- a/src/components/games/shark-chase/shark-4-by-4/bot-strategy.ts
+++ b/src/components/games/shark-chase/shark-4-by-4/bot-strategy.ts
@@ -1,6 +1,10 @@
 import { sample } from 'lodash';
 import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
 import type { Board } from '../helpers';
+import type { moves } from './shark-chase';
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 const getAdjacentCells = (pos: number): number[] => {
   const cells: number[] = [];
@@ -13,12 +17,12 @@ const getAdjacentCells = (pos: number): number[] => {
 
 // The shark's turn is a route of up to two steps, named as a whole: the halfway
 // cell is only chosen to reach the target safely, so the two are one decision.
-const asSharkRoute = (from: number, via: number, to: number): BotMove[] =>
+const asSharkRoute = (from: number, via: number, to: number): BotMove<MoveName>[] =>
   to === from
     ? [{ move: 'moveShark', args: [via] }]
     : [{ move: 'moveShark', args: [via] }, { move: 'moveShark', args: [to] }];
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const randomBotStrategy: Bot = ({ board, ctx }) => {
   if (ctx.chosenRoleIndex === 0) {
     const safeMoves = [...getAdjacentCells(board.shark).filter(c => board.submarines[c] === 0), board.shark];
     const firstPos = sample(safeMoves)!;
@@ -45,7 +49,7 @@ export const randomBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
   }
 };
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const smartBotStrategy: Bot = ({ board, ctx }) => {
   if (ctx.chosenRoleIndex === 0) {
     const finalPos = getNextSharkPositionByAI(board)!;
     const firstPos = getIntermediateSharkPosition(board.submarines, board.shark, finalPos);

--- a/src/components/games/shark-chase/shark-5-by-5/bot-strategy.ts
+++ b/src/components/games/shark-chase/shark-5-by-5/bot-strategy.ts
@@ -1,6 +1,10 @@
 import { sample } from 'lodash';
 import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
 import type { Board } from '../helpers';
+import type { moves } from './shark-chase';
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 import sharkExceptionMoves from './shark-exception-moves.json';
 
 const getAdjacentCells = (pos: number): number[] => {
@@ -14,12 +18,12 @@ const getAdjacentCells = (pos: number): number[] => {
 
 // The shark's turn is a route of up to two steps, named as a whole: the halfway
 // cell is only chosen to reach the target safely, so the two are one decision.
-const asSharkRoute = (from: number, via: number, to: number): BotMove[] =>
+const asSharkRoute = (from: number, via: number, to: number): BotMove<MoveName>[] =>
   to === from
     ? [{ move: 'moveShark', args: [via] }]
     : [{ move: 'moveShark', args: [via] }, { move: 'moveShark', args: [to] }];
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const randomBotStrategy: Bot = ({ board, ctx }) => {
   if (ctx.chosenRoleIndex === 0) {
     const safeMoves = [...getAdjacentCells(board.shark).filter(c => board.submarines[c] === 0), board.shark];
     const firstPos = sample(safeMoves)!;
@@ -46,7 +50,7 @@ export const randomBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
   }
 };
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const smartBotStrategy: Bot = ({ board, ctx }) => {
   if (ctx.chosenRoleIndex === 0) {
     const finalPos = getNextSharkPositionByAI(board)!;
     const firstPos = getIntermediateSharkPosition(board.submarines, board.shark, finalPos);

--- a/src/components/games/single-number-increase/increment-or-double/increment-or-double.tsx
+++ b/src/components/games/single-number-increase/increment-or-double/increment-or-double.tsx
@@ -61,7 +61,10 @@ export const getBotNextNumber = (board: Board): number => {
   return sample([board + 1, board * 2])!;
 };
 
-const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+const smartBotStrategy: Bot = ({ board }) => {
   const next = getBotNextNumber(board);
   if (next === board * 2) {
     return { move: 'double' };

--- a/src/components/games/single-number-increase/increment-or-double/increment-or-double.tsx
+++ b/src/components/games/single-number-increase/increment-or-double/increment-or-double.tsx
@@ -61,8 +61,7 @@ export const getBotNextNumber = (board: Board): number => {
   return sample([board + 1, board * 2])!;
 };
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 const smartBotStrategy: Bot = ({ board }) => {
   const next = getBotNextNumber(board);

--- a/src/components/games/single-number-increase/plus-one-two-three/plus-one-two-three.tsx
+++ b/src/components/games/single-number-increase/plus-one-two-three/plus-one-two-three.tsx
@@ -52,7 +52,10 @@ export const moves = {
   }
 };
 
-const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+const smartBotStrategy: Bot = ({ board }) => {
   const nextBoard = board % (1 + maxStep) !== 0
     ? board + (1 + maxStep) - board % (1 + maxStep)
     : board + random(1, maxStep);

--- a/src/components/games/single-number-increase/plus-one-two-three/plus-one-two-three.tsx
+++ b/src/components/games/single-number-increase/plus-one-two-three/plus-one-two-three.tsx
@@ -52,8 +52,7 @@ export const moves = {
   }
 };
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 const smartBotStrategy: Bot = ({ board }) => {
   const nextBoard = board % (1 + maxStep) !== 0

--- a/src/components/games/single-number-increase/superstitious-counting/bot-strategy.ts
+++ b/src/components/games/single-number-increase/superstitious-counting/bot-strategy.ts
@@ -1,11 +1,14 @@
 import { random } from 'lodash';
 import type { BotStrategy } from '../../../strategy-game-factory';
-import type { Board } from './superstitious-counting';
+import type { Board, moves } from './superstitious-counting';
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) =>
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'step', args: [randomStep(board.restricted)] });
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+export const smartBotStrategy: Bot = ({ board }) => {
   const step = getOptimalBotStep(board);
   return { move: 'step', args: [step] };
 };

--- a/src/components/games/single-number-increase/superstitious-counting/bot-strategy.ts
+++ b/src/components/games/single-number-increase/superstitious-counting/bot-strategy.ts
@@ -2,8 +2,7 @@ import { random } from 'lodash';
 import type { BotStrategy } from '../../../strategy-game-factory';
 import type { Board, moves } from './superstitious-counting';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'step', args: [randomStep(board.restricted)] });

--- a/src/components/games/single-pile-removal/doubling-reduction/doubling-reduction.tsx
+++ b/src/components/games/single-pile-removal/doubling-reduction/doubling-reduction.tsx
@@ -60,12 +60,15 @@ export const moves = {
   }
 };
 
-const smartBotStrategy: BotStrategy<Board> = ({ board }) =>
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+const smartBotStrategy: Bot = ({ board }) =>
   ({ move: 'take', args: [chooseSmartTake(board)] });
 
 // Test bot: takes the whole pile if that wins immediately, otherwise a random
 // legal amount.
-const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
+const randomBotStrategy: Bot = ({ board }) => {
   if (board.stones <= board.maxTake) {
     return { move: 'take', args: [board.stones] };
   }

--- a/src/components/games/single-pile-removal/doubling-reduction/doubling-reduction.tsx
+++ b/src/components/games/single-pile-removal/doubling-reduction/doubling-reduction.tsx
@@ -60,8 +60,7 @@ export const moves = {
   }
 };
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 const smartBotStrategy: Bot = ({ board }) =>
   ({ move: 'take', args: [chooseSmartTake(board)] });

--- a/src/components/games/single-pile-removal/prime-exponentials/prime-exponentials.tsx
+++ b/src/components/games/single-pile-removal/prime-exponentials/prime-exponentials.tsx
@@ -129,13 +129,16 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   );
 };
 
-const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+const randomBotStrategy: Bot = ({ board }) => {
   const validMoves = allPrimePowers.filter(e => e.value <= board);
   const { prime, exponent } = sample(validMoves)!;
   return { move: 'subtractPrimeExponent', args: [{ prime, exponent }] };
 };
 
-const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+const smartBotStrategy: Bot = ({ board }) => {
   if (board === 1) {
     return { move: 'subtractPrimeExponent', args: [{ prime: 2, exponent: 0 }] };
   }

--- a/src/components/games/single-pile-removal/prime-exponentials/prime-exponentials.tsx
+++ b/src/components/games/single-pile-removal/prime-exponentials/prime-exponentials.tsx
@@ -129,8 +129,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   );
 };
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 const randomBotStrategy: Bot = ({ board }) => {
   const validMoves = allPrimePowers.filter(e => e.value <= board);

--- a/src/components/games/single-pile-removal/primely-to-zero/primely-to-zero.tsx
+++ b/src/components/games/single-pile-removal/primely-to-zero/primely-to-zero.tsx
@@ -55,8 +55,7 @@ export const moves = {
   }
 };
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 const randomBotStrategy: Bot = ({ board }) => {
   const step = isValidStep(board) ? board : sample([...validSteps].filter(s => s < board))!;

--- a/src/components/games/single-pile-removal/primely-to-zero/primely-to-zero.tsx
+++ b/src/components/games/single-pile-removal/primely-to-zero/primely-to-zero.tsx
@@ -55,12 +55,15 @@ export const moves = {
   }
 };
 
-const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+const randomBotStrategy: Bot = ({ board }) => {
   const step = isValidStep(board) ? board : sample([...validSteps].filter(s => s < board))!;
   return { move: 'moveTo', args: [board - step] };
 };
 
-const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+const smartBotStrategy: Bot = ({ board }) => {
   const remainder = board % 4;
   let step: number;
   if (remainder !== 0) {

--- a/src/components/games/single-pile-removal/take-1-or-halve/take-1-or-halve.tsx
+++ b/src/components/games/single-pile-removal/take-1-or-halve/take-1-or-halve.tsx
@@ -70,7 +70,10 @@ export const moves = {
   }
 };
 
-const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+const randomBotStrategy: Bot = ({ board }) => {
   if (board % 2 === 0 && random(0, 1) === 0) {
     return { move: 'halve' };
   } else {
@@ -78,7 +81,7 @@ const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
   }
 };
 
-const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+const smartBotStrategy: Bot = ({ board }) => {
   if (board !== 4 && board % 4 === 0) {
     return { move: 'take1' };
   } else if (board === 6) {

--- a/src/components/games/single-pile-removal/take-1-or-halve/take-1-or-halve.tsx
+++ b/src/components/games/single-pile-removal/take-1-or-halve/take-1-or-halve.tsx
@@ -70,8 +70,7 @@ export const moves = {
   }
 };
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 const randomBotStrategy: Bot = ({ board }) => {
   if (board % 2 === 0 && random(0, 1) === 0) {

--- a/src/components/games/single-pile-removal/take-power-of-two/take-power-of-two.tsx
+++ b/src/components/games/single-pile-removal/take-power-of-two/take-power-of-two.tsx
@@ -69,10 +69,13 @@ const generateTestStartBoard = () => {
   }
 };
 
-const randomBotStrategy: BotStrategy<Board> = ({ board }) =>
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'subtractPowerOfTwo', args: [sample(getAvailableExponents(board))] });
 
-const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+const smartBotStrategy: Bot = ({ board }) => {
   if (board === 1) {
     return { move: 'subtractPowerOfTwo', args: [0] };
   }

--- a/src/components/games/single-pile-removal/take-power-of-two/take-power-of-two.tsx
+++ b/src/components/games/single-pile-removal/take-power-of-two/take-power-of-two.tsx
@@ -69,8 +69,7 @@ const generateTestStartBoard = () => {
   }
 };
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'subtractPowerOfTwo', args: [sample(getAvailableExponents(board))] });

--- a/src/components/games/single-pile-removal/three-more/three-more.tsx
+++ b/src/components/games/single-pile-removal/three-more/three-more.tsx
@@ -68,8 +68,7 @@ export const moves = {
   }
 };
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 const smartBotStrategy: Bot = ({ board }) =>
   ({ move: 'take', args: [chooseSmartTake(board)] });

--- a/src/components/games/single-pile-removal/three-more/three-more.tsx
+++ b/src/components/games/single-pile-removal/three-more/three-more.tsx
@@ -68,7 +68,10 @@ export const moves = {
   }
 };
 
-const smartBotStrategy: BotStrategy<Board> = ({ board }) =>
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+const smartBotStrategy: Bot = ({ board }) =>
   ({ move: 'take', args: [chooseSmartTake(board)] });
 
 const startBoard = (stones: number): Board => ({ stones, maxTake: OPENING_MAX });

--- a/src/components/games/single-pile-removal/waning-stones/waning-stones.tsx
+++ b/src/components/games/single-pile-removal/waning-stones/waning-stones.tsx
@@ -45,12 +45,15 @@ export const moves = {
   }
 };
 
-const smartBotStrategy: BotStrategy<Board> = ({ board }) =>
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+const smartBotStrategy: Bot = ({ board }) =>
   ({ move: 'take', args: [chooseSmartTake(board)] });
 
 // Test bot: takes the whole pile if that wins immediately, otherwise a random
 // legal amount.
-const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
+const randomBotStrategy: Bot = ({ board }) => {
   if (board.stones <= board.maxTake) {
     return { move: 'take', args: [board.stones] };
   }

--- a/src/components/games/single-pile-removal/waning-stones/waning-stones.tsx
+++ b/src/components/games/single-pile-removal/waning-stones/waning-stones.tsx
@@ -45,8 +45,7 @@ export const moves = {
   }
 };
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 const smartBotStrategy: Bot = ({ board }) =>
   ({ move: 'take', args: [chooseSmartTake(board)] });

--- a/src/components/games/six-fields-circle/bot-strategy.ts
+++ b/src/components/games/six-fields-circle/bot-strategy.ts
@@ -4,6 +4,10 @@ import {
   type Board, type Move, OPPOSITE_PAIRS, getLegalMoves, hasLegalMove, pairSum,
   sampleNonEmptyField
 } from "./helpers";
+import type { moves } from './six-fields-circle';
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 // Optimal move: keep all three opposite-pair sums even, which hands the
 // opponent a losing position. When the mover is already in a losing position
@@ -37,8 +41,8 @@ export const getRandomMove = (board: Board): Move => {
   return sample(winningMoves.length > 0 ? winningMoves : legalMoves)!;
 };
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board }) =>
+export const smartBotStrategy: Bot = ({ board }) =>
   ({ move: 'removeFromTwo', args: [getSmartMove(board)] });
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) =>
+export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'removeFromTwo', args: [getRandomMove(board)] });

--- a/src/components/games/six-fields-circle/bot-strategy.ts
+++ b/src/components/games/six-fields-circle/bot-strategy.ts
@@ -6,8 +6,7 @@ import {
 } from "./helpers";
 import type { moves } from './six-fields-circle';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 // Optimal move: keep all three opposite-pair sums even, which hands the
 // opponent a losing position. When the mover is already in a losing position

--- a/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
+++ b/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
@@ -95,10 +95,13 @@ const isGameEnd = (board, ctx) => {
   return false;
 }
 
-const randomBotStrategy: BotStrategy<Board> = ({ board, ctx }) =>
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+const randomBotStrategy: Bot = ({ board, ctx }) =>
   ({ move: 'removeStone', args: [getPileOfRandomAllowedMove(board, ctx)] });
 
-const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+const smartBotStrategy: Bot = ({ board, ctx }) => {
   if (board.leftRestriction[ctx.currentPlayer!]) {
     return { move: 'removeStone', args: [1] };
   }

--- a/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
+++ b/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
@@ -95,8 +95,7 @@ const isGameEnd = (board, ctx) => {
   return false;
 }
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 const randomBotStrategy: Bot = ({ board, ctx }) =>
   ({ move: 'removeStone', args: [getPileOfRandomAllowedMove(board, ctx)] });

--- a/src/components/games/sum-fifteen/sum-fifteen.tsx
+++ b/src/components/games/sum-fifteen/sum-fifteen.tsx
@@ -97,8 +97,7 @@ export const moves = {
   }
 };
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 const smartBotStrategy: Bot = ({ board, ctx }) => {
   const player = (ctx.currentPlayer ?? currentPlayerFromOwner(board.owner)) as 0 | 1;

--- a/src/components/games/sum-fifteen/sum-fifteen.tsx
+++ b/src/components/games/sum-fifteen/sum-fifteen.tsx
@@ -97,12 +97,15 @@ export const moves = {
   }
 };
 
-const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+const smartBotStrategy: Bot = ({ board, ctx }) => {
   const player = (ctx.currentPlayer ?? currentPlayerFromOwner(board.owner)) as 0 | 1;
   return { move: 'chooseNumber', args: [chooseSmartMove(board.owner, player)] };
 };
 
-const randomBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+const randomBotStrategy: Bot = ({ board, ctx }) => {
   const player = (ctx.currentPlayer ?? currentPlayerFromOwner(board.owner)) as 0 | 1;
   return { move: 'chooseNumber', args: [chooseTestMove(board.owner, player)] };
 };

--- a/src/components/games/take-and-point/bot-strategy.ts
+++ b/src/components/games/take-and-point/bot-strategy.ts
@@ -9,6 +9,10 @@ import {
   nonEmptyIndices,
   removerWins
 } from './helpers';
+import type { moves } from './take-and-point';
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 type Removal = { index: number; amount: number };
 
@@ -102,14 +106,14 @@ export const chooseRemoval = (board: Board): Removal => {
 // A turn takes stones and then points at the piles the opponent may take from,
 // both named at once — except on the opening turn, which only points, and when
 // the take empties the board and wins the game there and then.
-const asTurn = (board: Board, { index, amount }: Removal, point: (board: Board) => number[]): BotMove[] => {
+const asTurn = (board: Board, { index, amount }: Removal, point: (board: Board) => number[]): BotMove<MoveName>[] => {
   const nextBoard: Board = { piles: applyRemoval(board.piles, index, amount), pointed: null };
-  const removal = { move: 'takeStones', args: [index, amount] };
+  const removal: BotMove<MoveName> = { move: 'takeStones', args: [index, amount] };
   if (isTerminal(nextBoard)) return [removal];
   return [removal, { move: 'pointPiles', args: [point(nextBoard)] }];
 };
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+export const smartBotStrategy: Bot = ({ board }) => {
   if (board.pointed === null) return { move: 'pointPiles', args: [choosePointing(board)] };
   return asTurn(board, chooseRemoval(board), choosePointing);
 };
@@ -130,7 +134,7 @@ const randomPointing = (board: Board): number[] => {
   return shuffle(nonEmpty).slice(0, 2);
 };
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
+export const randomBotStrategy: Bot = ({ board }) => {
   if (board.pointed === null) return { move: 'pointPiles', args: [randomPointing(board)] };
   return asTurn(board, randomRemoval(board), randomPointing);
 };

--- a/src/components/games/ten-coins/ten-coins.tsx
+++ b/src/components/games/ten-coins/ten-coins.tsx
@@ -176,8 +176,7 @@ export const moves = {
 // Smart bot: play the winning move when one exists (drive towards a losing
 // position, or merge to a single value). In a losing position, make the reply
 // that leaves the opponent with the most ways to blunder.
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 export const smartBotStrategy: Bot = ({ board }) => {
   const candidateMoves = movesFromSet(distinctValues(board));

--- a/src/components/games/ten-coins/ten-coins.tsx
+++ b/src/components/games/ten-coins/ten-coins.tsx
@@ -176,7 +176,10 @@ export const moves = {
 // Smart bot: play the winning move when one exists (drive towards a losing
 // position, or merge to a single value). In a losing position, make the reply
 // that leaves the opponent with the most ways to blunder.
-export const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+export const smartBotStrategy: Bot = ({ board }) => {
   const candidateMoves = movesFromSet(distinctValues(board));
 
   const winningMoves = candidateMoves.filter(isWinningMove);
@@ -197,7 +200,7 @@ export const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
 };
 
 // Test bot: play a random legal move, but grab an immediate win when available.
-const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
+const randomBotStrategy: Bot = ({ board }) => {
   const candidateMoves = movesFromSet(distinctValues(board));
   const winningNow = candidateMoves.filter(m => m.resultSet.length === 1);
   const move = sample(winningNow.length > 0 ? winningNow : candidateMoves)!;

--- a/src/components/games/ten-digit-number/ten-digit-number.tsx
+++ b/src/components/games/ten-digit-number/ten-digit-number.tsx
@@ -106,7 +106,10 @@ export const moves = {
   }
 };
 
-const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+const randomBotStrategy: Bot = ({ board }) => {
   const turnsLeft = totalDigits - board.digits.length;
   const currentPlayer = (totalDigits - turnsLeft) % 2;
 
@@ -123,7 +126,7 @@ const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
   return { move: 'chooseDigit', args: [sample(availableDigits)] };
 };
 
-const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+const smartBotStrategy: Bot = ({ board }) => {
   const turnsLeft = totalDigits - board.digits.length;
   const currentPlayer = (totalDigits - turnsLeft) % 2;
 

--- a/src/components/games/ten-digit-number/ten-digit-number.tsx
+++ b/src/components/games/ten-digit-number/ten-digit-number.tsx
@@ -106,8 +106,7 @@ export const moves = {
   }
 };
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 const randomBotStrategy: Bot = ({ board }) => {
   const turnsLeft = totalDigits - board.digits.length;

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/bot-strategy.ts
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/bot-strategy.ts
@@ -3,8 +3,7 @@ import { Sheriff, Thief, hasWinningTriple, getUntakenCards, type Board } from '.
 import { type BotStrategy } from '../../../strategy-game-factory';
 import { applyTakeCard, CARD_COUNT, type moves } from './moves';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 const TURN_PLAYER = [Sheriff, Thief, Sheriff, Thief, Sheriff];
 

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/bot-strategy.ts
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/bot-strategy.ts
@@ -1,14 +1,17 @@
 import { sample } from 'lodash';
 import { Sheriff, Thief, hasWinningTriple, getUntakenCards, type Board } from '../helpers';
 import { type BotStrategy } from '../../../strategy-game-factory';
-import { applyTakeCard, CARD_COUNT } from './moves';
+import { applyTakeCard, CARD_COUNT, type moves } from './moves';
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 const TURN_PLAYER = [Sheriff, Thief, Sheriff, Thief, Sheriff];
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) =>
+export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'takeCard', args: [[sample(getUntakenCards(board, CARD_COUNT))]] });
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) =>
+export const smartBotStrategy: Bot = ({ board, ctx }) =>
   ({ move: 'takeCard', args: [[getBotCard(board, ctx.currentPlayer!)]] });
 
 export const getBotCard = (board: Board, botPlayerIndex: number): number => {

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/bot-strategy.ts
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/bot-strategy.ts
@@ -3,8 +3,7 @@ import { Sheriff, Thief, hasWinningTriple, getUntakenCards, type Board } from '.
 import { type BotStrategy } from '../../../strategy-game-factory';
 import { applyTakeCard, CARD_COUNT, type moves } from './moves';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'takeCard', args: [sample(getUntakenCards(board, CARD_COUNT))] });

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/bot-strategy.ts
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/bot-strategy.ts
@@ -1,12 +1,15 @@
 import { sample } from 'lodash';
 import { Sheriff, Thief, hasWinningTriple, getUntakenCards, type Board } from '../helpers';
 import { type BotStrategy } from '../../../strategy-game-factory';
-import { applyTakeCard, CARD_COUNT } from './moves';
+import { applyTakeCard, CARD_COUNT, type moves } from './moves';
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) =>
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'takeCard', args: [sample(getUntakenCards(board, CARD_COUNT))] });
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) =>
+export const smartBotStrategy: Bot = ({ board, ctx }) =>
   ({ move: 'takeCard', args: [getBotCard(board, ctx.currentPlayer!)] });
 
 // Shared across calls: minimax's score depends only on (cards, botPlayerIndex), so

--- a/src/components/games/three-piles-rebuild/three-piles-rebuild.tsx
+++ b/src/components/games/three-piles-rebuild/three-piles-rebuild.tsx
@@ -196,14 +196,17 @@ export const moves = {
 
 // "Keep, then split" is one decision, so the turn is named as a whole (mirrors
 // the pile-splitting games).
-const asTurn = ({ keepId, parts }: { keepId: number; parts: number[] }): BotMove[] => [
+const asTurn = ({ keepId, parts }: { keepId: number; parts: number[] }): BotMove<MoveName>[] => [
   { move: 'keepPile', args: [keepId] },
   { move: 'splitPile', args: [parts] }
 ];
 
-const smartBotStrategy: BotStrategy<Board> = ({ board }) => asTurn(getSmartBotStep(board));
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
-const randomBotStrategy: BotStrategy<Board> = ({ board }) => asTurn(getRandomBotStep(board));
+const smartBotStrategy: Bot = ({ board }) => asTurn(getSmartBotStep(board));
+
+const randomBotStrategy: Bot = ({ board }) => asTurn(getRandomBotStep(board));
 
 const getPlayerStepDescription = () => ({
   hu: 'Válaszd ki, melyik kupacot tartod meg (a másik kettőt eldobod), majd oszd három új kupacra.',

--- a/src/components/games/tictactoe-alikes/anti-tictactoe/bot-strategy.ts
+++ b/src/components/games/tictactoe-alikes/anti-tictactoe/bot-strategy.ts
@@ -4,8 +4,7 @@ import { roleColors, hasFirstPlayerWon, isGameEnd, type Board } from './helpers'
 import type { BotStrategy } from '../../../strategy-game-factory';
 import type { moves } from './anti-tictactoe';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'placePiece', args: [sample(emptyCells(board))] });

--- a/src/components/games/tictactoe-alikes/anti-tictactoe/bot-strategy.ts
+++ b/src/components/games/tictactoe-alikes/anti-tictactoe/bot-strategy.ts
@@ -2,11 +2,15 @@ import { range, isNull, sample, cloneDeep } from 'lodash';
 import { hasWinningSubset } from '../helpers';
 import { roleColors, hasFirstPlayerWon, isGameEnd, type Board } from './helpers';
 import type { BotStrategy } from '../../../strategy-game-factory';
+import type { moves } from './anti-tictactoe';
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) =>
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'placePiece', args: [sample(emptyCells(board))] });
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const smartBotStrategy: Bot = ({ board, ctx }) => {
   const id = getOptimalBotPlacingPosition(board, ctx.chosenRoleIndex);
   return { move: 'placePiece', args: [id] };
 };

--- a/src/components/games/tictactoe-alikes/tictactoe-doublestart/bot-strategy.ts
+++ b/src/components/games/tictactoe-alikes/tictactoe-doublestart/bot-strategy.ts
@@ -2,21 +2,25 @@ import { range, isNull, sample, sampleSize, cloneDeep } from 'lodash';
 import { hasWinningSubset } from '../helpers';
 import { isGameEnd, hasFirstPlayerWon, roleColors, type Board } from './helpers';
 import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
+import type { moves } from './tictactoe-doublestart';
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 const emptyCells = (board: Board) => range(0, 9).filter(i => isNull(board[i]));
 
 // The opening turn places two pieces, named together as one decision.
-const placements = (...cells: (number | undefined)[]): BotMove[] =>
+const placements = (...cells: (number | undefined)[]): BotMove<MoveName>[] =>
   cells.map(cell => ({ move: 'placePiece', args: [cell] }));
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
+export const randomBotStrategy: Bot = ({ board }) => {
   const allowedPlaces = emptyCells(board);
   if (allowedPlaces.length < 9) return placements(sample(allowedPlaces));
   const [first, second] = sampleSize(allowedPlaces, 2);
   return placements(first, second);
 };
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const smartBotStrategy: Bot = ({ board, ctx }) => {
   if (emptyCells(board).length === 9) {
     // two neighbouring corners, chosen randomly
     const opening = sample([[0, 2], [2, 8], [6, 8], [0, 6]])!;

--- a/src/components/games/tictactoe-alikes/tictactoe/bot-strategy.ts
+++ b/src/components/games/tictactoe-alikes/tictactoe/bot-strategy.ts
@@ -1,8 +1,12 @@
 import { isNull, range, sample } from 'lodash';
 import { pColor, botColor, inPlacingPhase, isGameEnd, type Board } from './helpers';
 import type { BotStrategy } from '../../../strategy-game-factory';
+import type { moves } from './tictactoe';
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+export const randomBotStrategy: Bot = ({ board }) => {
   const allowedPlaces = getAllowedPlaces({ board, amIBot: true });
   if (inPlacingPhase(board)) {
     const safePlaces = allowedPlaces.filter(i => !opponentCanWinNext(board, i));
@@ -22,7 +26,7 @@ const opponentCanWinNext = (board: Board, position) => {
   });
 };
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+export const smartBotStrategy: Bot = ({ board }) => {
   if (inPlacingPhase(board)) {
     const id = getOptimalBotPlacingPosition(board);
     return { move: 'placePiece', args: [id] };

--- a/src/components/games/tictactoe-alikes/tictactoe/bot-strategy.ts
+++ b/src/components/games/tictactoe-alikes/tictactoe/bot-strategy.ts
@@ -3,8 +3,7 @@ import { pColor, botColor, inPlacingPhase, isGameEnd, type Board } from './helpe
 import type { BotStrategy } from '../../../strategy-game-factory';
 import type { moves } from './tictactoe';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 export const randomBotStrategy: Bot = ({ board }) => {
   const allowedPlaces = getAllowedPlaces({ board, amIBot: true });

--- a/src/components/games/totem-poles/triangular-grid-ropes-10/bot-strategy.ts
+++ b/src/components/games/totem-poles/triangular-grid-ropes-10/bot-strategy.ts
@@ -12,8 +12,7 @@ import {
 import type { BotStrategy } from '../../../strategy-game-factory';
 import type { moves } from './triangular-grid-ropes-10';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 //    0
 //   1 2

--- a/src/components/games/totem-poles/triangular-grid-ropes-10/bot-strategy.ts
+++ b/src/components/games/totem-poles/triangular-grid-ropes-10/bot-strategy.ts
@@ -10,16 +10,20 @@ import {
   type Edge
 } from './helpers';
 import type { BotStrategy } from '../../../strategy-game-factory';
+import type { moves } from './triangular-grid-ropes-10';
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 //    0
 //   1 2
 //  3 4 5
 // 6 7 8 9
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) =>
+export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'stretchRope', args: [sample(getAllowedMoves(board))] });
 
-export const smartBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const smartBotStrategy: Bot = ({ board, ctx }) => {
   const move = getOptimalSmartBotMove({ board, chosenRoleIndex: ctx.chosenRoleIndex });
   return { move: 'stretchRope', args: [move] };
 };

--- a/src/components/games/totem-poles/triangular-grid-ropes-15/bot-strategy.ts
+++ b/src/components/games/totem-poles/triangular-grid-ropes-15/bot-strategy.ts
@@ -2,6 +2,10 @@ import { sample } from 'lodash';
 import { getAllowedMoves, type Board } from './helpers';
 import { findWinningMove } from './solver';
 import type { BotStrategy } from '../../../strategy-game-factory';
+import type { moves } from './triangular-grid-ropes-15';
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 //         0
 //        1 2
@@ -9,14 +13,14 @@ import type { BotStrategy } from '../../../strategy-game-factory';
 //      6 7 8 9
 //    10 11 12 13 14
 
-export const randomBotStrategy: BotStrategy<Board> = ({ board }) =>
+export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'stretchRope', args: [sample(getAllowedMoves(board))] });
 
 // The bot searches for a winning move every turn (see solver.ts), so it plays
 // optimally whichever side it is on: as the second player it always wins, and
 // as the first player it wins the moment the opponent makes a mistake. When the
 // position is genuinely lost it plays on with a reasonable move.
-export const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+export const smartBotStrategy: Bot = ({ board }) => {
   if (board.length === 0) {
     // The bot opens (and, from the empty board, is on the losing side). Open on
     // a side of the medial triangle — a natural, symmetric first move.

--- a/src/components/games/totem-poles/triangular-grid-ropes-15/bot-strategy.ts
+++ b/src/components/games/totem-poles/triangular-grid-ropes-15/bot-strategy.ts
@@ -4,8 +4,7 @@ import { findWinningMove } from './solver';
 import type { BotStrategy } from '../../../strategy-game-factory';
 import type { moves } from './triangular-grid-ropes-15';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 //         0
 //        1 2

--- a/src/components/games/triangle-circle-game/strategy/bot-strategy.ts
+++ b/src/components/games/triangle-circle-game/strategy/bot-strategy.ts
@@ -8,6 +8,10 @@ import {
 import { OPENING_EDGES, isLineTurnWon, marchEdges, winningPairHeatEdges } from './forced-win';
 import { makeMoveEvaluator } from './search';
 import type { BotStrategy } from '../../../strategy-game-factory';
+import type { moves } from '../triangle-circle-game';
+
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
 
 // Smart bot.
 //
@@ -34,7 +38,7 @@ const SEARCH: SearchOpts = { depth: 12, budget: 45_000 };
 
 // Build a bot with a given search budget. Exposed so tests can dial the
 // fallback search down; the shipped bot uses SEARCH.
-export const makeSmartBotStrategy = (searchOpts: SearchOpts = SEARCH): BotStrategy<Board> =>
+export const makeSmartBotStrategy = (searchOpts: SearchOpts = SEARCH): Bot =>
   ({ board, ctx }) => {
     if (ctx.currentPlayer === LINE) {
       return { move: 'shadeEdge', args: [chooseLineMove(board, searchOpts)] };
@@ -48,7 +52,7 @@ export const smartBotStrategy = makeSmartBotStrategy(SEARCH);
 // Easy "test" bot: plays at random for whichever side it holds, except that it
 // grabs an immediate (one-move) win when one exists. Good for getting a feel
 // for the rules before a real game.
-export const randomBotStrategy: BotStrategy<Board> = ({ board, ctx }) => {
+export const randomBotStrategy: Bot = ({ board, ctx }) => {
   if (ctx.currentPlayer === LINE) {
     return { move: 'shadeEdge', args: [randomLineMove(board)] };
   } else {

--- a/src/components/games/triangle-circle-game/strategy/bot-strategy.ts
+++ b/src/components/games/triangle-circle-game/strategy/bot-strategy.ts
@@ -10,8 +10,7 @@ import { makeMoveEvaluator } from './search';
 import type { BotStrategy } from '../../../strategy-game-factory';
 import type { moves } from '../triangle-circle-game';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 // Smart bot.
 //

--- a/src/components/games/triangle-coloring/triangle-coloring.tsx
+++ b/src/components/games/triangle-coloring/triangle-coloring.tsx
@@ -143,8 +143,7 @@ export const moves = {
 
 const getAllowedMoves = (board: Board) => range(16).filter(i => board[i] === ALLOWED);
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'colorTriangle', args: [sample(getAllowedMoves(board))] });

--- a/src/components/games/triangle-coloring/triangle-coloring.tsx
+++ b/src/components/games/triangle-coloring/triangle-coloring.tsx
@@ -143,10 +143,13 @@ export const moves = {
 
 const getAllowedMoves = (board: Board) => range(16).filter(i => board[i] === ALLOWED);
 
-const randomBotStrategy: BotStrategy<Board> = ({ board }) =>
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'colorTriangle', args: [sample(getAllowedMoves(board))] });
 
-const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+const smartBotStrategy: Bot = ({ board }) => {
   const optimalMove = getOptimalSmartBotMove(board);
   return { move: 'colorTriangle', args: [optimalMove] };
 };

--- a/src/components/games/twelve-squares/twelve-squares.tsx
+++ b/src/components/games/twelve-squares/twelve-squares.tsx
@@ -55,12 +55,15 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   );
 };
 
-const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+const randomBotStrategy: Bot = ({ board }) => {
   const validSteps = [1, 2].filter(step => isValidStep(board, step));
   return { move: 'step', args: [sample(validSteps)] };
 };
 
-const optimalBotStrategy: BotStrategy<Board> = ({ board }) => {
+const optimalBotStrategy: Bot = ({ board }) => {
   const step = getOptimalBotStep(board);
   return { move: 'step', args: [step] };
 };

--- a/src/components/games/twelve-squares/twelve-squares.tsx
+++ b/src/components/games/twelve-squares/twelve-squares.tsx
@@ -55,8 +55,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   );
 };
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 const randomBotStrategy: Bot = ({ board }) => {
   const validSteps = [1, 2].filter(step => isValidStep(board, step));

--- a/src/components/games/two-of-three-takeaway/two-of-three-takeaway.tsx
+++ b/src/components/games/two-of-three-takeaway/two-of-three-takeaway.tsx
@@ -117,12 +117,15 @@ export const moves = {
   }
 };
 
-const smartBotStrategy: BotStrategy<Board> = ({ board }) => {
+type MoveName = keyof typeof moves
+type Bot = BotStrategy<Board, MoveName>
+
+const smartBotStrategy: Bot = ({ board }) => {
   const [i, j] = getSmartBotMove(board);
   return { move: 'takeChips', args: [i, j] };
 };
 
-const randomBotStrategy: BotStrategy<Board> = ({ board }) => {
+const randomBotStrategy: Bot = ({ board }) => {
   const [i, j] = getRandomBotMove(board);
   return { move: 'takeChips', args: [i, j] };
 };

--- a/src/components/games/two-of-three-takeaway/two-of-three-takeaway.tsx
+++ b/src/components/games/two-of-three-takeaway/two-of-three-takeaway.tsx
@@ -117,8 +117,7 @@ export const moves = {
   }
 };
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, keyof typeof moves>
 
 const smartBotStrategy: Bot = ({ board }) => {
   const [i, j] = getSmartBotMove(board);


### PR DESCRIPTION
Follow-up to #388, and stacked on it — it needs the `BotStrategy<TBoard, TMoveName>` type parameter introduced there. **Base this on `main` once #388 merges.**

#388 left `BotMove.move` as `string` by default and pinned the union in only the two games the docs use as examples. So in the other 49 files a mistyped move name still typechecked, and only failed when the bot got to play it. This pins the rest.

## What changed

Every bot in the project now names moves through its own game's move names:

```ts
import type { Board, moves } from './helpers';

type MoveName = keyof typeof moves
type Bot = BotStrategy<Board, MoveName>

export const smartBotStrategy: Bot = ({ board }) => ({ move: 'moveKnight', args: [botMove] });
```

A typo is now a typecheck error at the bot that made it:

```
Type '"moveKngiht"' is not assignable to type '"moveKnight"'.
```

Helpers that build a turn's moves narrow along with them (`BotMove<MoveName>[]`) — `coins-in-3-piles`'s `asTurn`, `architect-and-bandits`'s `asArchitectDay`, `policeman-thief-c`'s `asCopMoves`, `number-pyramid`'s `tryLevel`.

## Notes

- Every game already exported its `moves`, so nothing had to be re-exported to make this possible — the import added per game is type-only, so it adds no runtime dependency.
- No behaviour change: types only, plus the doc updates in `AGENTS.md`, `README.md` and the `new-game` skill, which now describe this as the convention rather than an option.
- The alias carries no per-file comment (the convention lives in `AGENTS.md`) and sits next to the bots rather than above the moves object it refers to.
- `triangle-circle-game/strategy/spec-helpers.ts` deliberately keeps the wide type: it accepts any strategy.

## Verification

`npm test` — versions, lint, typecheck, 1215 tests, all green. I also introduced a deliberate typo in `chess-knight` to confirm the pinning actually bites, then reverted it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgKsSPf9CbvBkKhZKC94yN)_