### PR TITLE
Add conformance test for all games and fix bot strategy bugs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,9 @@ can play against the computer (choosing a role) or against another human in the
 same browser. The computer plays optimally, so the visitor can only win by also
 playing optimally.
 
-The goal is to eventually include all past Dürer competition games. Currently
-roughly half are implemented.
+The goal is to include all past Dürer competition games. Most are implemented
+(76 in `gameList.ts`); what remains is a tail of stragglers plus each new
+competition's games as they are held.
 
 ## Tech stack
 
@@ -99,6 +100,16 @@ hand-rolled game loop. That is what turns "the AI is truly optimal" into a test:
 the smart bot must win as the mover from a winning start board, and as the
 replier from a losing one (see `coins-in-3-piles`, `remove-row-or-column`).
 
+Every registered game is already swept once by
+`games/plays-to-an-end.spec.ts`, which plays each variant headlessly and asserts
+only that a match completes and names a winner — `runMatch` throws on an unknown
+move, a move the game's own `validate` rejects, a move named after the turn
+ended, and a game that never ends, so a new game gets that much conformance for
+free. It is a test of the *game*, not of the bot's judgement, and it is kept
+cheap on purpose: variants whose bot searches are listed out of it by name
+(their own bot spec covers them), and the rest play as many random start boards
+as a small per-variant time budget allows.
+
 Size the sweep to what the strategy costs. Sweeping every start board is right
 for a cheap strategy over a small state space (`coins-in-3-piles`: 124 boards,
 ~50 ms) and wrong for one that searches (`totem-poles`: ~3 s for a handful of
@@ -109,8 +120,8 @@ the parity invariant, the win/loss predicate.
 ## Planned future directions
 
 ### Primary (ongoing)
-- **Add remaining Dürer competition games** — the main ongoing effort; goal is
-  to cover all past competition games
+- **Add Dürer competition games** — the games of each new competition, plus the
+  tail of older ones still missing
 - **Refactoring and style improvements** — keep the codebase clean, consistent,
   and easy to maintain
 

--- a/src/components/games/add-reduce-double/bot-strategy.spec.ts
+++ b/src/components/games/add-reduce-double/bot-strategy.spec.ts
@@ -1,4 +1,6 @@
+import { range, uniq } from 'lodash';
 import { getSmartBotStep } from './bot-strategy';
+import { isTransferAllowed, type Board } from './gameplay';
 
 describe('add-reduce-double getSmartBotStep', () => {
   describe('unbalanced piles (diff > 1): deterministic', () => {
@@ -45,5 +47,28 @@ describe('add-reduce-double getSmartBotStep', () => {
       }
       expect(seenPiles).toEqual(new Set([0, 1]));
     });
+  });
+});
+
+// The cases above all happen to use even piles, which is what let a bot that
+// named `2 * random(1, pile / 2)` pass: lodash's `random` returns a float as
+// soon as either bound is one, and an odd pile halves to a float. Sweep every
+// position instead — an odd pile is both dealt (start boards are two draws from
+// 3..10) and reached in play (a pile grows by half of an even take, so [4, 4]
+// becomes [2, 5]).
+describe('legality of the bot\'s own move', () => {
+  it('names a legal transfer from every position', () => {
+    const positions = range(0, 13)
+      .flatMap(a => range(0, 13).map(b => [a, b] as Board))
+      .filter(([a, b]) => a + b > 2 && Math.max(a, b) >= 2);
+
+    // the balanced branch draws at random, so one call per position proves little
+    const illegal = positions.flatMap(board =>
+      range(20)
+        .map(() => getSmartBotStep(board))
+        .filter(step => !isTransferAllowed(board, step))
+        .map(step => `${JSON.stringify(board)} -> ${JSON.stringify(step)}`));
+
+    expect(uniq(illegal)).toEqual([]);
   });
 });

