### PR TITLE
Let a game pin its bots' move arguments, not just the names

### DIFF
--- a/.claude/commands/new-game.md
+++ b/.claude/commands/new-game.md
@@ -47,7 +47,6 @@ Create `src/components/games/<game-name>/<game-name>.tsx`. The contract you are 
 - For user-facing text referring to the other participant, prefer "other player" / "másik játékos" over "opponent" / "ellenfél" — the latter reads as too harsh, especially in Hungarian
 - `getPlayerStepDescription` should make it obvious what the current player should do — it is the game's instruction line, not a status label
 - Keep the game's `moves` (and the `Board` type) in a React-free `helpers.ts` when the game is more than trivial: it is what lets a spec and the bot's move pinning import them without pulling in JSX
-- Export the moves as a type next to them (`export type Moves = typeof moves`) and give the bots `BotStrategy<Board, Moves>`, which makes a mistyped move name or a wrong argument list a typecheck error. Annotate every `apply` parameter — an unannotated one types as `any` and checks nothing
 - Pull `name`, `title`, `credit` from `gameList` rather than hardcoding them
 
 ### 5. Re-export the component from `src/components/games/index.ts`

--- a/.claude/commands/new-game.md
+++ b/.claude/commands/new-game.md
@@ -46,7 +46,8 @@ Create `src/components/games/<game-name>/<game-name>.tsx`. The contract you are 
 - If the user supplied the rule text, use it verbatim in `rule.hu` by default. Don't silently rephrase, correct, or abbreviate it. **Exception:** when the original wording doesn't fit the online implementation — e.g. it refers to the competition organizers/judges instead of the opponent/computer, or to physical artifacts (paper, pencil, cards on a table) that don't exist in the browser version — it's fine to reword it slightly to fit. In that case, explicitly highlight every change you made to the user (e.g. show before/after) so they can review it. For any other wording change, propose it and wait for approval before applying.
 - For user-facing text referring to the other participant, prefer "other player" / "másik játékos" over "opponent" / "ellenfél" — the latter reads as too harsh, especially in Hungarian
 - `getPlayerStepDescription` should make it obvious what the current player should do — it is the game's instruction line, not a status label
-- Keep the game's `moves` (and the `Board` type) in a React-free `helpers.ts` when the game is more than trivial: it is what lets a spec and the bot's move-name pinning import them without pulling in JSX
+- Keep the game's `moves` (and the `Board` type) in a React-free `helpers.ts` when the game is more than trivial: it is what lets a spec and the bot's move pinning import them without pulling in JSX
+- Export the moves as a type next to them (`export type Moves = typeof moves`) and give the bots `BotStrategy<Board, Moves>`, which makes a mistyped move name or a wrong argument list a typecheck error. Annotate every `apply` parameter — an unannotated one types as `any` and checks nothing
 - Pull `name`, `title`, `credit` from `gameList` rather than hardcoding them
 
 ### 5. Re-export the component from `src/components/games/index.ts`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,22 +170,33 @@ headless match — and asks the strategy again while the turn is still its own.
 Naming a move after the turn ended is a bug (dev: throw); naming moves the
 game-winning move made moot is fine (they are dropped).
 
-`BotMove.move` is a string, so a mistyped name would only surface when the bot
-plays it (dev: throw, naming the move names the game does have). Every game
-therefore pins the union to its own moves, which turns a typo into a typecheck
-error — follow suit in a new game:
+Left unpinned, `BotMove` is `{ move: string, args?: unknown[] }`, so neither a
+mistyped name nor wrong arguments surface until the bot plays the move (dev:
+throw). A game pins both by exporting its moves as a type, next to the moves
+themselves:
 
 ```ts
-import type { Board, moves } from './helpers';
+// helpers.ts, under the moves object
+export type Moves = typeof moves;
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+// bot-strategy.ts
+import type { Board, Moves } from './helpers';
+
+type Bot = BotStrategy<Board, Moves>
 
 export const smartBotStrategy: Bot = ({ board }) => ({ move: 'removeLine', args: [choice] });
 ```
 
