### PR TITLE
Pin every game's bots to its own moves, arguments included

### DIFF
--- a/src/components/games/add-reduce-double/add-reduce-double.tsx
+++ b/src/components/games/add-reduce-double/add-reduce-double.tsx
@@ -121,6 +121,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     A pályán mindig két kupac korong található. Egy lépésben az éppen soron következő játékos az egyik

--- a/src/components/games/add-reduce-double/bot-strategy.ts
+++ b/src/components/games/add-reduce-double/bot-strategy.ts
@@ -1,8 +1,8 @@
 import { random, sample, range } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
-import type { Board, moves } from './add-reduce-double';
+import type { Board, Moves } from './add-reduce-double';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 export const randomBotStrategy: Bot = ({ board }) => {
   const validMoves: { pileId: number; pieceCount: number }[] = [];
@@ -11,7 +11,7 @@ export const randomBotStrategy: Bot = ({ board }) => {
       validMoves.push({ pileId, pieceCount });
     }
   }
-  return { move: 'moveHalvedPieces', args: [sample(validMoves)] };
+  return { move: 'moveHalvedPieces', args: [sample(validMoves)!] };
 };
 
 export const getSmartBotStep = (board: Board): { pileId: number; pieceCount: number } => {

--- a/src/components/games/amor-and-cupido/amor-and-cupido.tsx
+++ b/src/components/games/amor-and-cupido/amor-and-cupido.tsx
@@ -17,6 +17,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     Cupido és Ámor a következő játékkal ütik el az időt: 6 ember közül felváltva

--- a/src/components/games/amor-and-cupido/bot-strategy.ts
+++ b/src/components/games/amor-and-cupido/bot-strategy.ts
@@ -3,9 +3,9 @@ import type { BotStrategy } from '../../strategy-game-factory';
 import {
   type Board, getAllowedMoves, completesTriangle, canonicalKey
 } from './helpers';
-import type { moves } from './amor-and-cupido';
+import type { Moves } from './amor-and-cupido';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 // Game value of a position, memoised by canonical (isomorphism-reduced) key.
 // Shared across calls/tests: the value depends only on the position and who is

--- a/src/components/games/architect-and-bandits/architect-and-bandits-a/architect-and-bandits-a.tsx
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-a/architect-and-bandits-a.tsx
@@ -73,6 +73,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     Óxisz városa egy szabályos nyolcszög alakú fallal van körülvéve, melynek szomszédos csúcsai 10 km-re

--- a/src/components/games/architect-and-bandits/architect-and-bandits-a/bot-strategy.ts
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-a/bot-strategy.ts
@@ -1,10 +1,9 @@
 import { maxBy } from 'lodash';
 import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
 import type { Board } from '../helpers';
-import type { moves } from './architect-and-bandits-a';
+import type { Moves } from './architect-and-bandits-a';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, Moves>
 
 // Vertices A(0)..H(7) clockwise. Each edge = 10 km, max 4 edges/day.
 // Architect wins by visiting all 8 vertices over 4 days despite 3 nightly destructions.
@@ -28,8 +27,8 @@ export const smartBotStrategy: Bot = ({ board, ctx }) => {
 
 // The architect's whole day is planned as one route (see the strategy above),
 // so its steps are named together, with the day closed at the end of them.
-const asArchitectDay = (path: number[]): BotMove<MoveName>[] => [
-  ...path.map((vertex): BotMove<MoveName> => ({ move: 'moveArchitect', args: [vertex] })),
+const asArchitectDay = (path: number[]): BotMove<Moves>[] => [
+  ...path.map((vertex): BotMove<Moves> => ({ move: 'moveArchitect', args: [vertex] })),
   { move: 'endDay' }
 ];
 
@@ -110,7 +109,7 @@ export const getOptimalArchitectPath = (board: Board) => {
 // Bandit heuristic: pick the tower that maximises the
 // minimum path the architect needs to cover all missing+newly-destroyed vertices.
 // Destroying the architect's current position is excluded: startNextDay rebuilds it for free.
-const banditMove = (board: Board): BotMove<MoveName> => {
+const banditMove = (board: Board): BotMove<Moves> => {
   const pos = board.architectPosition;
   const candidates = board.towers
     .map((t, i) => (t && i !== pos ? i : null))

--- a/src/components/games/architect-and-bandits/architect-and-bandits-b/architect-and-bandits-b.tsx
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-b/architect-and-bandits-b.tsx
@@ -71,6 +71,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     Óxisz városa egy szabályos tízszög alakú fallal van körülvéve, melynek szomszédos csúcsai 10 km-re

--- a/src/components/games/architect-and-bandits/architect-and-bandits-b/bot-strategy.ts
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-b/bot-strategy.ts
@@ -1,10 +1,9 @@
 import { maxBy, sample } from 'lodash';
 import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
 import type { Board } from '../helpers';
-import type { moves } from './architect-and-bandits-b';
+import type { Moves } from './architect-and-bandits-b';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, Moves>
 
 // Vertices A(0)..J(9) clockwise. Each edge = 10 km, max 5 edges/day.
 // Architect wins by visiting all 10 vertices over 4 days despite 3 nightly destructions.
@@ -28,8 +27,8 @@ export const smartBotStrategy: Bot = ({ board, ctx }) => {
 
 // The architect's whole day is planned as one route (see the strategy above),
 // so its steps are named together, with the day closed at the end of them.
-const asArchitectDay = (path: number[]): BotMove<MoveName>[] => [
-  ...path.map((vertex): BotMove<MoveName> => ({ move: 'moveArchitect', args: [vertex] })),
+const asArchitectDay = (path: number[]): BotMove<Moves>[] => [
+  ...path.map((vertex): BotMove<Moves> => ({ move: 'moveArchitect', args: [vertex] })),
   { move: 'endDay' }
 ];
 
@@ -112,7 +111,7 @@ export const getOptimalArchitectPath = (board: Board) => {
 // Bandit heuristic: day 1 random; later days pick the tower that maximises the
 // minimum path the architect needs to cover all missing+newly-destroyed vertices.
 // Destroying the architect's current position is excluded: startNextDay rebuilds it for free.
-const banditMove = (board: Board): BotMove<MoveName> => {
+const banditMove = (board: Board): BotMove<Moves> => {
   const pos = board.architectPosition;
   const candidates = board.towers
     .map((t, i) => (t && i !== pos ? i : null))

--- a/src/components/games/bacteria/bot-strategy.ts
+++ b/src/components/games/bacteria/bot-strategy.ts
@@ -14,10 +14,10 @@ import {
   topRowIdx,
   ATTACKER,
   DEFENDER,
-  type moves
+  type Moves
 } from "./helpers";
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 export type { AttackMove };
 

--- a/src/components/games/bacteria/helpers.ts
+++ b/src/components/games/bacteria/helpers.ts
@@ -126,6 +126,8 @@ export const moves = {
   spread: attackerMove('spread')
 };
 
+export type Moves = typeof moves;
+
 export const isShiftRight = ({ attackRow, attackCol, row, col }) => {
   return attackRow === row && (col === (attackCol + 1));
 };

--- a/src/components/games/bank-robbers/bank-robbers.tsx
+++ b/src/components/games/bank-robbers/bank-robbers.tsx
@@ -87,6 +87,8 @@ export const moves = {
   }
 }
 
+export type Moves = typeof moves;
+
 // A bank may be robbed while it still stands and at least one of its two
 // neighbours does too — a bank whose neighbours are both gone has police lying
 // in wait. Both gangs rob from the same circle, so whose turn it is does not
@@ -100,7 +102,7 @@ const getAllowedBanks = (board: Board) => {
   })
 }
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'rob', args: [sample(getAllowedBanks(board))!] });

--- a/src/components/games/bank-robbers/bot-strategy.ts
+++ b/src/components/games/bank-robbers/bot-strategy.ts
@@ -1,8 +1,8 @@
 import { random, sample } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
-import type { Board, moves } from './bank-robbers';
+import type { Board, Moves } from './bank-robbers';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 export const smartBotStrategy: Bot = ({ board }) => {
   let bankIndex = 0;

--- a/src/components/games/chess-bishops/bot-strategy.ts
+++ b/src/components/games/chess-bishops/bot-strategy.ts
@@ -1,9 +1,9 @@
 import { sample, cloneDeep, random, shuffle } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
 import { markForbiddenFields, getAllowedMoves, boardIndices, BISHOP, type Board, type Field } from './helpers';
-import type { moves } from './chess-bishops';
+import type { Moves } from './chess-bishops';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 const HORIZONTAL = "h" as const;
 const VERTICAL = "v" as const;
@@ -11,7 +11,7 @@ type Axis = typeof HORIZONTAL | typeof VERTICAL;
 let axis: Axis | null = null;
 
 export const randomBotStrategy: Bot = ({ board }) =>
-  ({ move: 'placeBishop', args: [sample(getAllowedMoves(board))] });
+  ({ move: 'placeBishop', args: [sample(getAllowedMoves(board))!] });
 
 export const smartBotStrategy: Bot = ({ board }) => {
   const allowedHMirrorMoves = boardIndices.filter(

--- a/src/components/games/chess-bishops/chess-bishops.tsx
+++ b/src/components/games/chess-bishops/chess-bishops.tsx
@@ -92,6 +92,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     Két játékos felváltva tesz le a sakktáblára futókat. Egy új futót mindig

--- a/src/components/games/chess-ducks/bot-strategy.ts
+++ b/src/components/games/chess-ducks/bot-strategy.ts
@@ -1,15 +1,15 @@
-import { getBoardIndices, withDuckPlaced, getAllowedMoves, type Board, type Field, type moves } from "./helpers";
+import { getBoardIndices, withDuckPlaced, getAllowedMoves, type Board, type Field, type Moves } from "./helpers";
 import { type BotStrategy } from "../../strategy-game-factory";
 import { shuffle, sample } from "lodash";
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 /* This strategy file is relevant for the 4x7 case */
 const [ROWS, COLS] = [4, 7];
 const [DUCK] = [1];
 
 export const randomBotStrategy: Bot = ({ board }) =>
-  ({ move: 'placeDuck', args: [sample(getAllowedMoves(board))] });
+  ({ move: 'placeDuck', args: [sample(getAllowedMoves(board))!] });
 
 export const smartBotStrategy: Bot = ({ board }) => {
   const allowedMoves = getAllowedMoves(board);

--- a/src/components/games/chess-ducks/helpers.ts
+++ b/src/components/games/chess-ducks/helpers.ts
@@ -61,3 +61,6 @@ export const moves = {
     }
   }
 };
+
+export type Moves = typeof moves;
+

--- a/src/components/games/chess-knight/bot-strategy.ts
+++ b/src/components/games/chess-knight/bot-strategy.ts
@@ -1,12 +1,12 @@
 import { sample } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
 import { getAllowedMoves, type Board, type Field } from './helpers';
-import type { moves } from './chess-knight';
+import type { Moves } from './chess-knight';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 export const randomBotStrategy: Bot = ({ board }) =>
-  ({ move: 'moveKnight', args: [sample(getAllowedMoves(board))] });
+  ({ move: 'moveKnight', args: [sample(getAllowedMoves(board))!] });
 
 export const smartBotStrategy: Bot = ({ board }) => {
   const allowedMoves = getAllowedMoves(board);

--- a/src/components/games/chess-knight/chess-knight.tsx
+++ b/src/components/games/chess-knight/chess-knight.tsx
@@ -68,6 +68,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     Egy 4 × 4-es tábla egyik mezőjén kezdetben egy huszár áll. Két játékos felváltva

--- a/src/components/games/chess-rook/bot-strategy.ts
+++ b/src/components/games/chess-rook/bot-strategy.ts
@@ -1,12 +1,12 @@
 import { last, random, sample } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
 import { getAllowedMoves, type Board } from './helpers';
-import type { moves } from './chess-rook';
+import type { Moves } from './chess-rook';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 export const randomBotStrategy: Bot = ({ board }) =>
-  ({ move: 'moveRook', args: [sample(getAllowedMoves(board))] });
+  ({ move: 'moveRook', args: [sample(getAllowedMoves(board))!] });
 
 export const smartBotStrategy: Bot = ({ board }) => {
   const { row, col } = board.rookPosition;

--- a/src/components/games/chess-rook/chess-rook.tsx
+++ b/src/components/games/chess-rook/chess-rook.tsx
@@ -68,6 +68,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     A játékosok felváltva lépnek egy bástyával, amely a sakktábla bal felső sarkából indul. A

--- a/src/components/games/chocolate-breaking/bot-strategy.ts
+++ b/src/components/games/chocolate-breaking/bot-strategy.ts
@@ -1,9 +1,9 @@
 import { sample } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
 import { allMoves, applyBreak, totalGrundy, hasSafeBreak, type Board, type Move } from './helpers';
-import type { moves } from './chocolate-breaking';
+import type { Moves } from './chocolate-breaking';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 const winningMoves = (board: Board): Move[] =>
   allMoves(board.pieces).filter(m => totalGrundy(applyBreak(board, m).pieces) === 0);

--- a/src/components/games/chocolate-breaking/chocolate-breaking.tsx
+++ b/src/components/games/chocolate-breaking/chocolate-breaking.tsx
@@ -127,6 +127,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     Két játékos felváltva tör egy tábla csokit a rácsvonalai mentén. Kezdetben egy téglalap alakú

--- a/src/components/games/cube-coloring/bot-strategy.ts
+++ b/src/components/games/cube-coloring/bot-strategy.ts
@@ -1,9 +1,9 @@
 import { difference, range, shuffle, sample } from 'lodash';
 import { isAllowedStep, isColored, neighbours, colors, type Board } from './helpers';
 import type { BotStrategy } from '../../strategy-game-factory';
-import type { moves } from './cube-coloring';
+import type { Moves } from './cube-coloring';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 export const randomBotStrategy: Bot = ({ board }) => {
   const validMoves: { vertex: number, color: string }[] = [];
@@ -15,7 +15,7 @@ export const randomBotStrategy: Bot = ({ board }) => {
       }
     }
   }
-  return { move: 'colorVertex', args: [sample(validMoves)] };
+  return { move: 'colorVertex', args: [sample(validMoves)!] };
 };
 
 export const smartBotStrategy: Bot = ({ board, ctx }) => {

--- a/src/components/games/cube-coloring/cube-coloring.tsx
+++ b/src/components/games/cube-coloring/cube-coloring.tsx
@@ -156,6 +156,8 @@ export const moves = {
   }
 }
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     Adott egy téglatest rácsa, aminek be van húzva az egyik testátlója.

--- a/src/components/games/digit-subtraction/digit-subtraction.tsx
+++ b/src/components/games/digit-subtraction/digit-subtraction.tsx
@@ -54,7 +54,9 @@ export const moves = {
   }
 };
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+export type Moves = typeof moves;
+
+type Bot = BotStrategy<Board, Moves>
 
 const randomBotStrategy: Bot = ({ board }) => {
   const digits = uniqueNonZeroDigits(board);

--- a/src/components/games/discs-flip-or-remove/discs-flip-or-remove.tsx
+++ b/src/components/games/discs-flip-or-remove/discs-flip-or-remove.tsx
@@ -134,8 +134,9 @@ export const moves = {
   }
 };
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+export type Moves = typeof moves;
+
+type Bot = BotStrategy<Board, Moves>
 
 export const smartBotStrategy: Bot = ({ board }) => {
   const rem = board[0] % 3;
@@ -158,7 +159,7 @@ export const smartBotStrategy: Bot = ({ board }) => {
 };
 
 const randomBotStrategy: Bot = ({ board }) => {
-  const validMoves: BotMove<MoveName>[] = [];
+  const validMoves: BotMove<Moves>[] = [];
   if (board[0] >= 1) validMoves.push({ move: 'removeDiscs', args: [1] });
   if (board[0] >= 2) validMoves.push({ move: 'removeDiscs', args: [2] });
   if (board[1] >= 1) validMoves.push({ move: 'turnDiscs', args: [1] });

--- a/src/components/games/distinct-squares/five-squares/bot-strategy.ts
+++ b/src/components/games/distinct-squares/five-squares/bot-strategy.ts
@@ -1,13 +1,12 @@
 import { sum, isEqual, sample, range } from 'lodash';
 import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
-import type { Board, moves } from './five-squares';
+import type { Board, Moves } from './five-squares';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, Moves>
 
 // The second player places two squares per turn, chosen together (see
 // bestPairs), so the turn is named as a whole.
-const asTurn = (squares: number[]): BotMove<MoveName>[] =>
+const asTurn = (squares: number[]): BotMove<Moves>[] =>
   squares.map(square => ({ move: 'addPiece', args: [square] }));
 
 const randomSquare = () => sample(range(5))!;

--- a/src/components/games/distinct-squares/five-squares/five-squares.tsx
+++ b/src/components/games/distinct-squares/five-squares/five-squares.tsx
@@ -36,6 +36,8 @@ export const moves = {
   }
 }
 
+export type Moves = typeof moves;
+
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const turnState = ctx.turnState as TurnState;
   const firstPlacedSquareIndex = turnState?.firstPlacedSquareIndex ?? null;

--- a/src/components/games/distinct-squares/two-times-two/bot-strategy.ts
+++ b/src/components/games/distinct-squares/two-times-two/bot-strategy.ts
@@ -1,11 +1,11 @@
 import { sum, isEqual, sample, range } from 'lodash';
 import type { BotStrategy } from '../../../strategy-game-factory';
-import type { Board, moves } from './two-times-two';
+import type { Board, Moves } from './two-times-two';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 export const randomBotStrategy: Bot = () =>
-  ({ move: 'addPiece', args: [sample(range(0, 4))] });
+  ({ move: 'addPiece', args: [sample(range(0, 4))!] });
 
 export const smartBotStrategy: Bot = ({ board, ctx }) => {
   const botPlayerIndex = ctx.currentPlayer!;
@@ -16,7 +16,7 @@ export const smartBotStrategy: Bot = ({ board, ctx }) => {
   });
   const best = Math.max(...scores);
   const bestTiles = range(0, 4).filter(i => scores[i] === best);
-  return { move: 'addPiece', args: [sample(bestTiles)] };
+  return { move: 'addPiece', args: [sample(bestTiles)!] };
 };
 
 // Return `+1` if the bot's player index won, `-1` otherwise.

--- a/src/components/games/distinct-squares/two-times-two/two-times-two.tsx
+++ b/src/components/games/distinct-squares/two-times-two/two-times-two.tsx
@@ -24,6 +24,8 @@ export const moves = {
   }
 }
 
+export type Moves = typeof moves;
+
 const BoardClient = ({ board, moves }: BoardClientProps<Board>) => (
   <GameBoard>
     <div className="grid grid-cols-2 border-t-2 border-l-2">

--- a/src/components/games/dominoes-4x4/bot-strategy.ts
+++ b/src/components/games/dominoes-4x4/bot-strategy.ts
@@ -1,8 +1,8 @@
 import { sample } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
-import { type Board, type Domino, BOARDSIZE, type moves } from './dominoes-4x4';
+import { type Board, type Domino, BOARDSIZE, type Moves } from './dominoes-4x4';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 // This game is Domineering on a 4x4 board: player 0 (Árgyélus) only ever places
 // vertical dominoes, player 1 (Félix) only horizontal ones. It is a partizan game

--- a/src/components/games/dominoes-4x4/dominoes-4x4.tsx
+++ b/src/components/games/dominoes-4x4/dominoes-4x4.tsx
@@ -176,6 +176,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     Árgyélus és Félix felváltva pakolnak 1 × 2-es dominókat egy 4 × 4-es táblára. Árgyélus mindig

--- a/src/components/games/dominoes-on-chessboard/bot-strategy.ts
+++ b/src/components/games/dominoes-on-chessboard/bot-strategy.ts
@@ -1,13 +1,13 @@
 import { sample, last } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
 import {
-  type Board, type Domino, type Field, type moves, ALL_FIELDS, BOARDSIZE, getPossibleMoves
+  type Board, type Domino, type Field, type Moves, ALL_FIELDS, BOARDSIZE, getPossibleMoves
 } from './dominoes-on-chessboard';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 export const randomBotStrategy: Bot = ({ board }) =>
-  ({ move: 'placeDomino', args: [sample(getPossibleMoves(board))] });
+  ({ move: 'placeDomino', args: [sample(getPossibleMoves(board))!] });
 
 const mirror = ({ row, col }: Field): Field => ({ row: BOARDSIZE - 1 - row, col: BOARDSIZE - 1 - col });
 
@@ -26,7 +26,7 @@ export const smartBotStrategy: Bot = ({ board, ctx }) => {
   // position can be solved, to capitalize on any mistakes the opponent makes; fall
   // back to a random move otherwise.
   const exactMove = getExactWinningMove(board);
-  return { move: 'placeDomino', args: [exactMove ?? sample(getPossibleMoves(board))] };
+  return { move: 'placeDomino', args: [exactMove ?? sample(getPossibleMoves(board))!] };
 };
 
 // This game (Cram) is impartial - either player may place a domino in either

--- a/src/components/games/dominoes-on-chessboard/dominoes-on-chessboard.tsx
+++ b/src/components/games/dominoes-on-chessboard/dominoes-on-chessboard.tsx
@@ -173,6 +173,8 @@ export const moves = {
   }
 }
 
+export type Moves = typeof moves;
+
 const toldalek = {
   '4': 'e',
   '6': 'o',

--- a/src/components/games/five-connected-fields/bot-strategy.ts
+++ b/src/components/games/five-connected-fields/bot-strategy.ts
@@ -1,9 +1,9 @@
 import { sample } from "lodash";
 import { type BotStrategy } from "../../strategy-game-factory";
 import { type Board, legalNodes } from "./helpers";
-import type { moves } from './five-connected-fields';
+import type { Moves } from './five-connected-fields';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 // Every move raises the total coin count by exactly 1, so the game is a
 // strictly monotonic DAG: it always terminates and can be solved exactly by a

--- a/src/components/games/five-connected-fields/five-connected-fields.tsx
+++ b/src/components/games/five-connected-fields/five-connected-fields.tsx
@@ -21,6 +21,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     Az ábrán öt mező látható, melyeket vonalak kötnek össze. Kezdetben mind az öt

--- a/src/components/games/five-five-card/bot-strategy.ts
+++ b/src/components/games/five-five-card/bot-strategy.ts
@@ -1,13 +1,13 @@
 import { sample, range } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
-import { type Board, getWinnerIndex, type moves } from './five-five-card';
+import { type Board, getWinnerIndex, type Moves } from './five-five-card';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 export const randomBotStrategy: Bot = ({ board, ctx }) => {
   const opponentIdx = ctx.chosenRoleIndex!;
   const validIds = range(1, 6).filter(id => board[opponentIdx][id - 1] !== null);
-  return { move: 'removeCard', args: [sample(validIds)] };
+  return { move: 'removeCard', args: [sample(validIds)!] };
 };
 
 export const smartBotStrategy: Bot = ({ board, ctx }) => {

--- a/src/components/games/five-five-card/five-five-card.tsx
+++ b/src/components/games/five-five-card/five-five-card.tsx
@@ -85,6 +85,8 @@ export const moves = {
   }
 }
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     Mindkét játékos előtt 5-5 kártyalap van az 1-5 egész számokkal megszámozva.

--- a/src/components/games/four-connected-fields/bot-strategy.ts
+++ b/src/components/games/four-connected-fields/bot-strategy.ts
@@ -1,9 +1,9 @@
 import { sample } from "lodash";
 import { type BotStrategy } from "../../strategy-game-factory";
 import { type Board, legalNodes, hasAnyMove } from "./helpers";
-import type { moves } from './four-connected-fields';
+import type { Moves } from './four-connected-fields';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 // Every move raises the total coin count by exactly 1, so the game is a strictly
 // monotonic DAG: it always terminates and can be solved exactly by a memoized

--- a/src/components/games/four-connected-fields/four-connected-fields.tsx
+++ b/src/components/games/four-connected-fields/four-connected-fields.tsx
@@ -21,6 +21,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     Az ábrán négy mező látható, melyeket vonalak kötnek össze. Kezdetben mind a

--- a/src/components/games/four-piles-spread-ahead/bot-strategy.ts
+++ b/src/components/games/four-piles-spread-ahead/bot-strategy.ts
@@ -1,8 +1,8 @@
 import { random, sample, range } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
-import type { Board, moves } from './four-piles-spread-ahead';
+import type { Board, Moves } from './four-piles-spread-ahead';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 export const randomBotStrategy: Bot = ({ board }) => {
   const validMoves: { pileId: number; pieceCount: number }[] = [];
@@ -11,7 +11,7 @@ export const randomBotStrategy: Bot = ({ board }) => {
       validMoves.push({ pileId, pieceCount });
     }
   }
-  return { move: 'spreadPieces', args: [sample(validMoves)] };
+  return { move: 'spreadPieces', args: [sample(validMoves)!] };
 };
 
 export const smartBotStrategy: Bot = ({ board }) => {

--- a/src/components/games/four-piles-spread-ahead/four-piles-spread-ahead.tsx
+++ b/src/components/games/four-piles-spread-ahead/four-piles-spread-ahead.tsx
@@ -154,6 +154,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     Adott négy, korongokból álló kupac, melyek 1-től 4-ig vannak számozva. Egy lépésben a

--- a/src/components/games/four-piles-two-grabs/four-piles-two-grabs.tsx
+++ b/src/components/games/four-piles-two-grabs/four-piles-two-grabs.tsx
@@ -149,7 +149,9 @@ export const moves = {
   }
 };
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+export type Moves = typeof moves;
+
+type Bot = BotStrategy<Board, Moves>
 
 const smartBotStrategy: Bot = ({ board }) =>
   ({ move: 'takeStones', args: [getSmartBotMove(board)] });

--- a/src/components/games/hunyadi-and-the-janissaries/bot-strategy.ts
+++ b/src/components/games/hunyadi-and-the-janissaries/bot-strategy.ts
@@ -1,8 +1,8 @@
 import { random } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
-import { SULTAN, type Board, type SoldierColor, type Soldier, type moves } from './helpers';
+import { SULTAN, type Board, type SoldierColor, type Soldier, type Moves } from './helpers';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 export const smartBotStrategy: Bot = ({ board, ctx }) => {
   if (ctx.chosenRoleIndex === SULTAN) {

--- a/src/components/games/hunyadi-and-the-janissaries/helpers.ts
+++ b/src/components/games/hunyadi-and-the-janissaries/helpers.ts
@@ -99,3 +99,6 @@ export const moves = {
     }
   }
 };
+
+export type Moves = typeof moves;
+

--- a/src/components/games/latin-square-filling/latin-square-filling.tsx
+++ b/src/components/games/latin-square-filling/latin-square-filling.tsx
@@ -126,7 +126,9 @@ export const moves = {
   }
 };
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+export type Moves = typeof moves;
+
+type Bot = BotStrategy<Board, Moves>
 
 const smartBotStrategy: Bot = ({ board }) => {
   const { cell, digit } = getSmartBotStep(board);

--- a/src/components/games/magic-box/magic-box-a/bot-strategy.ts
+++ b/src/components/games/magic-box/magic-box-a/bot-strategy.ts
@@ -1,12 +1,12 @@
 import { range, sample } from 'lodash';
 import { isGameEnd, placeStone, type Board } from './helpers';
 import type { BotStrategy } from '../../../strategy-game-factory';
-import type { moves } from './magic-box-a';
+import type { Moves } from './magic-box-a';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 export const randomBotStrategy: Bot = ({ board }) =>
-  ({ move: 'placeStone', args: [sample(emptyCells(board))] });
+  ({ move: 'placeStone', args: [sample(emptyCells(board))!] });
 
 const emptyCells = (board: Board) => range(0, 9).filter(i => !board[i]);
 
@@ -37,13 +37,13 @@ export const smartBotStrategy: Bot = ({ board, ctx }) => {
     const outcome = isGameEnd(nextBoard) ? 1 - chosenRoleIndex : winner(nextBoard, 1 - chosenRoleIndex);
     return outcome === chosenRoleIndex;
   });
-  if (winningPlaces.length > 0) return { move: 'placeStone', args: [sample(winningPlaces)] };
+  if (winningPlaces.length > 0) return { move: 'placeStone', args: [sample(winningPlaces)!] };
 
   // no winning move exists; at least avoid losing immediately if possible
   const notInstantLosingPlaces = allowedPlaces.filter(i => !isGameEnd(placeStone(board, i)));
   if (notInstantLosingPlaces.length > 0) {
-    return { move: 'placeStone', args: [sample(notInstantLosingPlaces)] };
+    return { move: 'placeStone', args: [sample(notInstantLosingPlaces)!] };
   }
 
-  return { move: 'placeStone', args: [sample(allowedPlaces)] };
+  return { move: 'placeStone', args: [sample(allowedPlaces)!] };
 };

--- a/src/components/games/magic-box/magic-box-a/magic-box-a.tsx
+++ b/src/components/games/magic-box/magic-box-a/magic-box-a.tsx
@@ -38,6 +38,8 @@ export const moves = {
   }
 }
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     A mágikus ládában kilenc rekesz van 3×3-as elrendezésben. Két játékos felváltva pakol köveket a

--- a/src/components/games/magic-box/magic-box-b/bot-strategy.ts
+++ b/src/components/games/magic-box/magic-box-b/bot-strategy.ts
@@ -1,14 +1,13 @@
 import { range, sample } from 'lodash';
 import { isLineFull, emptyCellsInLine, placeStoneAt, LINES, type Board } from './helpers';
 import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
-import type { moves } from './magic-box-b';
+import type { Moves } from './magic-box-b';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, Moves>
 
 // A turn is one decision — where to place, then which line to hand over — so it
 // is named as a whole. The opening turn has no pending line to place into.
-const asTurn = (pendingLine: number | null, cell: number | undefined, line: number): BotMove<MoveName>[] =>
+const asTurn = (pendingLine: number | null, cell: number | undefined, line: number): BotMove<Moves>[] =>
   pendingLine === null
     ? [{ move: 'designateLine', args: [line] }]
     : [{ move: 'placeStone', args: [cell] }, { move: 'designateLine', args: [line] }];

--- a/src/components/games/magic-box/magic-box-b/magic-box-b.tsx
+++ b/src/components/games/magic-box/magic-box-b/magic-box-b.tsx
@@ -29,6 +29,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     A mágikus ládában kilenc rekesz van 3×3-as elrendezésben. Két játékos felváltva pakol köveket a

--- a/src/components/games/matches-on-edges/bot-strategy.ts
+++ b/src/components/games/matches-on-edges/bot-strategy.ts
@@ -9,9 +9,9 @@ import {
   legalMoves,
   moverWins
 } from './helpers';
-import type { moves } from './matches-on-edges';
+import type { Moves } from './matches-on-edges';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 // A move is winning if it leaves the other player (who moves next) in a losing
 // position.

--- a/src/components/games/matches-on-edges/matches-on-edges.tsx
+++ b/src/components/games/matches-on-edges/matches-on-edges.tsx
@@ -23,6 +23,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     Egy 1 × n-es tábla szomszédos mezőit n − 1 elválasztó él határolja el egymástól, melyeken kezdetben

--- a/src/components/games/matchstick-piles/matchstick-piles.tsx
+++ b/src/components/games/matchstick-piles/matchstick-piles.tsx
@@ -150,6 +150,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 // --- Optimal strategy -------------------------------------------------------
 // Impartial game: the Grundy value of a single pile of size n is
 //   g(0)=0, g(1)=1, g(2)=2, and for n>=3: 2 if n is even, 0 if n is odd.
@@ -188,13 +190,12 @@ const applyMove = (board: Board, move: Move): Board => {
   );
 };
 
-const asBotMove = (move: Move): BotMove<MoveName> =>
+const asBotMove = (move: Move): BotMove<Moves> =>
   move.type === 'remove'
     ? { move: 'removeMatch', args: [move.pileId] }
     : { move: 'splitPile', args: [move.pileId, move.firstPart] };
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, Moves>
 
 const smartBotStrategy: Bot = ({ board }) => {
   const candidates = legalMoves(board);

--- a/src/components/games/modified-mill/bot-strategy.ts
+++ b/src/components/games/modified-mill/bot-strategy.ts
@@ -4,9 +4,9 @@ import { SYMMETRIES } from './board-data';
 import {
   type Board, CELL_COUNT, boardMasks, emptyCells, completesLine, linesThrough
 } from './helpers';
-import type { moves } from './modified-mill';
+import type { Moves } from './modified-mill';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 import strategyTable from './strategy.json';
 
 const STRATEGY: Record<string, number> = strategyTable;

--- a/src/components/games/modified-mill/modified-mill.tsx
+++ b/src/components/games/modified-mill/modified-mill.tsx
@@ -24,6 +24,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     Adott az ábrán látható módosított malom pálya. A két játékos felváltva helyez le piros

--- a/src/components/games/number-covering/number-covering.tsx
+++ b/src/components/games/number-covering/number-covering.tsx
@@ -41,25 +41,25 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
   );
 };
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 const randomBotStrategy: Bot = ({ board }) =>
-  ({ move: 'coverNumber', args: [sample(getRemaining(board))] });
+  ({ move: 'coverNumber', args: [sample(getRemaining(board))!] });
 
 export const smartBotStrategy: Bot = ({ board, ctx }) => {
   const remaining = getRemaining(board);
   const evens = remaining.filter(i => i%2 === 0);
   const odds = remaining.filter(i => i%2 === 1);
   if (evens.length === odds.length || evens.length === 0 || odds.length === 0) {
-    return { move: 'coverNumber', args: [sample(remaining)] };
+    return { move: 'coverNumber', args: [sample(remaining)!] };
   } else if (ctx.currentPlayer === 0) {
     // first player wants same-parity survivors -> remove from the smaller class
     const candidates = evens.length < odds.length ? evens : odds;
-    return { move: 'coverNumber', args: [sample(candidates)] };
+    return { move: 'coverNumber', args: [sample(candidates)!] };
   } else {
     // second player wants a mixed pair -> remove from the larger class
     const candidates = evens.length > odds.length ? evens : odds;
-    return { move: 'coverNumber', args: [sample(candidates)] };
+    return { move: 'coverNumber', args: [sample(candidates)!] };
   }
 };
 
@@ -104,6 +104,8 @@ export const moves = {
     }
   }
 }