--- a/src/components/games/add-reduce-double/bot-strategy.ts
+++ b/src/components/games/add-reduce-double/bot-strategy.ts
@@ -19,7 +19,9 @@ export const getSmartBotStep = (board: Board): { pileId: number; pieceCount: num
   if (board[0]-board[1] === -1 || board[0]-board[1] === 0 || board[0]-board[1] === 1) {
     const ran = random(0,1);
     pileId=(board[ran]>1) ? ran : (1 - ran);
-    pieceCount = 2 * random(1, board[pileId] / 2);
+    // `random` returns a float if either bound is one, and an odd pile halves
+    // to a float — which would name an illegal fractional transfer.
+    pieceCount = 2 * random(1, Math.floor(board[pileId] / 2));
   } else {
     pileId = (board[0]>board[1]) ? 0 : 1;
     const third = Math.floor((board[pileId]-board[1-pileId]+1)/3);

--- a/src/components/games/plays-to-an-end.spec.ts
+++ b/src/components/games/plays-to-an-end.spec.ts
@@ -1,0 +1,86 @@
+import * as games from './index';
+import { runMatch, type StrategyGame } from '../strategy-game-factory';
+
+// Plays every registered game headlessly, through the real moves, the real
+// validators and the real reducer. `runMatch` throws on everything this is
+// meant to catch — a bot naming a move the game does not have, a move its own
+// `validate` rejects, moves named after the turn ended, and a game that never
+// reaches an end — so the assertion is simply that a match completes and names
+// a winner.
+//
+// This is a conformance test for the *game*, not for the bot's judgement:
+// whether the smart bot wins from a winning position belongs in the game's own
+// bot-strategy spec.
+
+// A variant is listed here only because its bot searches deeply enough to
+// dominate the suite's runtime — several cost seconds, and swing by more than
+// 10x with the random start board they get. A game's rules are shared by all
+// its variants, so a cheap variant covers the same moves, validators and win
+// detection; what is lost is the coverage of that bot, which its own spec has.
+// Two games have no cheap variant left and so drop out of the sweep entirely:
+// AmorAndCupido (a single, searching variant) and TriangularGridRopes15 (both
+// variants search). Both have a bot-strategy spec of their own.
+const SLOW_VARIANTS = new Set([
+  'AmorAndCupido[0]',
+  'Bacteria[2]',
+  'ChessBishops[1]',
+  'ChessDucks[1]',
+  'ChessDucks[2]',
+  'FiveSquares[1]',
+  'RecolouringDiscs[1]',
+  'SharkChase5[1]',
+  'TriangleCircleGame[1]',
+  'TriangularGridRopes[1]',
+  'TriangularGridRopes15[0]',
+  'TriangularGridRopes15[1]'
+]);
+
+// Per variant: play up to MAX_MATCHES boards, stopping early once MATCH_BUDGET_MS
+// is spent. A game whose match costs microseconds gets every board; one costing
+// tens of milliseconds gets one or two.
+const MAX_MATCHES = 8;
+const MATCH_BUDGET_MS = 15;
+
+type Case = { name: string; Game: StrategyGame<unknown>; variantIndex: number };
+
+const allCases: Case[] = Object.entries(games as Record<string, StrategyGame<unknown>>)
+  .flatMap(([name, Game]) =>
+    Game.variants.map((_, variantIndex) => ({ name: `${name}[${variantIndex}]`, Game, variantIndex })));
+
+const cases = allCases.filter(({ name }) => !SLOW_VARIANTS.has(name));
+
+describe('every game plays to a decided end', () => {
+  it('covers every registered game', () => {
+    expect(allCases.length).toBeGreaterThan(100);
+    // a listed variant that no longer exists would silently stop excluding anything
+    const known = new Set(allCases.map(c => c.name));
+    expect([...SLOW_VARIANTS].filter(name => !known.has(name))).toEqual([]);
+    // every game keeps at least one variant in the sweep, except the one noted above
+    const covered = new Set(cases.map(c => c.name.replace(/\[\d+\]$/, '')));
+    const dropped = [...new Set(allCases.map(c => c.name.replace(/\[\d+\]$/, '')))]
+      .filter(game => !covered.has(game));
+    expect(dropped).toEqual(['AmorAndCupido', 'TriangularGridRopes15']);
+  });
+
+  it.each(cases)('$name', ({ Game, variantIndex }) => {
+    const variant = Game.variants[variantIndex]!;
+    const defaultVariant = Game.variants[Math.max(Game.variants.findIndex(v => v.isDefault), 0)]!;
+    const generateStartBoard = variant.generateStartBoard ?? defaultVariant.generateStartBoard!;
+    const botStrategy = variant.botStrategy!;
+
+    // Start boards are random, so one match samples one line of play. Keep
+    // playing fresh boards until the cheap games have had a handful or the
+    // budget runs out — which spends the time where matches are cheap instead
+    // of on a fixed count that the slowest game would set.
+    const deadline = performance.now() + MATCH_BUDGET_MS;
+    for (let match = 0; match < MAX_MATCHES; match++) {
+      const { winnerIndex } = runMatch({
+        gameplay: Game.gameplay,
+        strategies: [botStrategy, botStrategy],
+        startBoard: generateStartBoard()
+      });
+      expect([0, 1]).toContain(winnerIndex);
+      if (performance.now() > deadline) break;
+    }
+  });
+});

--- a/src/components/games/shark-chase/shark-4-by-4/bot-strategy.ts
+++ b/src/components/games/shark-chase/shark-4-by-4/bot-strategy.ts
@@ -16,9 +16,12 @@ const getAdjacentCells = (pos: number): number[] => {
 
 // The shark's turn is a route of up to two steps, named as a whole: the halfway
 // cell is only chosen to reach the target safely, so the two are one decision.
+// Standing still is the one single-step turn — any real first step leaves the
+// turn open for a second, so a route that stops after `via` would strand the
+// bot mid-turn. Returning to `from` is a two-step route like any other.
 const asSharkRoute = (from: number, via: number, to: number): BotMove<Moves>[] =>
-  to === from
-    ? [{ move: 'moveShark', args: [via] }]
+  via === from
+    ? [{ move: 'moveShark', args: [from] }]
     : [{ move: 'moveShark', args: [via] }, { move: 'moveShark', args: [to] }];
 
 export const randomBotStrategy: Bot = ({ board, ctx }) => {

--- a/src/components/games/shark-chase/shark-5-by-5/bot-strategy.ts
+++ b/src/components/games/shark-chase/shark-5-by-5/bot-strategy.ts
@@ -17,9 +17,12 @@ const getAdjacentCells = (pos: number): number[] => {
 
 // The shark's turn is a route of up to two steps, named as a whole: the halfway
 // cell is only chosen to reach the target safely, so the two are one decision.
+// Standing still is the one single-step turn — any real first step leaves the
+// turn open for a second, so a route that stops after `via` would strand the
+// bot mid-turn. Returning to `from` is a two-step route like any other.
 const asSharkRoute = (from: number, via: number, to: number): BotMove<Moves>[] =>
-  to === from
-    ? [{ move: 'moveShark', args: [via] }]
+  via === from
+    ? [{ move: 'moveShark', args: [from] }]
     : [{ move: 'moveShark', args: [via] }, { move: 'moveShark', args: [to] }];
 
 export const randomBotStrategy: Bot = ({ board, ctx }) => {

--- a/src/components/strategy-game-factory/index.ts
+++ b/src/components/strategy-game-factory/index.ts
@@ -1,5 +1,5 @@
 export { strategyGameFactory } from './strategy-game-factory';
-export type { Presentation, StrategyGameConfig } from './strategy-game-factory';
+export type { Presentation, StrategyGame, StrategyGameConfig } from './strategy-game-factory';
 export type {
   Phase, Mode, Ctx,
   MoveOutcome, MoveFunction, MoveDefinition, Gameplay, GameMoves, ClientGameMoves,

--- a/src/components/strategy-game-factory/strategy-game-factory.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.tsx
@@ -42,17 +42,27 @@ export type StrategyGameConfig<TBoard> = {
   variants: VariantInput<TBoard>[]
 }
 
+// The game component carries the headless half of its own configuration. It is
+// what `runMatch` needs to play the game with no browser, so the catalog-wide
+// conformance spec can reach every registered game without a second registry to
+// keep in step — and it is the shape a competition server would load a game by
+// (docs/real-competitions-plan.md).
+export type StrategyGame<TBoard> = React.FC & {
+  gameplay: Gameplay<TBoard>
+  variants: VariantInput<TBoard>[]
+}
+
 export const strategyGameFactory = <TBoard,>({
   presentation,
   BoardClient,
   gameplay,
   variants
-}: StrategyGameConfig<TBoard>) => {
+}: StrategyGameConfig<TBoard>): StrategyGame<TBoard> => {
   const { rule, roleLabels, getPlayerStepDescription } = presentation;
   const { moves, endOfTurnMove } = gameplay;
   const { defaultVariantIndex, defaultVariant, resolvedVariants } = resolveVariants(variants);
 
-  return () => {
+  const Game = () => {
     const { t } = useTranslation();
     const [selectedVariantIndex, setSelectedVariantIndex] = useState(defaultVariantIndex);
     const activeVariant = resolvedVariants[selectedVariantIndex] ?? defaultVariant;
@@ -361,4 +371,8 @@ export const strategyGameFactory = <TBoard,>({
     </main>
     );
   };
+
+  Game.gameplay = gameplay;
+  Game.variants = resolvedVariants;
+  return Game;
 };


### PR DESCRIPTION
## Summary
This PR adds a comprehensive conformance test that plays every registered game variant headlessly to verify they complete with a winner, and fixes bugs in three bot strategies.

## Key Changes

**New conformance test** (`games/plays-to-an-end.spec.ts`):
- Tests all registered game variants by playing them with bot strategies
- Verifies games complete and declare a winner
- Catches invalid moves, rejected moves, moves after turn end, and infinite games
- Excludes slow variants (those with expensive bot searches) by name to keep test runtime reasonable
- Validates that the exclusion list matches actual variants and that all games have at least one variant in the sweep (except two noted exceptions)

**Bot strategy fixes**:
- **Shark Chase (4×4 and 5×5)**: Fixed `asSharkRoute` logic — standing still should be represented as `via === from` (staying at origin), not `to === from`. The previous logic would incorrectly generate a two-step route when the shark should stand still, or miss the standing-still case entirely.
- **Add Reduce Double**: Fixed `getSmartBotStep` to use `Math.floor` when calculating the random piece count. Since `random()` returns a float when either bound is non-integer, dividing an odd pile by 2 produces a float that would name an illegal fractional transfer.

**Type and export updates**:
- Exported `StrategyGame<TBoard>` type from strategy-game-factory
- Added `gameplay` and `variants` properties to game components so they can be accessed headlessly by the conformance test and (per comments) by a competition server

**Documentation**:
- Updated AGENTS.md to reflect that 76 games are now implemented and explain the conformance test approach

https://claude.ai/code/session_01MgKsSPf9CbvBkKhZKC94yN