-Give the union its own `type MoveName = keyof typeof moves` alias only where
-something else names it too — a helper that builds a turn's moves returns
-`BotMove<MoveName>[]` (see `coins-in-3-piles`'s `asTurn`).
+`BotStrategy<Board, Moves>` derives the move names **and** each move's argument
+list from `apply`, so a typo, a wrong arity and a wrong argument type are all
+typecheck errors at the bot that made them. A helper that builds a turn's moves
+takes the same parameter: `BotMove<Moves>[]` (see `coins-in-3-piles`'s
+`asTurn`).
+
+The argument half is only as precise as `apply`'s signature — an unannotated
+parameter there types as `any` and silently checks nothing, so annotate them.
+`BotStrategy<Board>` (or a bare name union) still works and pins nothing beyond
+the name; a game that has not been converted yet keeps compiling.
 
 **`ctx`** fields available in moves and `BoardClient`:
 - `currentPlayer`: 0/1 — use this for game logic in both modes

--- a/src/components/games/coins-in-3-piles/bot-strategy.ts
+++ b/src/components/games/coins-in-3-piles/bot-strategy.ts
@@ -1,14 +1,13 @@
 import { findIndex, sample, range } from 'lodash';
 import type { BotMove, BotStrategy } from '../../strategy-game-factory';
-import type { Board, moves } from './helpers';
+import type { Board, Moves } from './helpers';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, Moves>
 
 // A turn is one decision — which coin to take, which to place back — so it is
 // named as a whole. Taking a 1-pengő coin has no place-back half at all.
-const asTurn = ({ remove, add }: TurnPlan): BotMove<MoveName>[] => {
-  const removal: BotMove<MoveName> = { move: 'removeCoin', args: [remove] };
+const asTurn = ({ remove, add }: TurnPlan): BotMove<Moves>[] => {
+  const removal: BotMove<Moves> = { move: 'removeCoin', args: [remove] };
   if (remove === 1) return [removal];
   return [removal, add === null ? { move: 'passAddition' } : { move: 'addCoin', args: [add] }];
 };

--- a/src/components/games/coins-in-3-piles/helpers.ts
+++ b/src/components/games/coins-in-3-piles/helpers.ts
@@ -31,7 +31,7 @@ export const moves = {
   removeCoin: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, value: number) =>
       ctx.turnState === null && value >= 1 && value <= 3 && board[value - 1] > 0,
-    apply: (board: Board, { ctx }: { ctx: Ctx }, value): MoveOutcome<Board> => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, value: number): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard[value - 1] -= 1;
       if (value === 1) {
@@ -48,7 +48,7 @@ export const moves = {
       const removed = (ctx.turnState as { removedCoinValue: number } | null)?.removedCoinValue;
       return removed != null && value >= 1 && value < removed;
     },
-    apply: (board: Board, { ctx }: { ctx: Ctx }, value) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, value: number) => {
       const nextBoard = cloneDeep(board);
       nextBoard[value - 1] += 1;
       return finishPlaceBack(nextBoard, ctx);
@@ -59,6 +59,10 @@ export const moves = {
     apply: (board: Board, { ctx }: { ctx: Ctx }) => finishPlaceBack(board, ctx)
   }
 }
+
+// The moves as a type, so a bot can name them: `BotStrategy<Board, Moves>`
+// pins both the move name and the arguments it takes.
+export type Moves = typeof moves
 
 // Shared second half of the place-back phase: whether a coin was added or the
 // player passed, the turn ends the same way.

--- a/src/components/games/coins-in-3-piles/helpers.ts
+++ b/src/components/games/coins-in-3-piles/helpers.ts
@@ -60,8 +60,6 @@ export const moves = {
   }
 }
 
-// The moves as a type, so a bot can name them: `BotStrategy<Board, Moves>`
-// pins both the move name and the arguments it takes.
 export type Moves = typeof moves
 
 // Shared second half of the place-back phase: whether a coin was added or the

--- a/src/components/games/recolouring-discs/bot-strategy.ts
+++ b/src/components/games/recolouring-discs/bot-strategy.ts
@@ -11,10 +11,9 @@ import {
   majorityWinner
 } from './helpers';
 import { solveForN } from './solver';