+
+export type Moves = typeof moves;
 
 const getPlayerStepDescription = () => ({
   hu: 'Kattints egy számra, hogy lefedd.',

--- a/src/components/games/number-pyramid/number-pyramid.tsx
+++ b/src/components/games/number-pyramid/number-pyramid.tsx
@@ -25,6 +25,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     A játék kezdetén adott nyolc pozitív egész szám az első szinten, és egy <code>k</code> pozitív

--- a/src/components/games/number-pyramid/strategy.ts
+++ b/src/components/games/number-pyramid/strategy.ts
@@ -1,9 +1,8 @@
 import { orderBy, random, range, sample, sampleSize, shuffle, sum } from 'lodash';
 import type { BotMove, BotStrategy } from '../../strategy-game-factory';
-import type { moves } from './number-pyramid';
+import type { Moves } from './number-pyramid';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, Moves>
 
 export type Slot = { value: number; state: 'active' | 'consumed' };
 export type Level = (Slot | null)[];
@@ -29,7 +28,7 @@ export const smartBotStrategy: Bot = ({ board, ctx }) => {
 
   const botIsWinner = isP2WinningPosition(board) === (ctx.currentPlayer === 1);
 
-  const tryLevel = (levelIdx, order: 'asc' | 'desc' = 'desc'): BotMove<MoveName> | null => {
+  const tryLevel = (levelIdx, order: 'asc' | 'desc' = 'desc'): BotMove<Moves> | null => {
     if (!hasActivePair(board.levels[levelIdx])) return null;
     const level = board.levels[levelIdx];
     const indices = orderBy(activeSlotIndices(level), (i) => level[i]!.value, order).slice(0, 2);

--- a/src/components/games/pairs-of-numbers/pairs-of-numbers.tsx
+++ b/src/components/games/pairs-of-numbers/pairs-of-numbers.tsx
@@ -53,7 +53,9 @@ export const moves = {
   }
 };
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+export type Moves = typeof moves;
+
+type Bot = BotStrategy<Board, Moves>
 
 const randomBotStrategy: Bot = () =>
   random(0, 1) === 0 ? { move: 'add1' } : { move: 'subtract' };

--- a/src/components/games/pile-splitting-games/pile-splitter-3/bot-strategy.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter-3/bot-strategy.ts
@@ -1,9 +1,8 @@
 import { random, sample } from 'lodash';
 import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
-import type { Board, moves } from './pile-splitter-3';
+import type { Board, Moves } from './pile-splitter-3';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, Moves>
 
 type BotStep = { removedPileId: number; pileId: number; pieceCount: number };
 
@@ -13,7 +12,7 @@ export const randomBotStrategy: Bot = ({ board }) => asTurn(getRandomStep(board)
 
 // A turn is one decision expressed as two moves: which pile to discard, and
 // where to cut one of those left.
-const asTurn = ({ removedPileId, pileId, pieceCount }: BotStep): BotMove<MoveName>[] => [
+const asTurn = ({ removedPileId, pileId, pieceCount }: BotStep): BotMove<Moves>[] => [
   { move: 'removePile', args: [removedPileId] },
   { move: 'splitPile', args: [{ pileId, pieceCount }] }
 ];

--- a/src/components/games/pile-splitting-games/pile-splitter-3/pile-splitter-3.tsx
+++ b/src/components/games/pile-splitting-games/pile-splitter-3/pile-splitter-3.tsx
@@ -171,6 +171,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const getPlayerStepDescription = () => ({
   hu: 'Először kattints az eltávolítandó kupacra, majd arra a korongra, ahol ketté akarod vágni a kupacot.',
   en: 'First click the pile to remove, then click the piece where you want to split another pile.'

--- a/src/components/games/pile-splitting-games/pile-splitter-4/bot-strategy.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter-4/bot-strategy.ts
@@ -1,9 +1,8 @@
 import { random, range, sample } from 'lodash';
 import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
-import type { Board, moves } from './pile-splitter-4';
+import type { Board, Moves } from './pile-splitter-4';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, Moves>
 
 type BotStep = { removedPileId: number; pileId: number; pieceCount: number };
 
@@ -13,7 +12,7 @@ export const randomBotStrategy: Bot = ({ board }) => asTurn(getRandomStep(board)
 
 // A turn is one decision expressed as two moves: which pile to discard, and
 // where to cut one of those left.
-const asTurn = ({ removedPileId, pileId, pieceCount }: BotStep): BotMove<MoveName>[] => [
+const asTurn = ({ removedPileId, pileId, pieceCount }: BotStep): BotMove<Moves>[] => [
   { move: 'removePile', args: [removedPileId] },
   { move: 'splitPile', args: [{ pileId, pieceCount }] }
 ];

--- a/src/components/games/pile-splitting-games/pile-splitter-4/pile-splitter-4.tsx
+++ b/src/components/games/pile-splitting-games/pile-splitter-4/pile-splitter-4.tsx
@@ -180,6 +180,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const getPlayerStepDescription = () => ({
   hu: 'Először kattints az eltávolítandó kupacra, majd arra a korongra, ahol ketté akarod vágni a kupacot.',
   en: 'First click the pile you wish to remove, then the disk where you want to split.'

--- a/src/components/games/pile-splitting-games/pile-splitter/bot-strategy.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter/bot-strategy.ts
@@ -1,13 +1,12 @@
 import { random, sample } from 'lodash';
 import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
-import type { Board, moves } from './pile-splitter';
+import type { Board, Moves } from './pile-splitter';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, Moves>
 
 // A turn is one decision expressed as two moves: which pile to keep, and where
 // to cut it.
-const asTurn = (pileId: number, pieceCount: number): BotMove<MoveName>[] => [
+const asTurn = (pileId: number, pieceCount: number): BotMove<Moves>[] => [
   { move: 'removePile', args: [1 - pileId] },
   { move: 'splitPile', args: [{ pileId, pieceCount }] }
 ];

--- a/src/components/games/pile-splitting-games/pile-splitter/pile-splitter.tsx
+++ b/src/components/games/pile-splitting-games/pile-splitter/pile-splitter.tsx
@@ -117,6 +117,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     A pályán mindig két kupac korong található.

--- a/src/components/games/pile-union/bot-strategy.ts
+++ b/src/components/games/pile-union/bot-strategy.ts
@@ -1,8 +1,8 @@
 import { sample, sortBy, sum } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
-import type { Board, moves } from './pile-union';
+import type { Board, Moves } from './pile-union';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 type MoveAction = { type: 'remove'; i: number } | { type: 'merge'; i: number; j: number }
 

--- a/src/components/games/pile-union/pile-union.tsx
+++ b/src/components/games/pile-union/pile-union.tsx
@@ -217,6 +217,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const getPlayerStepDescription = ({ board, ctx }) => {
   if (ctx.turnState !== null) {
     return {

--- a/src/components/games/policeman-thief/policeman-thief-ab/bot-strategy.ts
+++ b/src/components/games/policeman-thief/policeman-thief-ab/bot-strategy.ts
@@ -1,17 +1,16 @@
 import { random } from "lodash";
 import { neighbours, POLICE } from "./helpers";
-import type { Board, moves } from "./policeman-thief-ab";
+import type { Board, Moves } from "./policeman-thief-ab";
 import type { BotMove, BotStrategy } from "../../../strategy-game-factory";
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, Moves>
 
 export const smartBotStrategy: Bot = ({ board, ctx }) =>
   ctx.chosenRoleIndex === POLICE ? thiefMove(board) : policemenMoves(board);
 
 // Both policemen step in the same turn, planned together from the position they
 // start in, so the turn is named as a whole.
-const policemenMoves = (board: Board): BotMove<MoveName>[] => {
+const policemenMoves = (board: Board): BotMove<Moves>[] => {
   //policeman0 Step
   let index0 = board.policemen[0];
   // where it would catch the thief outright, which overrides any later choice
@@ -65,7 +64,7 @@ const policemenMoves = (board: Board): BotMove<MoveName>[] => {
   ];
 };
 
-const thiefMove = (board: Board): BotMove<MoveName> => {
+const thiefMove = (board: Board): BotMove<Moves> => {
   let index = board.thief;
   for (let i = 0; i < 3; i++) {
     if (

--- a/src/components/games/policeman-thief/policeman-thief-ab/policeman-thief-ab.tsx
+++ b/src/components/games/policeman-thief/policeman-thief-ab/policeman-thief-ab.tsx
@@ -94,6 +94,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const isGameEnd = (board: Board) => {
   if (board.turnCount === 3) {
     return true;

--- a/src/components/games/policeman-thief/policeman-thief-c/bot-strategy.ts
+++ b/src/components/games/policeman-thief/policeman-thief-c/bot-strategy.ts
@@ -1,10 +1,9 @@
 import { sample, random, range } from "lodash";
 import { neighbours, VERTEX_COUNT, dist, minDistToSet, THIEF } from "./helpers";
-import type { Board, moves } from "./policeman-thief-c";
+import type { Board, Moves } from "./policeman-thief-c";
 import type { BotMove, BotStrategy } from "../../../strategy-game-factory";
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, Moves>
 
 // ---------------------------------------------------------------------------
 // Minimax core (exhaustive; the graph and rules are fixed so the memo below is
@@ -122,13 +121,15 @@ const chooseCopPlacement = (copCount: number): number[] => {
 // Every policeman is placed (or stepped) in the same turn, from a plan made for
 // the position the turn starts in, so a turn is named as a whole. A step onto
 // the thief ends the game there and then, leaving the rest of the plan moot.
-const asCopMoves = (move: MoveName, target: number[]): BotMove<MoveName>[] =>
-  target.map(vertex => ({ move, args: [vertex] }));
+const asCopMoves = (move: 'placeCop' | 'moveCop', target: number[]): BotMove<Moves>[] =>
+  target.map(vertex => move === 'placeCop'
+    ? { move: 'placeCop', args: [vertex] }
+    : { move: 'moveCop', args: [vertex] });
 
-const placeCopsOptimally = (board: Board): BotMove<MoveName>[] =>
+const placeCopsOptimally = (board: Board): BotMove<Moves>[] =>
   asCopMoves('placeCop', chooseCopPlacement(board.copCount));
 
-const placeThiefOptimally = (board: Board): BotMove<MoveName> => {
+const placeThiefOptimally = (board: Board): BotMove<Moves> => {
   const cops = board.policemen;
   const candidates = range(VERTEX_COUNT).filter((v) => !cops.includes(v));
   const surviving = candidates.filter((v) => thiefSurvives(cops, v, 3));
@@ -147,10 +148,10 @@ export const chooseCopMove = (cops: number[], thief: number, movesLeft: number):
   return sample(argExtreme(pool, totalDistToThief, false))!;
 };
 
-const moveCopsOptimally = (board: Board): BotMove<MoveName>[] =>
+const moveCopsOptimally = (board: Board): BotMove<Moves>[] =>
   asCopMoves('moveCop', chooseCopMove(board.policemen, board.thief!, 3 - board.thiefMoveCount));
 
-const moveThiefOptimally = (board: Board): BotMove<MoveName> => {
+const moveThiefOptimally = (board: Board): BotMove<Moves> => {
   const { policemen: cops, thief } = board;
   const movesLeft = 3 - board.thiefMoveCount;
   const safe = neighbours[thief!].filter((t) => !cops.includes(t));
@@ -174,10 +175,10 @@ export const smartBotStrategy: Bot = ({ board, ctx }) => {
 // human thief realistically win, unlike the optimal bot.
 // ---------------------------------------------------------------------------
 
-const placeCopsRandom = (board: Board): BotMove<MoveName>[] =>
+const placeCopsRandom = (board: Board): BotMove<Moves>[] =>
   asCopMoves('placeCop', range(board.copCount).map(() => random(0, VERTEX_COUNT - 1)));
 
-const moveCopsRandom = (board: Board): BotMove<MoveName>[] => {
+const moveCopsRandom = (board: Board): BotMove<Moves>[] => {
   const thief = board.thief!;
   return asCopMoves('moveCop', board.policemen.map((c) => {
     const nbs = neighbours[c];
@@ -185,12 +186,12 @@ const moveCopsRandom = (board: Board): BotMove<MoveName>[] => {
   }));
 };
 
-const placeThiefRandom = (board: Board): BotMove<MoveName> => {
+const placeThiefRandom = (board: Board): BotMove<Moves> => {
   const candidates = range(VERTEX_COUNT).filter((v) => !board.policemen.includes(v));
   return { move: 'placeThief', args: [sample(candidates)!] };
 };
 
-const moveThiefRandom = (board: Board): BotMove<MoveName> => {
+const moveThiefRandom = (board: Board): BotMove<Moves> => {
   const safe = neighbours[board.thief!].filter((t) => !board.policemen.includes(t));
   return { move: 'moveThief', args: [sample(safe.length ? safe : neighbours[board.thief!])!] };
 };

--- a/src/components/games/policeman-thief/policeman-thief-c/policeman-thief-c.tsx
+++ b/src/components/games/policeman-thief/policeman-thief-c/policeman-thief-c.tsx
@@ -105,6 +105,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     A gráfon egy tolvaj menekül néhány rendőr elől. Előbb a rendőrök foglalják el

--- a/src/components/games/polynomial-building/bot-strategy.ts
+++ b/src/components/games/polynomial-building/bot-strategy.ts
@@ -3,9 +3,9 @@ import type { BotStrategy } from '../../strategy-game-factory';
 import {
   type Board, type Coef, COEFS, rootTriplesWithProduct, completionValue, canComplete
 } from './helpers';
-import type { moves } from './polynomial-building';
+import type { Moves } from './polynomial-building';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 // Weak bot: plays a random legal move, but completes to a win on the last move
 // when it can (only the first player, who always makes the final move, can win in 1).

--- a/src/components/games/polynomial-building/polynomial-building.tsx
+++ b/src/components/games/polynomial-building/polynomial-building.tsx
@@ -22,6 +22,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     Legyen <code className="whitespace-nowrap">P(x) = x³ + ax² + bx + c</code> egy polinom.

--- a/src/components/games/remove-divisor-multiple/remove-divisor-multiple.tsx
+++ b/src/components/games/remove-divisor-multiple/remove-divisor-multiple.tsx
@@ -76,18 +76,20 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const isGameEnd = (board: Board) => {
   const possibleMoves = range(1, board.numbersOnTable.length + 1)
     .filter(n => isAllowed(board, n));
   return possibleMoves.length === 0;
 }
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 const randomBotStrategy: Bot = ({ board }) => {
   const possibleMoves = range(1, board.numbersOnTable.length + 1)
     .filter(n => isAllowed(board, n));
-  return { move: 'removeNumber', args: [sample(possibleMoves)] };
+  return { move: 'removeNumber', args: [sample(possibleMoves)!] };
 };
 
 const smartBotStrategy: Bot = ({ board }) => {
@@ -97,11 +99,11 @@ const smartBotStrategy: Bot = ({ board }) => {
     ? strategyDict[numCount][stateId]
     : [];
   if (optimalMoves.length) {
-    return { move: 'removeNumber', args: [sample(optimalMoves)] };
+    return { move: 'removeNumber', args: [sample(optimalMoves)!] };
   } else {
     const possibleMoves = range(1, numCount + 1)
       .filter(n => isAllowed(board, n));
-    return { move: 'removeNumber', args: [sample(possibleMoves)] };
+    return { move: 'removeNumber', args: [sample(possibleMoves)!] };
   }
 };
 

--- a/src/components/games/rock-paper-scissor/bot-strategy.ts
+++ b/src/components/games/rock-paper-scissor/bot-strategy.ts
@@ -1,8 +1,8 @@
 import { random } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
-import type { Board, moves } from './rock-paper-scissor';
+import type { Board, Moves } from './rock-paper-scissor';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 export const smartBotStrategy: Bot = ({ board, ctx }) => {
   const currentPlayer = ctx.currentPlayer!;

--- a/src/components/games/rock-paper-scissor/rock-paper-scissor.tsx
+++ b/src/components/games/rock-paper-scissor/rock-paper-scissor.tsx
@@ -82,6 +82,8 @@ export const moves = {
   }
 }
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     A játék kezdetekor mindkét játékos elé leteszünk három kártyát: az egyik követ, a

--- a/src/components/games/rook-to-corner/bot-strategy.ts
+++ b/src/components/games/rook-to-corner/bot-strategy.ts
@@ -1,9 +1,9 @@
 import { sample } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
 import { getAllowedMoves, isTarget, type Board } from './helpers';
-import type { moves } from './rook-to-corner';
+import type { Moves } from './rook-to-corner';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 // Random play, but grab an immediate win (moving onto the bottom-right square)
 // whenever one is available.

--- a/src/components/games/rook-to-corner/rook-to-corner.tsx
+++ b/src/components/games/rook-to-corner/rook-to-corner.tsx
@@ -69,6 +69,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     Egy 8 × 8-as tábla egyik mezőjére elhelyezünk egy bástyát. A két játékos felváltva léphet a

--- a/src/components/games/shark-chase/shark-4-by-4/bot-strategy.ts
+++ b/src/components/games/shark-chase/shark-4-by-4/bot-strategy.ts
@@ -1,10 +1,9 @@
 import { sample } from 'lodash';
 import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
 import type { Board } from '../helpers';
-import type { moves } from './shark-chase';
+import type { Moves } from './shark-chase';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, Moves>
 
 const getAdjacentCells = (pos: number): number[] => {
   const cells: number[] = [];
@@ -17,7 +16,7 @@ const getAdjacentCells = (pos: number): number[] => {
 
 // The shark's turn is a route of up to two steps, named as a whole: the halfway
 // cell is only chosen to reach the target safely, so the two are one decision.
-const asSharkRoute = (from: number, via: number, to: number): BotMove<MoveName>[] =>
+const asSharkRoute = (from: number, via: number, to: number): BotMove<Moves>[] =>
   to === from
     ? [{ move: 'moveShark', args: [via] }]
     : [{ move: 'moveShark', args: [via] }, { move: 'moveShark', args: [to] }];

--- a/src/components/games/shark-chase/shark-4-by-4/shark-chase.tsx
+++ b/src/components/games/shark-chase/shark-4-by-4/shark-chase.tsx
@@ -60,6 +60,8 @@ export const moves = {
   }
 }
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     Kutatók a Dürerencicás-tóban felfedezték a kihalófélben lévő egyenesenmozgó macskacápa faj

--- a/src/components/games/shark-chase/shark-5-by-5/bot-strategy.ts
+++ b/src/components/games/shark-chase/shark-5-by-5/bot-strategy.ts
@@ -1,10 +1,9 @@
 import { sample } from 'lodash';
 import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
 import type { Board } from '../helpers';
-import type { moves } from './shark-chase';
+import type { Moves } from './shark-chase';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, Moves>
 import sharkExceptionMoves from './shark-exception-moves.json';
 
 const getAdjacentCells = (pos: number): number[] => {
@@ -18,7 +17,7 @@ const getAdjacentCells = (pos: number): number[] => {
 
 // The shark's turn is a route of up to two steps, named as a whole: the halfway
 // cell is only chosen to reach the target safely, so the two are one decision.
-const asSharkRoute = (from: number, via: number, to: number): BotMove<MoveName>[] =>
+const asSharkRoute = (from: number, via: number, to: number): BotMove<Moves>[] =>
   to === from
     ? [{ move: 'moveShark', args: [via] }]
     : [{ move: 'moveShark', args: [via] }, { move: 'moveShark', args: [to] }];

--- a/src/components/games/shark-chase/shark-5-by-5/shark-chase.tsx
+++ b/src/components/games/shark-chase/shark-5-by-5/shark-chase.tsx
@@ -66,6 +66,8 @@ export const moves = {
   }
 }
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     Kutatók a Dürerencicás-tóban felfedezték a kihalófélben lévő egyenesenmozgó macskacápa faj

--- a/src/components/games/single-number-increase/increment-or-double/increment-or-double.tsx
+++ b/src/components/games/single-number-increase/increment-or-double/increment-or-double.tsx
@@ -52,6 +52,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 // The mover wins exactly when the last number said is even, so the only winning
 // move is always x+1 (which hands the opponent an odd number). From 0 this plays
 // the forced opening 1. From an odd (losing) board both moves hand the opponent an
@@ -61,7 +63,7 @@ export const getBotNextNumber = (board: Board): number => {
   return sample([board + 1, board * 2])!;
 };
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 const smartBotStrategy: Bot = ({ board }) => {
   const next = getBotNextNumber(board);

--- a/src/components/games/single-number-increase/plus-one-two-three/plus-one-two-three.tsx
+++ b/src/components/games/single-number-increase/plus-one-two-three/plus-one-two-three.tsx
@@ -52,7 +52,9 @@ export const moves = {
   }
 };
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+export type Moves = typeof moves;
+
+type Bot = BotStrategy<Board, Moves>
 
 const smartBotStrategy: Bot = ({ board }) => {
   const nextBoard = board % (1 + maxStep) !== 0

--- a/src/components/games/single-number-increase/superstitious-counting/bot-strategy.ts
+++ b/src/components/games/single-number-increase/superstitious-counting/bot-strategy.ts
@@ -1,8 +1,8 @@
 import { random } from 'lodash';
 import type { BotStrategy } from '../../../strategy-game-factory';
-import type { Board, moves } from './superstitious-counting';
+import type { Board, Moves } from './superstitious-counting';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 export const randomBotStrategy: Bot = ({ board }) =>
   ({ move: 'step', args: [randomStep(board.restricted)] });

--- a/src/components/games/single-number-increase/superstitious-counting/superstitious-counting.tsx
+++ b/src/components/games/single-number-increase/superstitious-counting/superstitious-counting.tsx
@@ -84,6 +84,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     Károly és Dezső <code>m</code>-ig szeretnének elszámolni, és közben a következő játékot játsszák:

--- a/src/components/games/single-pile-removal/doubling-reduction/doubling-reduction.tsx
+++ b/src/components/games/single-pile-removal/doubling-reduction/doubling-reduction.tsx
@@ -60,7 +60,9 @@ export const moves = {
   }
 };
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+export type Moves = typeof moves;
+
+type Bot = BotStrategy<Board, Moves>
 
 const smartBotStrategy: Bot = ({ board }) =>
   ({ move: 'take', args: [chooseSmartTake(board)] });

--- a/src/components/games/single-pile-removal/prime-exponentials/prime-exponentials.tsx
+++ b/src/components/games/single-pile-removal/prime-exponentials/prime-exponentials.tsx
@@ -129,7 +129,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   );
 };
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 const randomBotStrategy: Bot = ({ board }) => {
   const validMoves = allPrimePowers.filter(e => e.value <= board);
@@ -174,6 +174,8 @@ export const moves = {
     }
   }
 };
+
+export type Moves = typeof moves;
 
 const rule = {
   hu: <>

--- a/src/components/games/single-pile-removal/primely-to-zero/primely-to-zero.tsx
+++ b/src/components/games/single-pile-removal/primely-to-zero/primely-to-zero.tsx
@@ -55,7 +55,9 @@ export const moves = {
   }
 };
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+export type Moves = typeof moves;
+
+type Bot = BotStrategy<Board, Moves>
 
 const randomBotStrategy: Bot = ({ board }) => {
   const step = isValidStep(board) ? board : sample([...validSteps].filter(s => s < board))!;

--- a/src/components/games/single-pile-removal/take-1-or-halve/take-1-or-halve.tsx
+++ b/src/components/games/single-pile-removal/take-1-or-halve/take-1-or-halve.tsx
@@ -70,7 +70,9 @@ export const moves = {
   }
 };
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+export type Moves = typeof moves;
+
+type Bot = BotStrategy<Board, Moves>
 
 const randomBotStrategy: Bot = ({ board }) => {
   if (board % 2 === 0 && random(0, 1) === 0) {

--- a/src/components/games/single-pile-removal/take-power-of-two/take-power-of-two.tsx
+++ b/src/components/games/single-pile-removal/take-power-of-two/take-power-of-two.tsx
@@ -69,10 +69,10 @@ const generateTestStartBoard = () => {
   }
 };
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 const randomBotStrategy: Bot = ({ board }) =>
-  ({ move: 'subtractPowerOfTwo', args: [sample(getAvailableExponents(board))] });
+  ({ move: 'subtractPowerOfTwo', args: [sample(getAvailableExponents(board))!] });
 
 const smartBotStrategy: Bot = ({ board }) => {
   if (board === 1) {
@@ -80,9 +80,12 @@ const smartBotStrategy: Bot = ({ board }) => {
   }
   const availableExponents = getAvailableExponents(board);
   if (board % 3 === 0) {
-    return { move: 'subtractPowerOfTwo', args: [sample(availableExponents)] };
+    return { move: 'subtractPowerOfTwo', args: [sample(availableExponents)!] };
   } else {
-    const optimalMove = reverse(availableExponents).find(e => (board - 2 ** e) % 3 === 0);
+    // board % 3 is 1 or 2 here, and 2**e alternates 1, 2, 1, 2 (mod 3), so
+    // e = 0 or e = 1 always lands on a multiple of 3 — both are available
+    // whenever board >= 2, which the board === 1 branch above guarantees.
+    const optimalMove = reverse(availableExponents).find(e => (board - 2 ** e) % 3 === 0)!;
     return { move: 'subtractPowerOfTwo', args: [optimalMove] };
   }
 }
@@ -113,6 +116,8 @@ export const moves = {
     }
   }
 }
+
+export type Moves = typeof moves;
 
 const rule = {
   hu: <>

--- a/src/components/games/single-pile-removal/three-more/three-more.tsx
+++ b/src/components/games/single-pile-removal/three-more/three-more.tsx
@@ -68,7 +68,9 @@ export const moves = {
   }
 };
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+export type Moves = typeof moves;
+
+type Bot = BotStrategy<Board, Moves>
 
 const smartBotStrategy: Bot = ({ board }) =>
   ({ move: 'take', args: [chooseSmartTake(board)] });

--- a/src/components/games/single-pile-removal/waning-stones/waning-stones.tsx
+++ b/src/components/games/single-pile-removal/waning-stones/waning-stones.tsx
@@ -45,7 +45,9 @@ export const moves = {
   }
 };
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+export type Moves = typeof moves;
+
+type Bot = BotStrategy<Board, Moves>
 
 const smartBotStrategy: Bot = ({ board }) =>
   ({ move: 'take', args: [chooseSmartTake(board)] });

--- a/src/components/games/six-fields-circle/bot-strategy.ts
+++ b/src/components/games/six-fields-circle/bot-strategy.ts
@@ -4,9 +4,9 @@ import {
   type Board, type Move, OPPOSITE_PAIRS, getLegalMoves, hasLegalMove, pairSum,
   sampleNonEmptyField
 } from "./helpers";
-import type { moves } from './six-fields-circle';
+import type { Moves } from './six-fields-circle';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 // Optimal move: keep all three opposite-pair sums even, which hands the
 // opponent a losing position. When the mover is already in a losing position

--- a/src/components/games/six-fields-circle/six-fields-circle.tsx
+++ b/src/components/games/six-fields-circle/six-fields-circle.tsx
@@ -22,6 +22,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const getPlayerStepDescription = ({ ctx }: { ctx: Ctx }) => {
   if ((ctx.turnState as { first: number } | null) !== null) {
     return {

--- a/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
+++ b/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
@@ -85,6 +85,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const isGameEnd = (board, ctx) => {
   if (isEqual(board.piles, [0, 0])) {
     return true;
@@ -95,7 +97,7 @@ const isGameEnd = (board, ctx) => {
   return false;
 }
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 const randomBotStrategy: Bot = ({ board, ctx }) =>
   ({ move: 'removeStone', args: [getPileOfRandomAllowedMove(board, ctx)] });

--- a/src/components/games/sum-fifteen/sum-fifteen.tsx
+++ b/src/components/games/sum-fifteen/sum-fifteen.tsx
@@ -97,7 +97,9 @@ export const moves = {
   }
 };
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+export type Moves = typeof moves;
+
+type Bot = BotStrategy<Board, Moves>
 
 const smartBotStrategy: Bot = ({ board, ctx }) => {
   const player = (ctx.currentPlayer ?? currentPlayerFromOwner(board.owner)) as 0 | 1;

--- a/src/components/games/take-and-point/bot-strategy.ts
+++ b/src/components/games/take-and-point/bot-strategy.ts
@@ -9,10 +9,9 @@ import {
   nonEmptyIndices,
   removerWins
 } from './helpers';
-import type { moves } from './take-and-point';
+import type { Moves } from './take-and-point';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, Moves>
 
 type Removal = { index: number; amount: number };
 
@@ -106,9 +105,9 @@ export const chooseRemoval = (board: Board): Removal => {
 // A turn takes stones and then points at the piles the opponent may take from,
 // both named at once — except on the opening turn, which only points, and when
 // the take empties the board and wins the game there and then.
-const asTurn = (board: Board, { index, amount }: Removal, point: (board: Board) => number[]): BotMove<MoveName>[] => {
+const asTurn = (board: Board, { index, amount }: Removal, point: (board: Board) => number[]): BotMove<Moves>[] => {
   const nextBoard: Board = { piles: applyRemoval(board.piles, index, amount), pointed: null };
-  const removal: BotMove<MoveName> = { move: 'takeStones', args: [index, amount] };
+  const removal: BotMove<Moves> = { move: 'takeStones', args: [index, amount] };
   if (isTerminal(nextBoard)) return [removal];
   return [removal, { move: 'pointPiles', args: [point(nextBoard)] }];
 };

--- a/src/components/games/take-and-point/take-and-point.tsx
+++ b/src/components/games/take-and-point/take-and-point.tsx
@@ -31,6 +31,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     A játék elején néhány kupacban kavicsok vannak. Egy játékos körében az alábbi két dolog történik

--- a/src/components/games/ten-coins/ten-coins.tsx
+++ b/src/components/games/ten-coins/ten-coins.tsx
@@ -173,10 +173,12 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 // Smart bot: play the winning move when one exists (drive towards a losing
 // position, or merge to a single value). In a losing position, make the reply
 // that leaves the opponent with the most ways to blunder.
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 export const smartBotStrategy: Bot = ({ board }) => {
   const candidateMoves = movesFromSet(distinctValues(board));

--- a/src/components/games/ten-digit-number/ten-digit-number.tsx
+++ b/src/components/games/ten-digit-number/ten-digit-number.tsx
@@ -106,7 +106,9 @@ export const moves = {
   }
 };
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+export type Moves = typeof moves;
+
+type Bot = BotStrategy<Board, Moves>
 
 const randomBotStrategy: Bot = ({ board }) => {
   const turnsLeft = totalDigits - board.digits.length;
@@ -118,11 +120,11 @@ const randomBotStrategy: Bot = ({ board }) => {
     );
     return {
       move: 'chooseDigit',
-      args: [sample(winningDigits.length > 0 ? winningDigits : availableDigits)]
+      args: [sample(winningDigits.length > 0 ? winningDigits : availableDigits)!]
     };
   }
 
-  return { move: 'chooseDigit', args: [sample(availableDigits)] };
+  return { move: 'chooseDigit', args: [sample(availableDigits)!] };
 };
 
 const smartBotStrategy: Bot = ({ board }) => {
@@ -133,7 +135,7 @@ const smartBotStrategy: Bot = ({ board }) => {
     d => winnerFromState((board.sumMod9 + d) % 9, turnsLeft - 1) === currentPlayer
   );
   if (winningDigits.length > 0) {
-    return { move: 'chooseDigit', args: [sample(winningDigits)] };
+    return { move: 'chooseDigit', args: [sample(winningDigits)!] };
   }
 
   // Losing position: minimise opponent's winning replies, pick randomly among equally bad moves.
@@ -147,7 +149,7 @@ const smartBotStrategy: Bot = ({ board }) => {
   const counts = availableDigits.map(opponentWinCount);
   const minCount = Math.min(...counts);
   const leastBadDigits = availableDigits.filter((_, i) => counts[i] === minCount);
-  return { move: 'chooseDigit', args: [sample(leastBadDigits)] };
+  return { move: 'chooseDigit', args: [sample(leastBadDigits)!] };
 };
 
 const rule = {

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/bot-strategy.ts
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/bot-strategy.ts
@@ -1,14 +1,14 @@
 import { sample } from 'lodash';
 import { Sheriff, Thief, hasWinningTriple, getUntakenCards, type Board } from '../helpers';
 import { type BotStrategy } from '../../../strategy-game-factory';
-import { applyTakeCard, CARD_COUNT, type moves } from './moves';
+import { applyTakeCard, CARD_COUNT, type Moves } from './moves';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 const TURN_PLAYER = [Sheriff, Thief, Sheriff, Thief, Sheriff];
 
 export const randomBotStrategy: Bot = ({ board }) =>
-  ({ move: 'takeCard', args: [[sample(getUntakenCards(board, CARD_COUNT))]] });
+  ({ move: 'takeCard', args: [[sample(getUntakenCards(board, CARD_COUNT))!]] });
 
 export const smartBotStrategy: Bot = ({ board, ctx }) =>
   ({ move: 'takeCard', args: [[getBotCard(board, ctx.currentPlayer!)]] });

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/moves.ts
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/moves.ts
@@ -34,3 +34,6 @@ export const moves = {
     }
   }
 };
+
+export type Moves = typeof moves;
+

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/bot-strategy.ts
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/bot-strategy.ts
@@ -1,12 +1,12 @@
 import { sample } from 'lodash';
 import { Sheriff, Thief, hasWinningTriple, getUntakenCards, type Board } from '../helpers';
 import { type BotStrategy } from '../../../strategy-game-factory';
-import { applyTakeCard, CARD_COUNT, type moves } from './moves';
+import { applyTakeCard, CARD_COUNT, type Moves } from './moves';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 export const randomBotStrategy: Bot = ({ board }) =>
-  ({ move: 'takeCard', args: [sample(getUntakenCards(board, CARD_COUNT))] });
+  ({ move: 'takeCard', args: [sample(getUntakenCards(board, CARD_COUNT))!] });
 
 export const smartBotStrategy: Bot = ({ board, ctx }) =>
   ({ move: 'takeCard', args: [getBotCard(board, ctx.currentPlayer!)] });

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/moves.ts
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/moves.ts
@@ -30,3 +30,6 @@ export const moves = {
     }
   }
 };
+
+export type Moves = typeof moves;
+

--- a/src/components/games/three-piles-rebuild/three-piles-rebuild.tsx
+++ b/src/components/games/three-piles-rebuild/three-piles-rebuild.tsx
@@ -194,15 +194,16 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 // "Keep, then split" is one decision, so the turn is named as a whole (mirrors
 // the pile-splitting games).
-const asTurn = ({ keepId, parts }: { keepId: number; parts: number[] }): BotMove<MoveName>[] => [
+const asTurn = ({ keepId, parts }: { keepId: number; parts: number[] }): BotMove<Moves>[] => [
   { move: 'keepPile', args: [keepId] },
   { move: 'splitPile', args: [parts] }
 ];
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, Moves>
 
 const smartBotStrategy: Bot = ({ board }) => asTurn(getSmartBotStep(board));
 

--- a/src/components/games/tictactoe-alikes/anti-tictactoe/anti-tictactoe.tsx
+++ b/src/components/games/tictactoe-alikes/anti-tictactoe/anti-tictactoe.tsx
@@ -53,6 +53,8 @@ export const moves = {
   }
 }
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     A 3×3-as antiamőba játékban a kezdő piros, a második kék korongokat rak le. Felváltva

--- a/src/components/games/tictactoe-alikes/anti-tictactoe/bot-strategy.ts
+++ b/src/components/games/tictactoe-alikes/anti-tictactoe/bot-strategy.ts
@@ -2,12 +2,12 @@ import { range, isNull, sample, cloneDeep } from 'lodash';
 import { hasWinningSubset } from '../helpers';
 import { roleColors, hasFirstPlayerWon, isGameEnd, type Board } from './helpers';
 import type { BotStrategy } from '../../../strategy-game-factory';
-import type { moves } from './anti-tictactoe';
+import type { Moves } from './anti-tictactoe';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 export const randomBotStrategy: Bot = ({ board }) =>
-  ({ move: 'placePiece', args: [sample(emptyCells(board))] });
+  ({ move: 'placePiece', args: [sample(emptyCells(board))!] });
 
 export const smartBotStrategy: Bot = ({ board, ctx }) => {
   const chosenRoleIndex = ctx.chosenRoleIndex!;
@@ -37,16 +37,16 @@ export const smartBotStrategy: Bot = ({ board, ctx }) => {
     return isWinningState(boardCopy, chosenRoleIndex === 1);
   });
 
-  if (optimalPlaces.length > 0) return { move: 'placePiece', args: [sample(optimalPlaces)] };
+  if (optimalPlaces.length > 0) return { move: 'placePiece', args: [sample(optimalPlaces)!] };
 
   // even if we are gonna lose, try to prolong it
   const aiPieces = range(0, 9).filter(i => board[i] === botColor);
   const notInstantLosingPlaces = allowedPlaces.filter(i => !hasWinningSubset([...aiPieces, i]));
   if (notInstantLosingPlaces.length > 0) {
-    return { move: 'placePiece', args: [sample(notInstantLosingPlaces)] };
+    return { move: 'placePiece', args: [sample(notInstantLosingPlaces)!] };
   }
 
-  return { move: 'placePiece', args: [sample(allowedPlaces)] };
+  return { move: 'placePiece', args: [sample(allowedPlaces)!] };
 };
 
 const emptyCells = (board: Board) => range(0, 9).filter(i => isNull(board[i]));

--- a/src/components/games/tictactoe-alikes/tictactoe-doublestart/bot-strategy.ts
+++ b/src/components/games/tictactoe-alikes/tictactoe-doublestart/bot-strategy.ts
@@ -2,15 +2,14 @@ import { range, isNull, sample, sampleSize, cloneDeep } from 'lodash';
 import { hasWinningSubset } from '../helpers';
 import { isGameEnd, hasFirstPlayerWon, roleColors, type Board } from './helpers';
 import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
-import type { moves } from './tictactoe-doublestart';
+import type { Moves } from './tictactoe-doublestart';
 
-type MoveName = keyof typeof moves
-type Bot = BotStrategy<Board, MoveName>
+type Bot = BotStrategy<Board, Moves>
 
 const emptyCells = (board: Board) => range(0, 9).filter(i => isNull(board[i]));
 
 // The opening turn places two pieces, named together as one decision.
-const placements = (...cells: (number | undefined)[]): BotMove<MoveName>[] =>
+const placements = (...cells: (number | undefined)[]): BotMove<Moves>[] =>
   cells.map(cell => ({ move: 'placePiece', args: [cell] }));
 
 export const randomBotStrategy: Bot = ({ board }) => {

--- a/src/components/games/tictactoe-alikes/tictactoe-doublestart/tictactoe-doublestart.tsx
+++ b/src/components/games/tictactoe-alikes/tictactoe-doublestart/tictactoe-doublestart.tsx
@@ -61,6 +61,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const getPlayerStepDescription = ({ board }) => {
   return isDuringFirstMove(board)
     ? {

--- a/src/components/games/tictactoe-alikes/tictactoe/bot-strategy.ts
+++ b/src/components/games/tictactoe-alikes/tictactoe/bot-strategy.ts
@@ -1,17 +1,17 @@
 import { isNull, range, sample } from 'lodash';
 import { pColor, botColor, inPlacingPhase, isGameEnd, type Board } from './helpers';
 import type { BotStrategy } from '../../../strategy-game-factory';
-import type { moves } from './tictactoe';
+import type { Moves } from './tictactoe';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 export const randomBotStrategy: Bot = ({ board }) => {
   const allowedPlaces = getAllowedPlaces({ board, amIBot: true });
   if (inPlacingPhase(board)) {
     const safePlaces = allowedPlaces.filter(i => !opponentCanWinNext(board, i));
-    return { move: 'placePiece', args: [sample(safePlaces.length > 0 ? safePlaces : allowedPlaces)] };
+    return { move: 'placePiece', args: [sample(safePlaces.length > 0 ? safePlaces : allowedPlaces)!] };
   } else {
-    return { move: 'whitenPiece', args: [sample(allowedPlaces)] };
+    return { move: 'whitenPiece', args: [sample(allowedPlaces)!] };
   }
 };
 

--- a/src/components/games/tictactoe-alikes/tictactoe/tictactoe.tsx
+++ b/src/components/games/tictactoe-alikes/tictactoe/tictactoe.tsx
@@ -83,6 +83,8 @@ export const moves = {
   }
 }
 
+export type Moves = typeof moves;
+
 const getPlayerStepDescription = ({ board, ctx }) => {
   return inPlacingPhase(board)
     ? {

--- a/src/components/games/totem-poles/triangular-grid-ropes-10/bot-strategy.ts
+++ b/src/components/games/totem-poles/triangular-grid-ropes-10/bot-strategy.ts
@@ -10,9 +10,9 @@ import {
   type Edge
 } from './helpers';
 import type { BotStrategy } from '../../../strategy-game-factory';
-import type { moves } from './triangular-grid-ropes-10';
+import type { Moves } from './triangular-grid-ropes-10';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 //    0
 //   1 2
@@ -20,19 +20,21 @@ type Bot = BotStrategy<Board, keyof typeof moves>
 // 6 7 8 9
 
 export const randomBotStrategy: Bot = ({ board }) =>
-  ({ move: 'stretchRope', args: [sample(getAllowedMoves(board))] });
+  ({ move: 'stretchRope', args: [sample(getAllowedMoves(board))!] });
 
 export const smartBotStrategy: Bot = ({ board, ctx }) => {
   const allowedMoves = getAllowedMoves(board);
   if (ctx.chosenRoleIndex === 1) {
     if (board.length === 0) {
-      const opening = sample([{ from: 3, to: 5 }, { from: 1, to: 8 }, { from: 2, to: 7 }]);
+      const opening = sample([{ from: 3, to: 5 }, { from: 1, to: 8 }, { from: 2, to: 7 }])!;
       return { move: 'stretchRope', args: [opening] };
     } else {
       const symDir = edgeDirection(board[0]!)!;
       const lastMove = last(board)!;
       if (edgeDirection(lastMove) === symDir) {
-        return { move: 'stretchRope', args: [allowedMoves.find(e => edgeDirection(e) === symDir)] };
+        // The mirroring strategy keeps the position symmetric, so an edge in
+        // the symmetry direction is still free whenever the opponent just took one.
+        return { move: 'stretchRope', args: [allowedMoves.find(e => edgeDirection(e) === symDir)!] };
       } else {
         const mirrorOfLastMove: Edge = {
           from: mirrorNodes[symDir][lastMove.from],
@@ -40,7 +42,7 @@ export const smartBotStrategy: Bot = ({ board, ctx }) => {
         };
         if (!isAllowed(board, mirrorOfLastMove)) {
           console.error('Unexpected state, falling back');
-          return { move: 'stretchRope', args: [sample(allowedMoves)] };
+          return { move: 'stretchRope', args: [sample(allowedMoves)!] };
         }
         return { move: 'stretchRope', args: [mirrorOfLastMove] };
       }
@@ -53,7 +55,7 @@ export const smartBotStrategy: Bot = ({ board, ctx }) => {
   });
 
   if (nonTrivialMoves.length === 0) {
-    return { move: 'stretchRope', args: [sample(allowedMoves)] };
+    return { move: 'stretchRope', args: [sample(allowedMoves)!] };
   }
 
   if (trivialMoves.length % 2 === 0) {
@@ -80,7 +82,7 @@ export const smartBotStrategy: Bot = ({ board, ctx }) => {
     }
   }
 
-  return { move: 'stretchRope', args: [sample(allowedMoves)] };
+  return { move: 'stretchRope', args: [sample(allowedMoves)!] };
 };
 
 // given board *after* your step, are you set up to win the game for sure?

--- a/src/components/games/totem-poles/triangular-grid-ropes-10/triangular-grid-ropes-10.tsx
+++ b/src/components/games/totem-poles/triangular-grid-ropes-10/triangular-grid-ropes-10.tsx
@@ -116,6 +116,8 @@ export const moves = {
   }
 }
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     Egy indiánrezervátumban 10 totemoszlopot állítottak fel az ábrán látható háromszögrács szerint.

--- a/src/components/games/totem-poles/triangular-grid-ropes-15/bot-strategy.ts
+++ b/src/components/games/totem-poles/triangular-grid-ropes-15/bot-strategy.ts
@@ -2,9 +2,9 @@ import { sample } from 'lodash';
 import { getAllowedMoves, type Board } from './helpers';
 import { findWinningMove } from './solver';
 import type { BotStrategy } from '../../../strategy-game-factory';
-import type { moves } from './triangular-grid-ropes-15';
+import type { Moves } from './triangular-grid-ropes-15';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 //         0
 //        1 2
@@ -13,7 +13,7 @@ type Bot = BotStrategy<Board, keyof typeof moves>
 //    10 11 12 13 14
 
 export const randomBotStrategy: Bot = ({ board }) =>
-  ({ move: 'stretchRope', args: [sample(getAllowedMoves(board))] });
+  ({ move: 'stretchRope', args: [sample(getAllowedMoves(board))!] });
 
 // The bot searches for a winning move every turn (see solver.ts), so it plays
 // optimally whichever side it is on: as the second player it always wins, and
@@ -23,8 +23,8 @@ export const smartBotStrategy: Bot = ({ board }) => {
   if (board.length === 0) {
     // The bot opens (and, from the empty board, is on the losing side). Open on
     // a side of the medial triangle — a natural, symmetric first move.
-    return { move: 'stretchRope', args: [sample([{ from: 3, to: 5 }, { from: 3, to: 12 }, { from: 5, to: 12 }])] };
+    return { move: 'stretchRope', args: [sample([{ from: 3, to: 5 }, { from: 3, to: 12 }, { from: 5, to: 12 }])!] };
   }
   const winningMove = findWinningMove(board);
-  return { move: 'stretchRope', args: [winningMove ?? sample(getAllowedMoves(board))] };
+  return { move: 'stretchRope', args: [winningMove ?? sample(getAllowedMoves(board))!] };
 };

--- a/src/components/games/totem-poles/triangular-grid-ropes-15/triangular-grid-ropes-15.tsx
+++ b/src/components/games/totem-poles/triangular-grid-ropes-15/triangular-grid-ropes-15.tsx
@@ -116,6 +116,8 @@ export const moves = {
   }
 }
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     Egy indiánrezervátumban 15 totemoszlopot állítottak fel az ábrán látható háromszögrács szerint.

--- a/src/components/games/triangle-circle-game/strategy/bot-strategy.ts
+++ b/src/components/games/triangle-circle-game/strategy/bot-strategy.ts
@@ -8,9 +8,9 @@ import {
 import { OPENING_EDGES, isLineTurnWon, marchEdges, winningPairHeatEdges } from './forced-win';
 import { makeMoveEvaluator } from './search';
 import type { BotStrategy } from '../../../strategy-game-factory';
-import type { moves } from '../triangle-circle-game';
+import type { Moves } from '../triangle-circle-game';
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 // Smart bot.
 //

--- a/src/components/games/triangle-circle-game/triangle-circle-game.tsx
+++ b/src/components/games/triangle-circle-game/triangle-circle-game.tsx
@@ -38,6 +38,8 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const rule = {
   hu: <>
     Ebben a játékban ketten játszanak, a vonal-, illetve a körjátékos. A vonaljátékos a táblán minden

--- a/src/components/games/triangle-coloring/triangle-coloring.tsx
+++ b/src/components/games/triangle-coloring/triangle-coloring.tsx
@@ -141,12 +141,14 @@ export const moves = {
   }
 };
 
+export type Moves = typeof moves;
+
 const getAllowedMoves = (board: Board) => range(16).filter(i => board[i] === ALLOWED);
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 const randomBotStrategy: Bot = ({ board }) =>
-  ({ move: 'colorTriangle', args: [sample(getAllowedMoves(board))] });
+  ({ move: 'colorTriangle', args: [sample(getAllowedMoves(board))!] });
 
 const smartBotStrategy: Bot = ({ board }) => {
   const allowedMoves = getAllowedMoves(board);
@@ -154,7 +156,7 @@ const smartBotStrategy: Bot = ({ board }) => {
     i => isWinningState(withTriangleColored(board, i))
   );
 
-  return { move: 'colorTriangle', args: [optimalPlace ?? sample(allowedMoves)] };
+  return { move: 'colorTriangle', args: [optimalPlace ?? sample(allowedMoves)!] };
 };
 
 // given board *after* your step, are you set up to win the game for sure?

--- a/src/components/games/twelve-squares/twelve-squares.tsx
+++ b/src/components/games/twelve-squares/twelve-squares.tsx
@@ -55,11 +55,11 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   );
 };
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+type Bot = BotStrategy<Board, Moves>
 
 const randomBotStrategy: Bot = ({ board }) => {
   const validSteps = [1, 2].filter(step => isValidStep(board, step));
-  return { move: 'step', args: [sample(validSteps)] };
+  return { move: 'step', args: [sample(validSteps)!] };
 };
 
 const optimalBotStrategy: Bot = ({ board: { left, right } }) => {
@@ -84,6 +84,8 @@ export const moves = {
     }
   }
 };
+
+export type Moves = typeof moves;
 
 const rule = {
   hu: <>

--- a/src/components/games/two-of-three-takeaway/two-of-three-takeaway.tsx
+++ b/src/components/games/two-of-three-takeaway/two-of-three-takeaway.tsx
@@ -117,7 +117,9 @@ export const moves = {
   }
 };
 
-type Bot = BotStrategy<Board, keyof typeof moves>
+export type Moves = typeof moves;
+
+type Bot = BotStrategy<Board, Moves>
 
 const smartBotStrategy: Bot = ({ board }) => {
   const [i, j] = getSmartBotMove(board);


### PR DESCRIPTION
The sweep following #392, which added the shape and converted three games. Mechanical, but it found 51 real problems — see below.

## What changed

Each game exports its moves as a type next to them, and its bots take it:

```ts
export type Moves = typeof moves;     // in the file exporting moves
type Bot = BotStrategy<Board, Moves>  // in the bots
```

All 77 bots are now pinned. The wide `BotStrategy<Board>` survives only where a spec helper deliberately accepts any strategy (`recolouring-discs`, `polynomial-building`, `triangle-circle-game/spec-helpers`).

## What typing the arguments found

**48 places passed a possibly-undefined value into a move.** `sample(...)` returns `T | undefined`, and every one of these was writing `args: [sample(candidates)]` — so if the list were ever empty, `undefined` would arrive at the move as a real argument and be applied to the board. Each draws from a list that is non-empty whenever the bot is asked to move, so they now carry the non-null assertion the call sites already implied.

**Three needed a decision rather than an assertion:**

- **`take-power-of-two`** searched for an exponent with `.find()` and used the result directly. It is always found, for a reason worth writing down: in that branch `board % 3` is 1 or 2, and `2**e` alternates 1, 2 (mod 3), so `e = 0` or `e = 1` always lands on a multiple of 3 — both available once `board >= 2`, which the `board === 1` branch above guarantees.
- **`triangular-grid-ropes-10`** does the same in its mirroring branch. Here the guarantee is the strategy's own invariant — mirroring keeps the position symmetric, so an edge in the symmetry direction is free whenever the opponent has just taken one. Worth flagging as the one assertion that rests on a strategy invariant rather than an obviously non-empty list.
- **`policeman-thief-c`**'s `asCopMoves` took a move *name*, which the sweep's rename turned into the moves object. Naming the two moves it is actually called with lets each branch build its own move, rather than one union the compiler cannot check against a discriminated type:

```ts
const asCopMoves = (move: 'placeCop' | 'moveCop', target: number[]): BotMove<Moves>[] =>
  target.map(vertex => move === 'placeCop'
    ? { move: 'placeCop', args: [vertex] }
    : { move: 'moveCop', args: [vertex] });
```

## Verification

- `npm test` — versions, lint, typecheck, 1220 tests, all green.
- Confirmed the pinning bites after the sweep by renaming a move in `bacteria`'s bot: `Type '({ board, ctx }) => { move: "defendxx"; … }' is not assignable to type 'Bot'`. Reverted.
- Played `TwelveSquares`, `Bacteria`, `PolicemanthiefC`, `TriangularGridRopes`, `TriangularGridRopes15` and `TakePowerOfTwo` in a browser — the six games whose strategy code was hand-edited rather than mechanically rewritten. Bot moves in each, no page errors.

Reviewing tip: the diff is `Moves`/`sample(...)!` everywhere except the three cases above — `git diff` filtered for anything else is just those.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgKsSPf9CbvBkKhZKC94yN)_