### PR TITLE
Inline the bot move helpers back into the strategies

### DIFF
--- a/src/components/games/chess-bishops/bot-strategy.spec.ts
+++ b/src/components/games/chess-bishops/bot-strategy.spec.ts
@@ -1,9 +1,13 @@
 import lodash from 'lodash';
-import { getOptimalSmartBotMove } from './bot-strategy';
-import { generateStartBoard, BISHOP, markForbiddenFields } from './helpers'
+import { smartBotStrategy } from './bot-strategy';
+import { generateStartBoard, BISHOP, markForbiddenFields, type Board, type Field } from './helpers'
+import { botNextMoveArgs, makeCtx } from '../../../test-utils';
+
+const smartBotPlacement = (board: Board): Field =>
+  botNextMoveArgs(smartBotStrategy({ board, ctx: makeCtx() }))[0];
 
 describe('test bishop strategy', () => {
-  describe('getOptimalSmartBotMove()', () => {
+  describe('smartBotStrategy', () => {
     afterEach(() => {
       vi.restoreAllMocks();
     });
@@ -14,7 +18,7 @@ describe('test bishop strategy', () => {
       const board = generateStartBoard();
       markForbiddenFields(board, { row: 1, col: 5 });
       board[1][5] = BISHOP;
-      const res = getOptimalSmartBotMove(board);
+      const res = smartBotPlacement(board);
       expect(res).toEqual({ row: 1, col: 2 });
     });
 
@@ -24,7 +28,7 @@ describe('test bishop strategy', () => {
       const board = generateStartBoard();
       markForbiddenFields(board, { row: 1, col: 5 });
       board[1][5] = BISHOP;
-      const res = getOptimalSmartBotMove(board);
+      const res = smartBotPlacement(board);
       expect(res).toEqual({ row: 6, col: 5 });
     });
 
@@ -32,12 +36,12 @@ describe('test bishop strategy', () => {
       const board = generateStartBoard();
       markForbiddenFields(board, { row: 1, col: 5 });
       board[1][5] = BISHOP;
-      const move2 = getOptimalSmartBotMove(board);
+      const move2 = smartBotPlacement(board);
       markForbiddenFields(board, move2);
       board[move2.row][move2.col] = BISHOP;
       markForbiddenFields(board, { row: 6, col: 4 });
       board[6][4] = BISHOP;
-      const move4 = getOptimalSmartBotMove(board);
+      const move4 = smartBotPlacement(board);
       expect([
         [{ row: 1, col: 2 }, { row: 6, col: 3 }],
         [{ row: 6, col: 5 }, { row: 1, col: 4 }]

--- a/src/components/games/chess-bishops/bot-strategy.ts
+++ b/src/components/games/chess-bishops/bot-strategy.ts
@@ -14,11 +14,6 @@ export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'placeBishop', args: [sample(getAllowedMoves(board))] });
 
 export const smartBotStrategy: Bot = ({ board }) => {
-  const botMove = getOptimalSmartBotMove(board);
-  return { move: 'placeBishop', args: [botMove] };
-};
-
-export const getOptimalSmartBotMove = (board: Board): Field => {
   const allowedHMirrorMoves = boardIndices.filter(
     ({ row, col }) => board[row][col] === null && board[row][7 - col] === BISHOP
   );
@@ -34,10 +29,10 @@ export const getOptimalSmartBotMove = (board: Board): Field => {
   }
   if (bishopCount < 4) {
     if (axis === HORIZONTAL && allowedHMirrorMoves.length === 1) {
-      return allowedHMirrorMoves[0];
+      return { move: 'placeBishop', args: [allowedHMirrorMoves[0]] };
     }
     if (axis === VERTICAL && allowedVMirrorMoves.length === 1) {
-      return allowedVMirrorMoves[0];
+      return { move: 'placeBishop', args: [allowedVMirrorMoves[0]] };
     }
   }
 
@@ -47,7 +42,7 @@ export const getOptimalSmartBotMove = (board: Board): Field => {
   if (bishopCount == 2) {
     const optimalPlace = getOptimalThirdStep(board);
     if (optimalPlace !== undefined) {
-      return optimalPlace;
+      return { move: 'placeBishop', args: [optimalPlace] };
     }
   }
   // try to win from bad position if player does not play optimally
@@ -62,10 +57,10 @@ export const getOptimalSmartBotMove = (board: Board): Field => {
     });
 
     if (optimalPlace !== undefined) {
-      return optimalPlace;
+      return { move: 'placeBishop', args: [optimalPlace] };
     }
   }
-  return sample(allowedMoves)!;
+  return { move: 'placeBishop', args: [sample(allowedMoves)!] };
 };
 
 // given board *after* your step, are you set up to win the game for sure?

--- a/src/components/games/chess-ducks/bot-strategy.ts
+++ b/src/components/games/chess-ducks/bot-strategy.ts
@@ -12,11 +12,6 @@ export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'placeDuck', args: [sample(getAllowedMoves(board))] });
 
 export const smartBotStrategy: Bot = ({ board }) => {
-  const botMove = getOptimalSmartBotMove(board);
-  return { move: 'placeDuck', args: [botMove] };
-};
-
-const getOptimalSmartBotMove = (board: Board): Field => {
   const allowedMoves = getAllowedMoves(board);
   const boardIndices = getBoardIndices(board.length, board[0].length);
 
@@ -27,19 +22,22 @@ const getOptimalSmartBotMove = (board: Board): Field => {
 
   // live search is too slow and there is no optimal first step anyways
   if (duckCount === 0) {
-    return sample(allowedMoves)!;
+    return { move: 'placeDuck', args: [sample(allowedMoves)!] };
   }
 
   // live search is too slow
   if (duckCount === 1 && colCount === 7) {
-    return smartBotOptimalSecondSteps[`${ducks[0].row};${ducks[0].col}`];
+    return {
+      move: 'placeDuck',
+      args: [smartBotOptimalSecondSteps[`${ducks[0].row};${ducks[0].col}`]]
+    };
   }
 
   // use pre-calculated optimal 3rd moves as live calculation would be too slow
   if (duckCount == 2 && colCount === 7) {
     const optimalPlace = getOptimalThirdStep(board);
     if (optimalPlace !== undefined) {
-      return optimalPlace;
+      return { move: 'placeDuck', args: [optimalPlace] };
     }
   }
 
@@ -51,11 +49,11 @@ const getOptimalSmartBotMove = (board: Board): Field => {
     });
 
     if (optimalPlace !== undefined) {
-      return optimalPlace;
+      return { move: 'placeDuck', args: [optimalPlace] };
     }
   }
 
-  return sample(allowedMoves)!;
+  return { move: 'placeDuck', args: [sample(allowedMoves)!] };
 };
 
 type Coords = [number, number];

--- a/src/components/games/chess-knight/bot-strategy.ts
+++ b/src/components/games/chess-knight/bot-strategy.ts
@@ -9,28 +9,24 @@ export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'moveKnight', args: [sample(getAllowedMoves(board))] });
 
 export const smartBotStrategy: Bot = ({ board }) => {
-  const botMove = getOptimalSmartBotMove(board);
-  return { move: 'moveKnight', args: [botMove] };
-};
-
-export const getOptimalSmartBotMove = (board: Board): Field => {
   const allowedMoves = getAllowedMoves(board);
+
   if (allowedMoves.length === 1) {
-    return allowedMoves[0];
+    return { move: 'moveKnight', args: [allowedMoves[0]] };
   }
   if (isCenter(board.knightPosition)) {
     const cornerMove = allowedMoves.find(move => isCorner(move));
     if (cornerMove !== undefined) {
-      return cornerMove;
+      return { move: 'moveKnight', args: [cornerMove] };
     }
   }
   if (isEdgeMiddle(board.knightPosition)) {
     const moveOnEdgeCircle = allowedMoves.find(move => isEdgeMiddle(move));
     if (moveOnEdgeCircle !== undefined) {
-      return moveOnEdgeCircle;
+      return { move: 'moveKnight', args: [moveOnEdgeCircle] };
     }
   }
-  return sample(allowedMoves)!;
+  return { move: 'moveKnight', args: [sample(allowedMoves)!] };
 };
 
 const isCenter = ({ row, col }: Field): boolean => {

--- a/src/components/games/chess-rook/bot-strategy.spec.ts
+++ b/src/components/games/chess-rook/bot-strategy.spec.ts
@@ -1,12 +1,15 @@
-import { getOptimalSmartBotMove } from './bot-strategy';
-import { generateStartBoard, markVisitedFields } from './helpers';
+import { smartBotStrategy } from './bot-strategy';
+import { generateStartBoard, markVisitedFields, type Board, type Field } from './helpers';
+import { botNextMoveArgs, makeCtx } from '../../../test-utils';
 import { isEqual, cloneDeep } from 'lodash';
 
+const smartBotTarget = (board: Board): Field =>
+  botNextMoveArgs(smartBotStrategy({ board, ctx: makeCtx() }))[0];
+
 describe('chess rook', () => {
-  describe('getOptimalSmartBotMove()', () => {
+  describe('smartBotStrategy', () => {
     it('should move to end of row or column as a first step', () => {
-      const board = generateStartBoard();
-      const rookPosition = getOptimalSmartBotMove(board);
+      const rookPosition = smartBotTarget(generateStartBoard());
       expect(
         isEqual(rookPosition, { row: 0, col: 7 }) ||
         isEqual(rookPosition, { row: 7, col: 0 })
@@ -21,8 +24,7 @@ describe('chess rook', () => {
       nextBoard.chessBoard[0][5] = 'rook';
       nextBoard.rookPosition = { row: 0, col: 5 };
 
-      const rookPosition = getOptimalSmartBotMove(nextBoard);
-      expect(rookPosition).toEqual({ row: 7, col: 5 });
+      expect(smartBotTarget(nextBoard)).toEqual({ row: 7, col: 5 });
     });
   });
 });

--- a/src/components/games/chess-rook/bot-strategy.ts
+++ b/src/components/games/chess-rook/bot-strategy.ts
@@ -1,6 +1,6 @@
 import { last, random, sample } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
-import { getAllowedMoves, type Board, type Field } from './helpers';
+import { getAllowedMoves, type Board } from './helpers';
 import type { moves } from './chess-rook';
 
 type Bot = BotStrategy<Board, keyof typeof moves>
@@ -9,24 +9,19 @@ export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'moveRook', args: [sample(getAllowedMoves(board))] });
 
 export const smartBotStrategy: Bot = ({ board }) => {
-  const botMove = getOptimalSmartBotMove(board);
-  return { move: 'moveRook', args: [botMove] };
-};
-
-export const getOptimalSmartBotMove = (board: Board): Field => {
   const { row, col } = board.rookPosition;
   const allMoves = getAllowedMoves(board);
   const allowedHorizontalMoves = allMoves.filter(m => m.row === row);
   const allowedVerticalMoves = allMoves.filter(m => m.col === col);
 
   if (allowedHorizontalMoves.length < allowedVerticalMoves.length) {
-    return last(allowedVerticalMoves)!;
+    return { move: 'moveRook', args: [last(allowedVerticalMoves)!] };
   } else if (allowedHorizontalMoves.length > allowedVerticalMoves.length) {
-    return last(allowedHorizontalMoves)!;
+    return { move: 'moveRook', args: [last(allowedHorizontalMoves)!] };
   }
   if (random(0, 1) === 1) {
-    return last(allowedHorizontalMoves)!;
+    return { move: 'moveRook', args: [last(allowedHorizontalMoves)!] };
   } else {
-    return last(allowedVerticalMoves)!;
+    return { move: 'moveRook', args: [last(allowedVerticalMoves)!] };
   }
 };

--- a/src/components/games/magic-box/magic-box-a/bot-strategy.spec.ts
+++ b/src/components/games/magic-box/magic-box-a/bot-strategy.spec.ts
@@ -1,14 +1,18 @@
-import { getOptimalPlacingPosition } from './bot-strategy';
-import { generateEmptyBoard, isGameEnd, placeStone } from './helpers';
+import { smartBotStrategy } from './bot-strategy';
+import { generateEmptyBoard, isGameEnd, placeStone, type Board } from './helpers';
+import { botNextMoveArgs, makeCtx } from '../../../../test-utils';
 
-describe('getOptimalPlacingPosition', () => {
+const smartBotPlacement = (board: Board, chosenRoleIndex: number): number =>
+  botNextMoveArgs(smartBotStrategy({ board, ctx: makeCtx({ chosenRoleIndex }) }))[0];
+
+describe('smartBotStrategy', () => {
   it('should not place a stone that immediately completes a line if a safe move exists', () => {
     const board = [
       true, true, false,
       false, false, false,
       false, false, false
     ];
-    expect(getOptimalPlacingPosition(board, 0)).not.toBe(2);
+    expect(smartBotPlacement(board, 0)).not.toBe(2);
   });
 
   it('should pick the only remaining move that does not complete a line, regardless of role', () => {
@@ -18,8 +22,8 @@ describe('getOptimalPlacingPosition', () => {
       true, false, false
     ];
     // empty cells are 2, 3, 7, 8; placing at 2, 3 or 7 each completes a line, only 8 is safe
-    expect(getOptimalPlacingPosition(board, 0)).toBe(8);
-    expect(getOptimalPlacingPosition(board, 1)).toBe(8);
+    expect(smartBotPlacement(board, 0)).toBe(8);
+    expect(smartBotPlacement(board, 1)).toBe(8);
   });
 
   it('should fall back to one of the remaining cells when every move completes a line', () => {
@@ -28,7 +32,7 @@ describe('getOptimalPlacingPosition', () => {
       true, false, true,
       true, true, false
     ];
-    expect([0, 4, 8]).toContain(getOptimalPlacingPosition(board, 0));
+    expect([0, 4, 8]).toContain(smartBotPlacement(board, 0));
   });
 
   it('should let the second player always force a win with optimal play from an empty board', () => {
@@ -36,7 +40,7 @@ describe('getOptimalPlacingPosition', () => {
       let board = placeStone(generateEmptyBoard(), firstMove);
       let mover = 1;
       while (!isGameEnd(board)) {
-        const id = getOptimalPlacingPosition(board, mover) as number;
+        const id = smartBotPlacement(board, mover);
         board = placeStone(board, id);
         mover = 1 - mover;
       }

--- a/src/components/games/magic-box/magic-box-a/bot-strategy.ts
+++ b/src/components/games/magic-box/magic-box-a/bot-strategy.ts
@@ -8,11 +8,6 @@ type Bot = BotStrategy<Board, keyof typeof moves>
 export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'placeStone', args: [sample(emptyCells(board))] });
 
-export const smartBotStrategy: Bot = ({ board, ctx }) => {
-  const id = getOptimalPlacingPosition(board, ctx.chosenRoleIndex);
-  return { move: 'placeStone', args: [id] };
-};
-
 const emptyCells = (board: Board) => range(0, 9).filter(i => !board[i]);
 
 const winnerCache = new Map<string, number>();
@@ -33,7 +28,8 @@ const winner = (board: Board, toMove: number): number => {
   return result;
 };
 
-export const getOptimalPlacingPosition = (board: Board, chosenRoleIndex) => {
+export const smartBotStrategy: Bot = ({ board, ctx }) => {
+  const chosenRoleIndex = ctx.chosenRoleIndex!;
   const allowedPlaces = emptyCells(board);
 
   const winningPlaces = allowedPlaces.filter(i => {
@@ -41,11 +37,13 @@ export const getOptimalPlacingPosition = (board: Board, chosenRoleIndex) => {
     const outcome = isGameEnd(nextBoard) ? 1 - chosenRoleIndex : winner(nextBoard, 1 - chosenRoleIndex);
     return outcome === chosenRoleIndex;
   });
-  if (winningPlaces.length > 0) return sample(winningPlaces);
+  if (winningPlaces.length > 0) return { move: 'placeStone', args: [sample(winningPlaces)] };
 
   // no winning move exists; at least avoid losing immediately if possible
   const notInstantLosingPlaces = allowedPlaces.filter(i => !isGameEnd(placeStone(board, i)));
-  if (notInstantLosingPlaces.length > 0) return sample(notInstantLosingPlaces);
+  if (notInstantLosingPlaces.length > 0) {
+    return { move: 'placeStone', args: [sample(notInstantLosingPlaces)] };
+  }
 
-  return sample(allowedPlaces);
+  return { move: 'placeStone', args: [sample(allowedPlaces)] };
 };

--- a/src/components/games/number-covering/number-covering.spec.ts
+++ b/src/components/games/number-covering/number-covering.spec.ts
@@ -1,7 +1,10 @@
-import { isCoveringAllowed, getOptimalSmartBotMove, moves, COVERED } from './number-covering';
-import { makeCtx } from '../../../test-utils';
+import { isCoveringAllowed, smartBotStrategy, moves, COVERED, type Board } from './number-covering';
+import { botNextMoveArgs, makeCtx } from '../../../test-utils';
 
 const meta = { ctx: makeCtx() };
+
+const smartBotCover = (board: Board, currentPlayer: number): number =>
+  botNextMoveArgs(smartBotStrategy({ board, ctx: makeCtx({ currentPlayer }) }))[0];
 
 describe('isCoveringAllowed', () => {
   const board = [1, 2, COVERED, 4, 5];
@@ -29,22 +32,22 @@ describe('smart bot', () => {
 
   it('as first player covers from the smaller parity class', () => {
     // odds are the minority -> covers an odd
-    expect([1, 3, 5]).toContain(getOptimalSmartBotMove({ board: fourEvensThreeOdds, currentPlayer: 0 }));
+    expect([1, 3, 5]).toContain(smartBotCover(fourEvensThreeOdds, 0));
     // evens are the minority -> covers an even
-    expect([2, 4]).toContain(getOptimalSmartBotMove({ board: twoEvensFourOdds, currentPlayer: 0 }));
+    expect([2, 4]).toContain(smartBotCover(twoEvensFourOdds, 0));
   });
 
   it('as second player covers from the larger parity class', () => {
     // evens are the majority -> covers an even
-    expect([2, 4, 6, 8]).toContain(getOptimalSmartBotMove({ board: fourEvensThreeOdds, currentPlayer: 1 }));
+    expect([2, 4, 6, 8]).toContain(smartBotCover(fourEvensThreeOdds, 1));
     // odds are the majority -> covers an odd
-    expect([1, 3, 5, 7]).toContain(getOptimalSmartBotMove({ board: twoEvensFourOdds, currentPlayer: 1 }));
+    expect([1, 3, 5, 7]).toContain(smartBotCover(twoEvensFourOdds, 1));
   });
 
   it('plays a legal move when the parities are balanced', () => {
     const numbers = [1, 2, 3, 4, 5, 6, 7, 8]; // 4 evens, 4 odds
-    expect(numbers).toContain(getOptimalSmartBotMove({ board: numbers, currentPlayer: 0 }));
-    expect(numbers).toContain(getOptimalSmartBotMove({ board: numbers, currentPlayer: 1 }));
+    expect(numbers).toContain(smartBotCover(numbers, 0));
+    expect(numbers).toContain(smartBotCover(numbers, 1));
   });
 });
 

--- a/src/components/games/number-covering/number-covering.tsx
+++ b/src/components/games/number-covering/number-covering.tsx
@@ -4,7 +4,7 @@ import {
 import { range, sum, sample, cloneDeep } from 'lodash';
 import { useTranslation } from '../../../language';
 
-type Board = number[]
+export type Board = number[]
 
 export const COVERED = -1 as const;
 
@@ -47,26 +47,19 @@ const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'coverNumber', args: [sample(getRemaining(board))] });
 
 export const smartBotStrategy: Bot = ({ board, ctx }) => {
-  const botMove = getOptimalSmartBotMove({ board, currentPlayer: ctx.currentPlayer });
-  return { move: 'coverNumber', args: [botMove] };
-};
-
-export const getOptimalSmartBotMove = (
-  { board, currentPlayer }: { board: Board, currentPlayer: number | null }
-) => {
   const remaining = getRemaining(board);
   const evens = remaining.filter(i => i%2 === 0);
   const odds = remaining.filter(i => i%2 === 1);
   if (evens.length === odds.length || evens.length === 0 || odds.length === 0) {
-    return sample(remaining);
-  } else if (currentPlayer === 0) {
+    return { move: 'coverNumber', args: [sample(remaining)] };
+  } else if (ctx.currentPlayer === 0) {
     // first player wants same-parity survivors -> remove from the smaller class
     const candidates = evens.length < odds.length ? evens : odds;
-    return sample(candidates);
+    return { move: 'coverNumber', args: [sample(candidates)] };
   } else {
     // second player wants a mixed pair -> remove from the larger class
     const candidates = evens.length > odds.length ? evens : odds;
-    return sample(candidates);
+    return { move: 'coverNumber', args: [sample(candidates)] };
   }
 };
 

--- a/src/components/games/rock-paper-scissor/bot-strategy.spec.ts
+++ b/src/components/games/rock-paper-scissor/bot-strategy.spec.ts
@@ -1,33 +1,38 @@
-import { getOptimalSmartBotMove } from "./bot-strategy";
+import { smartBotStrategy } from "./bot-strategy";
+import { botNextMoveArgs, makeCtx } from '../../../test-utils';
+import type { Board } from './rock-paper-scissor';
 
-describe('getOptimalSmartBotMove', () => {
+const smartBotRemoval = (board: Board, currentPlayer: number): number =>
+  botNextMoveArgs(smartBotStrategy({ board, ctx: makeCtx({ currentPlayer }) }))[0];
+
+describe('smartBotStrategy', () => {
   it('as a second player remove useless piece in first step', () => {
     expect(
-      getOptimalSmartBotMove([['rock', 'paper', 'scissor'], ['rock', null, 'scissor']], 1)
+      smartBotRemoval([['rock', 'paper', 'scissor'], ['rock', null, 'scissor']], 1)
     ).toEqual(0);
     expect(
-      getOptimalSmartBotMove([['rock', 'paper', 'scissor'], ['rock', 'paper', null]], 1)
+      smartBotRemoval([['rock', 'paper', 'scissor'], ['rock', 'paper', null]], 1)
     ).toEqual(1);
     expect(
-      getOptimalSmartBotMove([['rock', 'paper', 'scissor'], [null, 'paper', 'scissor']], 1)
+      smartBotRemoval([['rock', 'paper', 'scissor'], [null, 'paper', 'scissor']], 1)
     ).toEqual(2);
   });
 
   it('as a second player remove useless piece in second step', () => {
     expect(
-      getOptimalSmartBotMove([[null, 'paper', 'scissor'], [null, null, 'scissor']], 1)
+      smartBotRemoval([[null, 'paper', 'scissor'], [null, null, 'scissor']], 1)
     ).toEqual(2);
   });
 
   it('as a first player remove a piece that you cannot beat if possible', () => {
     expect(
-      getOptimalSmartBotMove([['rock', null, 'scissor'], ['rock', null, 'scissor']], 0)
+      smartBotRemoval([['rock', null, 'scissor'], ['rock', null, 'scissor']], 0)
     ).toEqual(0);
   });
 
   it('as a first player remove a piece that can still beat you if possible', () => {
     expect(
-      getOptimalSmartBotMove([['rock', 'paper', null], ['rock', null, 'scissor']], 0)
+      smartBotRemoval([['rock', 'paper', null], ['rock', null, 'scissor']], 0)
     ).toEqual(2);
   });
 });

--- a/src/components/games/rock-paper-scissor/bot-strategy.ts
+++ b/src/components/games/rock-paper-scissor/bot-strategy.ts
@@ -5,16 +5,12 @@ import type { Board, moves } from './rock-paper-scissor';
 type Bot = BotStrategy<Board, keyof typeof moves>
 
 export const smartBotStrategy: Bot = ({ board, ctx }) => {
-  const idx = getOptimalSmartBotMove(board, ctx.currentPlayer!);
-  return { move: 'removeSymbol', args: [idx] };
-};
-
-export const getOptimalSmartBotMove = (board: Board, currentPlayer: number): number => {
+  const currentPlayer = ctx.currentPlayer!;
   // start with a random place as a first step
   if (currentPlayer === 0) {
     const allowedPlaces = [0, 1, 2].filter(i => board[1][i] !== null);
     if (allowedPlaces.length === 3) {
-      return random(0, 2);
+      return { move: 'removeSymbol', args: [random(0, 2)] };
     }
   }
 
@@ -27,7 +23,7 @@ export const getOptimalSmartBotMove = (board: Board, currentPlayer: number): num
 
       // first is occupied, second is not from given pair
       if (board[0][p[0]] === null && board[1][p[1]] !== null) {
-        return p[1];
+        return { move: 'removeSymbol', args: [p[1]] };
       }
     }
   }
@@ -40,7 +36,7 @@ export const getOptimalSmartBotMove = (board: Board, currentPlayer: number): num
     for (const p of pairs) {
       // first is not occupied, second is occupied from given pair
       if (board[0][p[0]] !== null && board[1][p[1]] === null) {
-        return p[0];
+        return { move: 'removeSymbol', args: [p[0]] };
       }
     }
   }

--- a/src/components/games/rook-to-corner/bot-strategy.spec.ts
+++ b/src/components/games/rook-to-corner/bot-strategy.spec.ts
@@ -1,23 +1,30 @@
 import { range } from 'lodash';
-import { getOptimalSmartBotMove, getRandomBotMove } from './bot-strategy';
+import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { getAllowedMoves, isTarget, boardSize, type Field } from './helpers';
+import { botNextMoveArgs, makeCtx } from '../../../test-utils';
 
 const isAllowed = (from: Field, to: Field) =>
   getAllowedMoves({ rookPosition: from }).some(m => m.row === to.row && m.col === to.col);
 
+const target = (strategy: typeof smartBotStrategy, rookPosition: Field): Field =>
+  botNextMoveArgs(strategy({ board: { rookPosition }, ctx: makeCtx() }))[0];
+
+const smartTarget = (rookPosition: Field) => target(smartBotStrategy, rookPosition);
+const randomTarget = (rookPosition: Field) => target(randomBotStrategy, rookPosition);
+
 describe('rook to corner', () => {
-  describe('getOptimalSmartBotMove()', () => {
+  describe('smartBotStrategy', () => {
     it('moves down onto the diagonal from an off-diagonal position with row < col', () => {
-      expect(getOptimalSmartBotMove({ rookPosition: { row: 2, col: 5 } })).toEqual({ row: 5, col: 5 });
+      expect(smartTarget({ row: 2, col: 5 })).toEqual({ row: 5, col: 5 });
     });
 
     it('moves right onto the diagonal from an off-diagonal position with row > col', () => {
-      expect(getOptimalSmartBotMove({ rookPosition: { row: 6, col: 1 } })).toEqual({ row: 6, col: 6 });
+      expect(smartTarget({ row: 6, col: 1 })).toEqual({ row: 6, col: 6 });
     });
 
     it('wins immediately by reaching the bottom-right corner when possible', () => {
-      expect(getOptimalSmartBotMove({ rookPosition: { row: 7, col: 2 } })).toEqual({ row: 7, col: 7 });
-      expect(getOptimalSmartBotMove({ rookPosition: { row: 3, col: 7 } })).toEqual({ row: 7, col: 7 });
+      expect(smartTarget({ row: 7, col: 2 })).toEqual({ row: 7, col: 7 });
+      expect(smartTarget({ row: 3, col: 7 })).toEqual({ row: 7, col: 7 });
     });
 
     it('from any non-diagonal position plays a legal move onto the diagonal', () => {
@@ -25,7 +32,7 @@ describe('rook to corner', () => {
         for (let col = 0; col < boardSize; col++) {
           if (row === col) continue;
           const from = { row, col };
-          const move = getOptimalSmartBotMove({ rookPosition: from });
+          const move = smartTarget(from);
           expect(move.row).toBe(move.col); // landed on the diagonal (a P-position)
           expect(isAllowed(from, move)).toBe(true);
         }
@@ -34,21 +41,21 @@ describe('rook to corner', () => {
 
     it('from a diagonal (losing) position still plays a legal move', () => {
       const from = { row: 3, col: 3 };
-      const move = getOptimalSmartBotMove({ rookPosition: from });
+      const move = smartTarget(from);
       expect(isAllowed(from, move)).toBe(true);
     });
   });
 
-  describe('getRandomBotMove()', () => {
+  describe('randomBotStrategy', () => {
     it('takes an immediate win when the target is reachable', () => {
-      expect(isTarget(getRandomBotMove({ rookPosition: { row: 7, col: 3 } }))).toBe(true);
-      expect(isTarget(getRandomBotMove({ rookPosition: { row: 1, col: 7 } }))).toBe(true);
+      expect(isTarget(randomTarget({ row: 7, col: 3 }))).toBe(true);
+      expect(isTarget(randomTarget({ row: 1, col: 7 }))).toBe(true);
     });
 
     it('otherwise plays a legal move', () => {
       const from = { row: 2, col: 3 };
       range(30).forEach(() => {
-        expect(isAllowed(from, getRandomBotMove({ rookPosition: from }))).toBe(true);
+        expect(isAllowed(from, randomTarget(from))).toBe(true);
       });
     });
   });

--- a/src/components/games/rook-to-corner/bot-strategy.ts
+++ b/src/components/games/rook-to-corner/bot-strategy.ts
@@ -1,23 +1,17 @@
 import { sample } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
-import { getAllowedMoves, isTarget, type Board, type Field } from './helpers';
+import { getAllowedMoves, isTarget, type Board } from './helpers';
 import type { moves } from './rook-to-corner';
 
 type Bot = BotStrategy<Board, keyof typeof moves>
 
-export const randomBotStrategy: Bot = ({ board }) =>
-  ({ move: 'moveRook', args: [getRandomBotMove(board)] });
-
 // Random play, but grab an immediate win (moving onto the bottom-right square)
 // whenever one is available.
-export const getRandomBotMove = (board: Board): Field => {
+export const randomBotStrategy: Bot = ({ board }) => {
   const allowedMoves = getAllowedMoves(board);
   const winningMove = allowedMoves.find(isTarget);
-  return winningMove ?? sample(allowedMoves)!;
+  return { move: 'moveRook', args: [winningMove ?? sample(allowedMoves)!] };
 };
-
-export const smartBotStrategy: Bot = ({ board }) =>
-  ({ move: 'moveRook', args: [getOptimalSmartBotMove(board)] });
 
 // The game is 2-heap Nim: the distances to the right and bottom edges are the
 // two heaps, and each move shrinks exactly one of them. The losing
@@ -26,13 +20,13 @@ export const smartBotStrategy: Bot = ({ board }) =>
 // move back onto the diagonal; from a diagonal (losing) position every move
 // loses to optimal play, so we make an arbitrary legal move and hope the
 // opponent slips.
-export const getOptimalSmartBotMove = (board: Board): Field => {
+export const smartBotStrategy: Bot = ({ board }) => {
   const { row, col } = board.rookPosition;
   if (row < col) {
-    return { row: col, col }; // move down onto the diagonal
+    return { move: 'moveRook', args: [{ row: col, col }] }; // move down onto the diagonal
   }
   if (row > col) {
-    return { row, col: row }; // move right onto the diagonal
+    return { move: 'moveRook', args: [{ row, col: row }] }; // move right onto the diagonal
   }
-  return sample(getAllowedMoves(board))!;
+  return { move: 'moveRook', args: [sample(getAllowedMoves(board))!] };
 };

--- a/src/components/games/single-number-increase/superstitious-counting/bot-strategy.spec.ts
+++ b/src/components/games/single-number-increase/superstitious-counting/bot-strategy.spec.ts
@@ -1,13 +1,18 @@
-import { getOptimalBotStep } from './bot-strategy';
+import { smartBotStrategy } from './bot-strategy';
+import { botNextMoveArgs, makeCtx } from '../../../../test-utils';
+import type { Board } from './superstitious-counting';
 
-describe('superstitious-counting getOptimalBotStep', () => {
+const smartBotStep = (board: Board): number =>
+  botNextMoveArgs(smartBotStrategy({ board, ctx: makeCtx() }))[0];
+
+describe('superstitious-counting smartBotStrategy', () => {
   it('returns any valid step when remainder is 0 (any step wins)', () => {
     // (20 - 6) % 14 === 0. Loop to exercise the random draw: every result must stay
     // within 1..12, never equal the restricted value, and the full allowed set must
     // eventually appear (catches off-by-one range bugs and a broken restricted filter).
     const seen = new Set<number>();
     for (let i = 0; i < 300; i++) {
-      const step = getOptimalBotStep({ current: 6, target: 20, restricted: 3 });
+      const step = smartBotStep({ current: 6, target: 20, restricted: 3 });
       expect(step).toBeGreaterThanOrEqual(1);
       expect(step).toBeLessThanOrEqual(12);
       expect(step).not.toBe(3);
@@ -20,7 +25,7 @@ describe('superstitious-counting getOptimalBotStep', () => {
     // (15 - 0) % 14 === 1
     const seen = new Set<number>();
     for (let i = 0; i < 300; i++) {
-      const step = getOptimalBotStep({ current: 0, target: 15, restricted: 5 });
+      const step = smartBotStep({ current: 0, target: 15, restricted: 5 });
       expect(step).toBeGreaterThanOrEqual(1);
       expect(step).toBeLessThanOrEqual(12);
       expect(step).not.toBe(5);
@@ -31,17 +36,17 @@ describe('superstitious-counting getOptimalBotStep', () => {
 
   it('returns the unique winning step when it is not restricted', () => {
     // (20 - 1) % 14 === 5, winning step = 5 - 1 = 4
-    expect(getOptimalBotStep({ current: 1, target: 20, restricted: 2 })).toBe(4);
+    expect(smartBotStep({ current: 1, target: 20, restricted: 2 })).toBe(4);
   });
 
   it('returns the unique winning step for another board state', () => {
     // (21 - 2) % 14 === 5, winning step = 4
-    expect(getOptimalBotStep({ current: 2, target: 21, restricted: 1 })).toBe(4);
+    expect(smartBotStep({ current: 2, target: 21, restricted: 1 })).toBe(4);
   });
 
   it('falls back to a valid random step when the winning step equals restricted', () => {
     // (20 - 1) % 14 === 5, winning step = 4, but 4 is restricted
-    const step = getOptimalBotStep({ current: 1, target: 20, restricted: 4 });
+    const step = smartBotStep({ current: 1, target: 20, restricted: 4 });
     expect(step).toBeGreaterThanOrEqual(1);
     expect(step).toBeLessThanOrEqual(12);
     expect(step).not.toBe(4);

--- a/src/components/games/single-number-increase/superstitious-counting/bot-strategy.ts
+++ b/src/components/games/single-number-increase/superstitious-counting/bot-strategy.ts
@@ -7,21 +7,18 @@ type Bot = BotStrategy<Board, keyof typeof moves>
 export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'step', args: [randomStep(board.restricted)] });
 
-export const smartBotStrategy: Bot = ({ board }) => {
-  const step = getOptimalBotStep(board);
-  return { move: 'step', args: [step] };
-};
-
-export const getOptimalBotStep = ({ current, target, restricted }) => {
+export const smartBotStrategy: Bot = ({ board: { current, target, restricted } }) => {
   if ((target - current) % 14 === 0) { // any step wins
-    return randomStep(restricted);
+    return { move: 'step', args: [randomStep(restricted)] };
   }
   if ((target - current) % 14 === 1) { // any step looses
-    return randomStep(restricted);
+    return { move: 'step', args: [randomStep(restricted)] };
   }
   // only one winning step
-  if ((target - current) % 14 - 1 === restricted) return randomStep(restricted);
-  else return (target - current) % 14 - 1;
+  if ((target - current) % 14 - 1 === restricted) {
+    return { move: 'step', args: [randomStep(restricted)] };
+  }
+  return { move: 'step', args: [(target - current) % 14 - 1] };
 };
 
 const randomStep = (restricted) => {

--- a/src/components/games/tictactoe-alikes/anti-tictactoe/bot-strategy.ts
+++ b/src/components/games/tictactoe-alikes/anti-tictactoe/bot-strategy.ts
@@ -10,17 +10,11 @@ export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'placePiece', args: [sample(emptyCells(board))] });
 
 export const smartBotStrategy: Bot = ({ board, ctx }) => {
-  const id = getOptimalBotPlacingPosition(board, ctx.chosenRoleIndex);
-  return { move: 'placePiece', args: [id] };
-};
-
-const emptyCells = (board: Board) => range(0, 9).filter(i => isNull(board[i]));
-
-const getOptimalBotPlacingPosition = (board: Board, chosenRoleIndex) => {
+  const chosenRoleIndex = ctx.chosenRoleIndex!;
   const allowedPlaces = emptyCells(board);
 
   // start with middle place as a first step
-  if (allowedPlaces.length === 9) return 4;
+  if (allowedPlaces.length === 9) return { move: 'placePiece', args: [4] };
 
   // as a first player, proceed with placing at an empty place symmetrical to player's piece
   if (chosenRoleIndex === 1) {
@@ -29,7 +23,7 @@ const getOptimalBotPlacingPosition = (board: Board, chosenRoleIndex) => {
     for (const p of pairs) {
       // first is occupied, second is not from given pair
       if (!isNull(board[p[0]]) && isNull(board[p[1]])) {
-        return p[1];
+        return { move: 'placePiece', args: [p[1]] };
       }
     }
   }
@@ -43,15 +37,19 @@ const getOptimalBotPlacingPosition = (board: Board, chosenRoleIndex) => {
     return isWinningState(boardCopy, chosenRoleIndex === 1);
   });
 
-  if (optimalPlaces.length > 0) return sample(optimalPlaces);
+  if (optimalPlaces.length > 0) return { move: 'placePiece', args: [sample(optimalPlaces)] };
 
   // even if we are gonna lose, try to prolong it
   const aiPieces = range(0, 9).filter(i => board[i] === botColor);
   const notInstantLosingPlaces = allowedPlaces.filter(i => !hasWinningSubset([...aiPieces, i]));
-  if (notInstantLosingPlaces.length > 0) return sample(notInstantLosingPlaces);
+  if (notInstantLosingPlaces.length > 0) {
+    return { move: 'placePiece', args: [sample(notInstantLosingPlaces)] };
+  }
 
-  return sample(allowedPlaces);
+  return { move: 'placePiece', args: [sample(allowedPlaces)] };
 };
+
+const emptyCells = (board: Board) => range(0, 9).filter(i => isNull(board[i]));
 
 // given board *after* your step, are you set up to win the game for sure?
 const isWinningState = (board: Board, amIFirst) => {

--- a/src/components/games/totem-poles/triangular-grid-ropes-10/bot-strategy.ts
+++ b/src/components/games/totem-poles/triangular-grid-ropes-10/bot-strategy.ts
@@ -23,20 +23,16 @@ export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'stretchRope', args: [sample(getAllowedMoves(board))] });
 
 export const smartBotStrategy: Bot = ({ board, ctx }) => {
-  const move = getOptimalSmartBotMove({ board, chosenRoleIndex: ctx.chosenRoleIndex });
-  return { move: 'stretchRope', args: [move] };
-};
-
-const getOptimalSmartBotMove = ({ board, chosenRoleIndex }: { board: Board, chosenRoleIndex: number | null }) => {
   const allowedMoves = getAllowedMoves(board);
-  if (chosenRoleIndex === 1) {
+  if (ctx.chosenRoleIndex === 1) {
     if (board.length === 0) {
-      return sample([{ from: 3, to: 5 }, { from: 1, to: 8 }, { from: 2, to: 7 }]);
+      const opening = sample([{ from: 3, to: 5 }, { from: 1, to: 8 }, { from: 2, to: 7 }]);
+      return { move: 'stretchRope', args: [opening] };
     } else {
       const symDir = edgeDirection(board[0]!)!;
       const lastMove = last(board)!;
       if (edgeDirection(lastMove) === symDir) {
-        return allowedMoves.find(e => edgeDirection(e) === symDir);
+        return { move: 'stretchRope', args: [allowedMoves.find(e => edgeDirection(e) === symDir)] };
       } else {
         const mirrorOfLastMove: Edge = {
           from: mirrorNodes[symDir][lastMove.from],
@@ -44,9 +40,9 @@ const getOptimalSmartBotMove = ({ board, chosenRoleIndex }: { board: Board, chos
         };
         if (!isAllowed(board, mirrorOfLastMove)) {
           console.error('Unexpected state, falling back');
-          return sample(allowedMoves);
+          return { move: 'stretchRope', args: [sample(allowedMoves)] };
         }
-        return mirrorOfLastMove;
+        return { move: 'stretchRope', args: [mirrorOfLastMove] };
       }
     }
   }
@@ -57,7 +53,7 @@ const getOptimalSmartBotMove = ({ board, chosenRoleIndex }: { board: Board, chos
   });
 
   if (nonTrivialMoves.length === 0) {
-    return sample(allowedMoves);
+    return { move: 'stretchRope', args: [sample(allowedMoves)] };
   }
 
   if (trivialMoves.length % 2 === 0) {
@@ -69,7 +65,7 @@ const getOptimalSmartBotMove = ({ board, chosenRoleIndex }: { board: Board, chos
     });
 
     if (optimalMove !== undefined) {
-      return optimalMove;
+      return { move: 'stretchRope', args: [optimalMove] };
     }
   } else {
     const simBoard = [...board, ...tail(trivialMoves)];
@@ -80,11 +76,11 @@ const getOptimalSmartBotMove = ({ board, chosenRoleIndex }: { board: Board, chos
     });
 
     if (optimalMove !== undefined) {
-      return optimalMove;
+      return { move: 'stretchRope', args: [optimalMove] };
     }
   }
 
-  return sample(allowedMoves);
+  return { move: 'stretchRope', args: [sample(allowedMoves)] };
 };
 
 // given board *after* your step, are you set up to win the game for sure?

--- a/src/components/games/triangle-coloring/triangle-coloring.tsx
+++ b/src/components/games/triangle-coloring/triangle-coloring.tsx
@@ -149,20 +149,12 @@ const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'colorTriangle', args: [sample(getAllowedMoves(board))] });
 
 const smartBotStrategy: Bot = ({ board }) => {
-  const optimalMove = getOptimalSmartBotMove(board);
-  return { move: 'colorTriangle', args: [optimalMove] };
-};
-
-const getOptimalSmartBotMove = (board: Board) => {
   const allowedMoves = getAllowedMoves(board);
   const optimalPlace = shuffle(allowedMoves).find(
     i => isWinningState(withTriangleColored(board, i))
   );
 
-  if (optimalPlace !== undefined) {
-    return optimalPlace;
-  }
-  return sample(allowedMoves);
+  return { move: 'colorTriangle', args: [optimalPlace ?? sample(allowedMoves)] };
 };
 
 // given board *after* your step, are you set up to win the game for sure?

--- a/src/components/games/twelve-squares/twelve-squares.tsx
+++ b/src/components/games/twelve-squares/twelve-squares.tsx
@@ -62,17 +62,12 @@ const randomBotStrategy: Bot = ({ board }) => {
   return { move: 'step', args: [sample(validSteps)] };
 };
 
-const optimalBotStrategy: Bot = ({ board }) => {
-  const step = getOptimalBotStep(board);
-  return { move: 'step', args: [step] };
-};
-
-const getOptimalBotStep = ({ left, right }) => {
+const optimalBotStrategy: Bot = ({ board: { left, right } }) => {
   const dst = right-left;
-  if(dst === 1) return 2;
-  if(dst === 2) return 1;
-  if(dst % 3 === 2) return random(1,2);
-  return (dst+1) % 3;
+  if(dst === 1) return { move: 'step', args: [2] };
+  if(dst === 2) return { move: 'step', args: [1] };
+  if(dst % 3 === 2) return { move: 'step', args: [random(1,2)] };
+  return { move: 'step', args: [(dst+1) % 3] };
 };
 
 export const moves = {


### PR DESCRIPTION
Follows up the review comment on #388: *"now that bot strategies are pure, easily testable, these thin wrappers are not justified imo, they were extracted for the sole purpose of easier unit testing from the strategy itself"*. Agreed, and it was a pattern rather than a one-off — 13 games had it.

## The shape being removed

```ts
export const smartBotStrategy: Bot = ({ board }) => {
  const botMove = getOptimalSmartBotMove(board);
  return { move: 'moveRook', args: [botMove] };
};

export const getOptimalSmartBotMove = (board: Board): Field => { /* the actual strategy */ };
```

Each strategy now names its move at the point it decides:

```ts
export const smartBotStrategy: Bot = ({ board }) => {
  ...
  if (allowedHorizontalMoves.length < allowedVerticalMoves.length) {
    return { move: 'moveRook', args: [last(allowedVerticalMoves)!] };
  }
  ...
};
```

## Games

`chess-knight`, `chess-ducks`, `chess-bishops`, `chess-rook`, `rook-to-corner`, `rock-paper-scissor`, `number-covering`, `triangle-coloring`, `twelve-squares`, `anti-tictactoe`, `magic-box-a`, `superstitious-counting`, `triangular-grid-ropes-10`.

Five had a spec importing the helper directly — `chess-bishops`, `chess-rook`, `rook-to-corner`, `rock-paper-scissor`, `superstitious-counting`, `magic-box-a` — which is the evidence for the original point: the export existed for the test. Those specs now read the decision off the bot:

```ts
const smartBotTarget = (board: Board): Field =>
  botNextMoveArgs(smartBotStrategy({ board, ctx: makeCtx() }))[0];
```

`chess-knight` and `chess-ducks` had no spec at all, so their split was pure leftover.

## Helpers whose parameters restated `ctx`

Four of them took as arguments what the strategy already had: `rock-paper-scissor` (`currentPlayer`), `triangular-grid-ropes-10` and `magic-box-a` / `anti-tictactoe` (`chosenRoleIndex`), while `twelve-squares` and `superstitious-counting` destructured the board a second time. Those parameters are gone — the strategies read `ctx` and destructure `board` once.

## Notes

- `number-covering` had to export its `Board` type for the spec; nothing else changed shape.
- `rook-to-corner`'s `getRandomBotMove` is inlined too — same pattern, same reason.
- The Nim explanation above `rook-to-corner`'s helper and the "live search is too slow" comments in `chess-ducks` moved with the code they explain.

## Verification

`npm test` — versions, lint, typecheck, 1215 tests, all green (same count as before: the spec rewrites replaced assertions rather than dropping them).

All 13 games were also played in a browser as the second player, confirming the bot still moves and no page errors are raised.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgKsSPf9CbvBkKhZKC94yN)_