-import type { moves } from './recolouring-discs';
+import type { Moves } from './recolouring-discs';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, Moves>
 
 interface Option {
   move: Move;
@@ -24,7 +23,7 @@ interface Option {
 const optionsFor = (cells: Cell[], player: number): Option[] =>
   legalMoves(cells, player).map(move => ({ move, cells: applyMove(cells, player, move) }));
 
-const asBotMove = (move: Move): BotMove<MoveName> => {
+const asBotMove = (move: Move): BotMove<Moves> => {
   if (move.type === 'move') return { move: 'moveDisc', args: [move.from, move.to] };
   if (move.type === 'place') return { move: 'placeDisc', args: [move.to] };
   return { move: 'pass' };

--- a/src/components/games/recolouring-discs/recolouring-discs.tsx
+++ b/src/components/games/recolouring-discs/recolouring-discs.tsx
@@ -52,6 +52,10 @@ export const moves = {
   }
 };
 
+// The moves as a type, so a bot can name them: `BotStrategy<Board, Moves>`
+// pins both the move name and the arguments it takes.
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     Egy sorban <i>n</i> mező van (itt legfeljebb 12); kezdetben a bal szélső mezőben egy piros, a jobb szélső

--- a/src/components/games/recolouring-discs/recolouring-discs.tsx
+++ b/src/components/games/recolouring-discs/recolouring-discs.tsx
@@ -52,8 +52,6 @@ export const moves = {
   }
 };
 
-// The moves as a type, so a bot can name them: `BotStrategy<Board, Moves>`
-// pins both the move name and the arguments it takes.
 export type Moves = typeof moves;
 
 const rule = {

--- a/src/components/games/remove-row-or-column/bot-strategy.ts
+++ b/src/components/games/remove-row-or-column/bot-strategy.ts
@@ -1,10 +1,10 @@
 import { sample, random } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
 import {
-  type Board, type Grid, type moves, getRectangles, getAllMoves, applyMove, isEmpty
+  type Board, type Grid, type Moves, getRectangles, getAllMoves, applyMove, isEmpty
 } from './helpers';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 // Sprague–Grundy value of a single a×b rectangle. A move removes a full row
 // (splitting a×b into (i-1)×b and (a-i)×b) or a full column (a×(j-1) and

--- a/src/components/games/remove-row-or-column/helpers.ts
+++ b/src/components/games/remove-row-or-column/helpers.ts
@@ -88,8 +88,6 @@ export const moves = {
   }
 };
 
-// The moves as a type, so a bot can name them: `BotStrategy<Board, Moves>`
-// pins both the move name and the arguments it takes.
 export type Moves = typeof moves;
 
 // Every legal move: for each rectangle, one move per row and one per column.

--- a/src/components/games/remove-row-or-column/helpers.ts
+++ b/src/components/games/remove-row-or-column/helpers.ts
@@ -88,6 +88,10 @@ export const moves = {
   }
 };
 
+// The moves as a type, so a bot can name them: `BotStrategy<Board, Moves>`
+// pins both the move name and the arguments it takes.
+export type Moves = typeof moves;
+
 // Every legal move: for each rectangle, one move per row and one per column.
 export const getAllMoves = (grid: Grid): Move[] => {
   const moves: Move[] = [];

--- a/src/components/strategy-game-factory/types.spec.ts
+++ b/src/components/strategy-game-factory/types.spec.ts
@@ -1,0 +1,59 @@
+import type { BotMove, Ctx, MoveOutcome } from './types';
+
+// A miniature game to pin `BotMove` against. Its `apply` signatures are what
+// the argument types are derived from, so they are annotated as a real game's
+// must be.
+const moves = {
+  take: {
+    apply: (board: number, _: { ctx: Ctx }, count: number): MoveOutcome<number> =>
+      ({ nextBoard: board - count })
+  },
+  swap: {
+    apply: (board: number, _: { ctx: Ctx }, from: number, to: number): MoveOutcome<number> =>
+      ({ nextBoard: board + from - to })
+  },
+  pass: {
+    apply: (board: number): MoveOutcome<number> => ({ nextBoard: board })
+  }
+};
+type Moves = typeof moves;
+
+// These assertions are checked by `tsc`, not at runtime: each @ts-expect-error
+// fails the build if the mistake below it ever starts compiling again.
+describe('BotMove pinned to a game', () => {
+  it('accepts each move with the arguments its apply takes', () => {
+    const named: BotMove<Moves>[] = [
+      { move: 'take', args: [2] },
+      { move: 'swap', args: [1, 3] },
+      { move: 'pass' }
+    ];
+    expect(named.map(({ move }) => move)).toEqual(Object.keys(moves));
+  });
+
+  it('rejects a move the game does not have', () => {
+    // @ts-expect-error 'takee' is not one of this game's moves
+    const named: BotMove<Moves> = { move: 'takee', args: [2] };
+    expect(named.move).toBe('takee');
+  });
+
+  it('rejects the wrong number of arguments', () => {
+    // @ts-expect-error take() takes exactly one argument
+    const tooMany: BotMove<Moves> = { move: 'take', args: [2, 3] };
+    // @ts-expect-error swap() takes two
+    const tooFew: BotMove<Moves> = { move: 'swap', args: [1] };
+    // @ts-expect-error pass() takes none
+    const unwanted: BotMove<Moves> = { move: 'pass', args: [1] };
+    expect([tooMany, tooFew, unwanted]).toHaveLength(3);
+  });
+
+  it('rejects an argument of the wrong type', () => {
+    // @ts-expect-error take() takes a number
+    const named: BotMove<Moves> = { move: 'take', args: ['2'] };
+    expect(named.args).toEqual(['2']);
+  });
+
+  it('leaves args unchecked when given only a union of names', () => {
+    const named: BotMove<'take' | 'swap'> = { move: 'take', args: ['anything', 1] };
+    expect(named.args).toHaveLength(2);
+  });
+});

--- a/src/components/strategy-game-factory/types.ts
+++ b/src/components/strategy-game-factory/types.ts
@@ -73,8 +73,22 @@ export type ClientGameMoves<TBoard> = Record<
     & { isAllowed: (board: TBoard, ...args: any[]) => boolean }
 >
 export type StrategyArgs<TBoard> = { board: TBoard; ctx: Ctx }
-// A move a bot wants played, named rather than dispatched.
-export type BotMove<TMoveName extends string = string> = { move: TMoveName; args?: unknown[] }
+// A game's `moves` object seen as a type — what a game exports as `Moves` so
+// its bots can name moves out of it.
+export type AnyMoves = Record<string, MoveDefinition<any>>
+// What a move takes beyond the board and the meta object: exactly the tail a
+// bot has to supply as `args`.
+type MoveArgs<TApply> =
+  TApply extends (board: any, meta: any, ...args: infer TArgs) => any ? TArgs : never
+// A move a bot wants played, named rather than dispatched. Parameterised by the
+// game's `Moves` it pins both halves: naming a move the game does not have, or
+// passing it the wrong arguments, is a typecheck error at the bot. Given only a
+// union of names (or nothing) it still pins the name, leaving `args` unchecked.
+export type BotMove<TMoves extends string | AnyMoves = string> =
+  TMoves extends string ? { move: TMoves; args?: unknown[] }
+  : TMoves extends AnyMoves
+    ? { [K in keyof TMoves]: { move: K; args?: MoveArgs<TMoves[K]['apply']> } }[keyof TMoves]
+    : never
 // A bot is a pure function of the position: it names the move it wants, or the
 // whole sequence when the turn is planned as one decision, and the engine plays
 // them out — paced in the browser so the bot appears to think, immediately in a
@@ -83,8 +97,8 @@ export type BotMove<TMoveName extends string = string> = { move: TMoveName; args
 // board to thread, so the same function can run on an authoritative server.
 // If the turn is still the bot's once its moves are played, it is asked again
 // (see engine/bot-turn.ts), so naming one move at a time is equally fine.
-export type BotStrategy<TBoard, TMoveName extends string = string> =
-  (args: StrategyArgs<TBoard>) => BotMove<TMoveName> | BotMove<TMoveName>[]
+export type BotStrategy<TBoard, TMoves extends string | AnyMoves = string> =
+  (args: StrategyArgs<TBoard>) => BotMove<TMoves> | BotMove<TMoves>[]
 export type BoardClientProps<TBoard> = Omit<StrategyArgs<TBoard>, 'moves'> & {
   moves: ClientGameMoves<TBoard>
   // Writes the mid-turn UI state a BoardClient needs to remember (which pile is


### PR DESCRIPTION
Closes the gap #389 left, and answers the `import type { moves }` question from its `bacteria` thread — the two turn out to be the same change.

## The gap

#389 pinned `BotMove.move` to the game's move names, but `args` stayed `unknown[]`, unrelated to the move being named. On `recolouring-discs`, whose `moveDisc` takes `(from, to)`:

```ts
{ move: 'moveDisc', args: [3] }   // compiled fine, failed only when played
```

## The change

`BotStrategy`'s second parameter now also accepts the game's **moves object as a type**, and derives both halves from it — the name union from the keys, each move's argument list from its `apply`:

```ts
export type BotMove<TMoves extends string | AnyMoves = string> =
  TMoves extends string ? { move: TMoves; args?: unknown[] }
  : TMoves extends AnyMoves
    ? { [K in keyof TMoves]: { move: K; args?: MoveArgs<TMoves[K]['apply']> } }[keyof TMoves]
    : never
```

A game exports that type next to the moves it names:

```ts
// helpers.ts, under the moves object
export type Moves = typeof moves;

// bot-strategy.ts
import type { Board, Moves } from './helpers';
type Bot = BotStrategy<Board, Moves>
```

That also removes the oddity you flagged on #389: `moves` is a value, so `import type { moves }` read as though it were a type. `Moves` **is** a type, and `typeof` disappears from the bots. It carries strictly more than a `MoveName` union would — a bare name union cannot express argument types — so it replaces that idea rather than sitting beside it.

## What it catches

All five verified by introducing each mistake and reverting it:

| written in a bot | error |
|---|---|
| `{ move: 'moveDsic', … }` | `Type '"moveDsic"' is not assignable to type '"pass" \| "moveDisc" \| "placeDisc"'. Did you mean '"moveDisc"'?` |
| `{ move: 'moveDisc', args: [from] }` | not assignable to `{ move: "moveDisc"; args?: [from: number, to: number] }` |
| `{ move: 'moveDisc', args: [from, to, 1] }` | `Type 'number' is not assignable to type 'undefined'` |
| `{ move: 'moveDisc', args: ['x', to] }` | `Type 'string' is not assignable to type 'number'` |
| `{ move: 'pass', args: [1] }` | not assignable to `{ move: "pass"; args?: [] }` |

The parameter names survive into the message (`[from: number, to: number]`), so the error says what the move wanted.

## Scope

Per `AGENTS.md` § Pull request size, this is the design plus pilots, not the sweep. The parameter still accepts a bare union of names or nothing, so the other ~75 games compile untouched and convert in a follow-up.

Piloted on three games chosen for what they exercise:
- **`recolouring-discs`** — the only game with a genuinely two-argument move, so the argument half is not theoretical here
- **`coins-in-3-piles`** — a helper that builds a whole turn, now `BotMove<Moves>[]`
- **`remove-row-or-column`** — the shape the docs point at

## Notes

- **The argument half is only as precise as `apply`'s signature.** Two `apply` parameters in `coins-in-3-piles` were unannotated, which types their args as `any` and checks nothing — annotated here, and `AGENTS.md` and the new-game skill now say to annotate them.
- `types.spec.ts` pins the checking itself: each `@ts-expect-error` fails the build if an unknown name, a wrong arity or a wrong argument type ever starts compiling again.

## Verification

`npm test` — versions, lint, typecheck, 1220 tests (1215 + 5 new), all green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgKsSPf9CbvBkKhZKC94yN)_