### PR TITLE
Extract bot strategies to separate files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,11 +56,12 @@ moves stored in a JSON file when performance requires it.
 whose behaviour it asserts — `gameplay.spec.ts` for the rules,
 `bot-strategy.spec.ts` for the strategy, `<game>.spec.ts` for what the game file
 itself holds, plus a topical name (`solver.spec.ts`, `geometry.spec.ts`) where
-one part of the strategy is worth testing on its own. So a game whose bot lives
-in its `.tsx` tests that bot from `<game>.spec.ts`, and "the bot only ever
-produces legal moves" belongs with the bot even though it reads a rule to check
-it. What must not happen is moves being tested from anywhere but
-`gameplay.spec.ts`.
+one part of the strategy is worth testing on its own. What the module *is*
+decides, not what the test reads along the way: "the bot only ever produces
+legal moves" belongs with the bot even though it checks a rule, and a start
+board asserted to be winnable belongs with the rules even though the Grundy
+value proving it comes from the bot. What must not happen is moves being tested
+from anywhere but `gameplay.spec.ts`.
 
 `gameplay.ts` is the **framework-free half of a game**: the same module a
 server-authoritative competition mode would validate moves with, so it has to
@@ -120,6 +121,17 @@ the parity invariant, the win/loss predicate.
 ## Planned future directions
 
 ### Primary (ongoing)
+- **Replace `boardgame.io` in `durer-aion` with this engine** — the current main
+  effort. `a-gondolkodas-orome/durer-aion` already runs real competitions
+  (server-authoritative match state, team identity, timers, results); the plan
+  is for `strategyGameFactory` to take over its game-engine slot rather than
+  build a competition backend here. See
+  [docs/real-competitions-plan.md](docs/real-competitions-plan.md) — that
+  document's "build here vs. reuse `durer-aion`" fork is decided in favour of
+  reuse, so the phases describing a new backend in this repo no longer apply.
+  What does apply is the engine work they share: a game's rules and its bot
+  each importable with no React, which is why `gameplay.ts` and
+  `bot-strategy.ts` are separate files.
 - **Add Dürer competition games** — the games of each new competition, plus the
   tail of older ones still missing
 - **Refactoring and style improvements** — keep the codebase clean, consistent,

--- a/docs/real-competitions-plan.md
+++ b/docs/real-competitions-plan.md
@@ -1,7 +1,15 @@
 # Supporting Real Competitions — High-Level Plan
 
-Status: **draft / planning** — not yet scheduled. This document captures the
-target design and a phased path to get there. Nothing here is built yet.
+Status: **partly superseded.** The fork this document ends on — build a
+competition backend here, or contribute the engine to the existing `durer-aion`
+monorepo — has since been decided in favour of **reuse**: the current effort is
+replacing `boardgame.io` in `a-gondolkodas-orome/durer-aion` with
+`strategyGameFactory`. Phases 2–5 below describe the backend this repo will now
+*not* build; read them as the requirements that repo has to meet, not as work
+scheduled here. Phase 1 (a headless engine) still applies and is largely done —
+every game's rules live in a React-free `gameplay.ts` and every bot in its own
+`bot-strategy.ts`, both enforced. The rest of the document is kept for the
+requirements it captures: what a competition needs, and why.
 
 ## Goal
 
@@ -132,13 +140,18 @@ imports. Needs test coverage.
 Partly done already: the move interpreter, the game store, the `ctx` derivation
 and the headless match runner live in `strategy-game-factory/engine/`, which
 imports no React, and every bot is a pure `({ board, ctx }) => BotMove[]`
-function that the runner can drive with no browser. Per game, the target layout
-is a React-free `gameplay.ts` holding the board type, the start boards and the
-moves, kept framework-free by ESLint (`AGENTS.md § Files in a game folder`); a
-pilot batch is converted and the rest follow mechanically. What then remains is
-the server-only split of the smart bot — and the rule that a competition game's
-start boards must not be derived from the winning characterisation, since that
-predicate would otherwise ship to the client alongside them.
+function that the runner can drive with no browser. Per game, the rules now live
+in a React-free `gameplay.ts` (board type, start boards, moves), kept
+framework-free by ESLint and by a spec that follows each module's imports
+looking for a `.tsx`; the strategy lives in its own `bot-strategy.ts`, so the
+two can be shipped to different places. `games/plays-to-an-end.spec.ts` plays
+every registered game headlessly, which is the match loop below minus the clock
+and the HTTP.
+
+What remains is keeping the smart bot out of whatever bundle the competitor
+loads — a build-level guarantee, not a file-layout one — and the rule that a
+competition game's start boards must not be derived from the winning
+characterisation, since that predicate would otherwise ship alongside them.
 
 ### Phase 2 — Stand up the backend
 

--- a/src/components/games/bank-robbers/bank-robbers.tsx
+++ b/src/components/games/bank-robbers/bank-robbers.tsx
@@ -1,7 +1,7 @@
-import { strategyGameFactory, type BoardClientProps, type BotStrategy, GameBoard } from '../../strategy-game-factory';
-import { range, sample } from 'lodash';
-import { smartBotStrategy } from './bot-strategy';
-import { generateStartBoard, getAllowedBanks, isRobbable, moves, type Board, type Moves } from './gameplay';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { range } from 'lodash';
+import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
+import { generateStartBoard, isRobbable, moves, type Board } from './gameplay';
 
 const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
   const getCoords = (index) => {
@@ -63,11 +63,6 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
     </GameBoard>
   );
 };
-
-type Bot = BotStrategy<Board, Moves>
-
-const randomBotStrategy: Bot = ({ board }) =>
-  ({ move: 'rob', args: [sample(getAllowedBanks(board))!] });
 
 const rule = {
   hu: <>

--- a/src/components/games/bank-robbers/bot-strategy.ts
+++ b/src/components/games/bank-robbers/bot-strategy.ts
@@ -1,6 +1,6 @@
 import { random, sample } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
-import type { Board, Moves } from './gameplay';
+import { getAllowedBanks, type Board, type Moves } from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>
 
@@ -994,3 +994,6 @@ const optimalStrategy = [
     [4]
   ]
 ];
+
+export const randomBotStrategy: Bot = ({ board }) =>
+  ({ move: 'rob', args: [sample(getAllowedBanks(board))!] });

--- a/src/components/games/digit-subtraction/bot-strategy.ts
+++ b/src/components/games/digit-subtraction/bot-strategy.ts
@@ -1,0 +1,25 @@
+import { sample } from 'lodash';
+import type { BotStrategy } from '../../strategy-game-factory';
+import { type Board, type Moves } from './gameplay';
+
+const digitsOf = (n: number): number[] =>
+  String(n).split('').map(Number).filter(d => d !== 0);
+
+const uniqueNonZeroDigits = (n: number): number[] =>
+  [...new Set(digitsOf(n))];
+
+type Bot = BotStrategy<Board, Moves>
+
+export const randomBotStrategy: Bot = ({ board }) => {
+  const digits = uniqueNonZeroDigits(board);
+  const winningDigits = digits.filter(d => board - d === 0);
+  return { move: 'subtractDigit', args: [sample(winningDigits.length > 0 ? winningDigits : digits)!] };
+};
+
+export const smartBotStrategy: Bot = ({ board }) => {
+  if (board % 10 !== 0) {
+    return { move: 'subtractDigit', args: [board % 10] };
+  } else {
+    return { move: 'subtractDigit', args: [sample(uniqueNonZeroDigits(board))!] };
+  }
+};

--- a/src/components/games/digit-subtraction/digit-subtraction.tsx
+++ b/src/components/games/digit-subtraction/digit-subtraction.tsx
@@ -1,12 +1,6 @@
-import { sample } from 'lodash';
-import { strategyGameFactory, type BotStrategy, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
-import { generateStartBoard, moves, type Board, type Moves } from './gameplay';
-
-const digitsOf = (n: number): number[] =>
-  String(n).split('').map(Number).filter(d => d !== 0);
-
-const uniqueNonZeroDigits = (n: number): number[] =>
-  [...new Set(digitsOf(n))];
+import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { generateStartBoard, moves, type Board } from './gameplay';
+import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
   const digits = String(board).split('').map(Number);
@@ -27,22 +21,6 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
       </div>
     </GameBoard>
   );
-};
-
-type Bot = BotStrategy<Board, Moves>
-
-const randomBotStrategy: Bot = ({ board }) => {
-  const digits = uniqueNonZeroDigits(board);
-  const winningDigits = digits.filter(d => board - d === 0);
-  return { move: 'subtractDigit', args: [sample(winningDigits.length > 0 ? winningDigits : digits)!] };
-};
-
-const smartBotStrategy: Bot = ({ board }) => {
-  if (board % 10 !== 0) {
-    return { move: 'subtractDigit', args: [board % 10] };
-  } else {
-    return { move: 'subtractDigit', args: [sample(uniqueNonZeroDigits(board))!] };
-  }
 };
 
 const rule = {

--- a/src/components/games/discs-flip-or-remove/bot-strategy.spec.ts
+++ b/src/components/games/discs-flip-or-remove/bot-strategy.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { playBotMove } from '../../../test-utils';
-import { smartBotStrategy } from './discs-flip-or-remove';
+import { smartBotStrategy } from './bot-strategy';
 import { moves as gameMoves } from './gameplay';
 
 // board[0] = blue discs, board[1] = red discs.

--- a/src/components/games/discs-flip-or-remove/bot-strategy.ts
+++ b/src/components/games/discs-flip-or-remove/bot-strategy.ts
@@ -1,0 +1,34 @@
+import type { BotMove, BotStrategy } from '../../strategy-game-factory';
+import { random, sample, filter } from 'lodash';
+import { type Board, type Moves } from './gameplay';
+
+type Bot = BotStrategy<Board, Moves>
+
+export const smartBotStrategy: Bot = ({ board }) => {
+  const rem = board[0] % 3;
+  if (rem === 0) {
+    const randomNonEmptyPile = sample(filter([0, 1], (i) => board[i] > 0))!;
+    const amount = board[randomNonEmptyPile] > 1 ? sample([1, 2])! : 1;
+    if (randomNonEmptyPile === 0) {
+      return { move: 'removeDiscs', args: [amount] };
+    } else {
+      return { move: 'turnDiscs', args: [amount] };
+    }
+  } else {
+    const amount = 3 - rem;
+    if (board[1] >= amount && random(0, 1) === 1) {
+      return { move: 'turnDiscs', args: [amount] };
+    } else {
+      return { move: 'removeDiscs', args: [rem] };
+    }
+  }
+};
+
+export const randomBotStrategy: Bot = ({ board }) => {
+  const validMoves: BotMove<Moves>[] = [];
+  if (board[0] >= 1) validMoves.push({ move: 'removeDiscs', args: [1] });
+  if (board[0] >= 2) validMoves.push({ move: 'removeDiscs', args: [2] });
+  if (board[1] >= 1) validMoves.push({ move: 'turnDiscs', args: [1] });
+  if (board[1] >= 2) validMoves.push({ move: 'turnDiscs', args: [2] });
+  return sample(validMoves)!;
+};

--- a/src/components/games/discs-flip-or-remove/discs-flip-or-remove.tsx
+++ b/src/components/games/discs-flip-or-remove/discs-flip-or-remove.tsx
@@ -1,14 +1,8 @@
-import {
-  strategyGameFactory,
-  type BotMove,
-  type BotStrategy,
-  type BoardClientProps,
-  GameBoard,
-  useHoverPreview
-} from '../../strategy-game-factory';
-import { range, isEqual, random, sample, filter } from 'lodash';
+import { strategyGameFactory, type BoardClientProps, GameBoard, useHoverPreview } from '../../strategy-game-factory';
+import { range, isEqual } from 'lodash';
 import { useTranslation } from '../../../language';
-import { generateStartBoard, generateTestStartBoard, moves, type Board, type Moves } from './gameplay';
+import { generateStartBoard, generateTestStartBoard, moves, type Board } from './gameplay';
+import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 const DisabledDisc = ({ bgColor }) => (
   <button className={`size-12 rounded-full ${bgColor}`} disabled />
@@ -85,37 +79,6 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
       {nextBoardDescription()}
     </GameBoard>
   );
-};
-
-type Bot = BotStrategy<Board, Moves>
-
-export const smartBotStrategy: Bot = ({ board }) => {
-  const rem = board[0] % 3;
-  if (rem === 0) {
-    const randomNonEmptyPile = sample(filter([0, 1], (i) => board[i] > 0))!;
-    const amount = board[randomNonEmptyPile] > 1 ? sample([1, 2])! : 1;
-    if (randomNonEmptyPile === 0) {
-      return { move: 'removeDiscs', args: [amount] };
-    } else {
-      return { move: 'turnDiscs', args: [amount] };
-    }
-  } else {
-    const amount = 3 - rem;
-    if (board[1] >= amount && random(0, 1) === 1) {
-      return { move: 'turnDiscs', args: [amount] };
-    } else {
-      return { move: 'removeDiscs', args: [rem] };
-    }
-  }
-};
-
-const randomBotStrategy: Bot = ({ board }) => {
-  const validMoves: BotMove<Moves>[] = [];
-  if (board[0] >= 1) validMoves.push({ move: 'removeDiscs', args: [1] });
-  if (board[0] >= 2) validMoves.push({ move: 'removeDiscs', args: [2] });
-  if (board[1] >= 1) validMoves.push({ move: 'turnDiscs', args: [1] });
-  if (board[1] >= 2) validMoves.push({ move: 'turnDiscs', args: [2] });
-  return sample(validMoves)!;
 };
 
 const getPlayerStepDescription = () => ({

--- a/src/components/games/four-piles-two-grabs/bot-strategy.ts
+++ b/src/components/games/four-piles-two-grabs/bot-strategy.ts
@@ -1,0 +1,10 @@
+import type { BotStrategy } from '../../strategy-game-factory';
+import { getRandomBotMove, getSmartBotMove, type Board, type Moves } from './gameplay';
+
+type Bot = BotStrategy<Board, Moves>
+
+export const smartBotStrategy: Bot = ({ board }) =>
+  ({ move: 'takeStones', args: [getSmartBotMove(board)] });
+
+export const randomBotStrategy: Bot = ({ board }) =>
+  ({ move: 'takeStones', args: [getRandomBotMove(board)] });

--- a/src/components/games/four-piles-two-grabs/four-piles-two-grabs.tsx
+++ b/src/components/games/four-piles-two-grabs/four-piles-two-grabs.tsx
@@ -1,16 +1,9 @@
 import { useEffect, useState } from 'react';
 import { range } from 'lodash';
-import { strategyGameFactory, type BotStrategy, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
 import { useTranslation } from '../../../language';
-import {
-  generateStartBoard,
-  getRandomBotMove,
-  getSmartBotMove,
-  moves,
-  type Board,
-  type Move,
-  type Moves
-} from './gameplay';
+import { generateStartBoard, moves, type Board, type Move } from './gameplay';
+import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 const Stepper = ({ label, disabled, onClick }: {
   label: string; disabled: boolean; onClick: () => void;
@@ -130,14 +123,6 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     </GameBoard>
   );
 };
-
-type Bot = BotStrategy<Board, Moves>
-
-const smartBotStrategy: Bot = ({ board }) =>
-  ({ move: 'takeStones', args: [getSmartBotMove(board)] });
-
-const randomBotStrategy: Bot = ({ board }) =>
-  ({ move: 'takeStones', args: [getRandomBotMove(board)] });
 
 const rule = {
   hu: <>

--- a/src/components/games/latin-square-filling/bot-strategy.ts
+++ b/src/components/games/latin-square-filling/bot-strategy.ts
@@ -1,0 +1,14 @@
+import type { BotStrategy } from '../../strategy-game-factory';
+import { getRandomBotStep, getSmartBotStep, type Board, type Moves } from './gameplay';
+
+type Bot = BotStrategy<Board, Moves>
+
+export const smartBotStrategy: Bot = ({ board }) => {
+  const { cell, digit } = getSmartBotStep(board);
+  return { move: 'placeDigit', args: [cell, digit] };
+};
+
+export const randomBotStrategy: Bot = ({ board }) => {
+  const { cell, digit } = getRandomBotStep(board);
+  return { move: 'placeDigit', args: [cell, digit] };
+};

--- a/src/components/games/latin-square-filling/latin-square-filling.tsx
+++ b/src/components/games/latin-square-filling/latin-square-filling.tsx
@@ -1,13 +1,8 @@
 import { useEffect, useState } from 'react';
-import {
-  strategyGameFactory,
-  type BoardClientProps,
-  type Ctx,
-  type BotStrategy,
-  GameBoard
-} from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, type Ctx, GameBoard } from '../../strategy-game-factory';
 import { useTranslation } from '../../../language';
-import { generateStartBoard, getRandomBotStep, getSmartBotStep, moves, type Board, type Moves } from './gameplay';
+import { generateStartBoard, moves, type Board } from './gameplay';
+import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
@@ -98,18 +93,6 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
       )}
     </GameBoard>
   );
-};
-
-type Bot = BotStrategy<Board, Moves>
-
-const smartBotStrategy: Bot = ({ board }) => {
-  const { cell, digit } = getSmartBotStep(board);
-  return { move: 'placeDigit', args: [cell, digit] };
-};
-
-const randomBotStrategy: Bot = ({ board }) => {
-  const { cell, digit } = getRandomBotStep(board);
-  return { move: 'placeDigit', args: [cell, digit] };
 };
 
 const getPlayerStepDescription = ({ ctx }: { board: Board; ctx: Ctx }) => {

--- a/src/components/games/matchstick-piles/bot-strategy.ts
+++ b/src/components/games/matchstick-piles/bot-strategy.ts
@@ -1,0 +1,64 @@
+import { sample } from 'lodash';
+import type { BotMove, BotStrategy } from '../../strategy-game-factory';
+import { type Board, type Moves } from './gameplay';
+
+// --- Optimal strategy -------------------------------------------------------
+// Impartial game: the Grundy value of a single pile of size n is
+//   g(0)=0, g(1)=1, g(2)=2, and for n>=3: 2 if n is even, 0 if n is odd.
+// The value of a position is the XOR of its piles; the player to move wins iff
+// that XOR is non-zero. A winning move is any move leaving the opponent an
+// all-zero XOR position.
+const grundy = (n: number): number => {
+  if (n <= 2) return n;
+  return n % 2 === 0 ? 2 : 0;
+};
+
+const xorSum = (board: Board): number => board.reduce((acc, n) => acc ^ grundy(n), 0);
+
+export type Move =
+  | { type: 'remove'; pileId: number }
+  | { type: 'split'; pileId: number; firstPart: number };
+
+const legalMoves = (board: Board): Move[] => {
+  const result: Move[] = [];
+  board.forEach((size, pileId) => {
+    result.push({ type: 'remove', pileId });
+    for (let firstPart = 1; firstPart < size; firstPart++) {
+      result.push({ type: 'split', pileId, firstPart });
+    }
+  });
+  return result;
+};
+
+const applyMove = (board: Board, move: Move): Board => {
+  if (move.type === 'remove') {
+    return board.map((n, i) => (i === move.pileId ? n - 1 : n)).filter(n => n > 0);
+  }
+  const size = board[move.pileId];
+  return board.flatMap((n, i) =>
+    i === move.pileId ? [move.firstPart, size - move.firstPart] : [n]
+  );
+};
+
+type Bot = BotStrategy<Board, Moves>
+
+const asBotMove = (move: Move): BotMove<Moves> =>
+  move.type === 'remove'
+    ? { move: 'removeMatch', args: [move.pileId] }
+    : { move: 'splitPile', args: [move.pileId, move.firstPart] };
+
+export const smartBotStrategy: Bot = ({ board }) => {
+  const candidates = legalMoves(board);
+  const winningMove = candidates.find(move => xorSum(applyMove(board, move)) === 0);
+  // In a losing position no move wins against optimal play, so play a random
+  // legal move and hope the opponent slips.
+  return asBotMove(winningMove ?? sample(candidates)!);
+};
+
+export const randomBotStrategy: Bot = ({ board }) => {
+  const candidates = legalMoves(board);
+  // Grab an immediately winning move (one that empties the board) if there is
+  // one; otherwise just play a random legal move.
+  const winningNow = candidates.find(move => applyMove(board, move).length === 0);
+  return asBotMove(winningNow ?? sample(candidates)!);
+};

--- a/src/components/games/matchstick-piles/matchstick-piles.tsx
+++ b/src/components/games/matchstick-piles/matchstick-piles.tsx
@@ -1,14 +1,8 @@
 import { Fragment } from 'react';
-import { range, sample, random } from 'lodash';
-import {
-  strategyGameFactory,
-  type BotStrategy,
-  type BotMove,
-  type BoardClientProps,
-  GameBoard,
-  useHoverPreview
-} from '../../strategy-game-factory';
-import { generateStartBoard, moves, type Board, type Moves } from './gameplay';
+import { range, random } from 'lodash';
+import { strategyGameFactory, type BoardClientProps, GameBoard, useHoverPreview } from '../../strategy-game-factory';
+import { generateStartBoard, moves, type Board } from './gameplay';
+import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 type Hover =
   | { pileId: number; kind: 'remove' }
@@ -108,67 +102,6 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
       </div>
     </GameBoard>
   );
-};
-
-// --- Optimal strategy -------------------------------------------------------
-// Impartial game: the Grundy value of a single pile of size n is
-//   g(0)=0, g(1)=1, g(2)=2, and for n>=3: 2 if n is even, 0 if n is odd.
-// The value of a position is the XOR of its piles; the player to move wins iff
-// that XOR is non-zero. A winning move is any move leaving the opponent an
-// all-zero XOR position.
-const grundy = (n: number): number => {
-  if (n <= 2) return n;
-  return n % 2 === 0 ? 2 : 0;
-};
-
-const xorSum = (board: Board): number => board.reduce((acc, n) => acc ^ grundy(n), 0);
-
-type Move =
-  | { type: 'remove'; pileId: number }
-  | { type: 'split'; pileId: number; firstPart: number };
-
-const legalMoves = (board: Board): Move[] => {
-  const result: Move[] = [];
-  board.forEach((size, pileId) => {
-    result.push({ type: 'remove', pileId });
-    for (let firstPart = 1; firstPart < size; firstPart++) {
-      result.push({ type: 'split', pileId, firstPart });
-    }
-  });
-  return result;
-};
-
-const applyMove = (board: Board, move: Move): Board => {
-  if (move.type === 'remove') {
-    return board.map((n, i) => (i === move.pileId ? n - 1 : n)).filter(n => n > 0);
-  }
-  const size = board[move.pileId];
-  return board.flatMap((n, i) =>
-    i === move.pileId ? [move.firstPart, size - move.firstPart] : [n]
-  );
-};
-
-const asBotMove = (move: Move): BotMove<Moves> =>
-  move.type === 'remove'
-    ? { move: 'removeMatch', args: [move.pileId] }
-    : { move: 'splitPile', args: [move.pileId, move.firstPart] };
-
-type Bot = BotStrategy<Board, Moves>
-
-const smartBotStrategy: Bot = ({ board }) => {
-  const candidates = legalMoves(board);
-  const winningMove = candidates.find(move => xorSum(applyMove(board, move)) === 0);
-  // In a losing position no move wins against optimal play, so play a random
-  // legal move and hope the opponent slips.
-  return asBotMove(winningMove ?? sample(candidates)!);
-};
-
-const randomBotStrategy: Bot = ({ board }) => {
-  const candidates = legalMoves(board);
-  // Grab an immediately winning move (one that empties the board) if there is
-  // one; otherwise just play a random legal move.
-  const winningNow = candidates.find(move => applyMove(board, move).length === 0);
-  return asBotMove(winningNow ?? sample(candidates)!);
 };
 
 const rule = {

--- a/src/components/games/number-covering/bot-strategy.spec.ts
+++ b/src/components/games/number-covering/bot-strategy.spec.ts
@@ -1,4 +1,4 @@
-import { smartBotStrategy } from './number-covering';
+import { smartBotStrategy } from './bot-strategy';
 import { COVERED, type Board } from './gameplay';
 import { botNextMoveArgs, makeCtx } from '../../../test-utils';
 

--- a/src/components/games/number-covering/bot-strategy.ts
+++ b/src/components/games/number-covering/bot-strategy.ts
@@ -1,0 +1,25 @@
+import type { BotStrategy } from '../../strategy-game-factory';
+import { sample } from 'lodash';
+import { getRemaining, type Board, type Moves } from './gameplay';
+
+type Bot = BotStrategy<Board, Moves>
+
+export const randomBotStrategy: Bot = ({ board }) =>
+  ({ move: 'coverNumber', args: [sample(getRemaining(board))!] });
+
+export const smartBotStrategy: Bot = ({ board, ctx }) => {
+  const remaining = getRemaining(board);
+  const evens = remaining.filter(i => i%2 === 0);
+  const odds = remaining.filter(i => i%2 === 1);
+  if (evens.length === odds.length || evens.length === 0 || odds.length === 0) {
+    return { move: 'coverNumber', args: [sample(remaining)!] };
+  } else if (ctx.currentPlayer === 0) {
+    // first player wants same-parity survivors -> remove from the smaller class
+    const candidates = evens.length < odds.length ? evens : odds;
+    return { move: 'coverNumber', args: [sample(candidates)!] };
+  } else {
+    // second player wants a mixed pair -> remove from the larger class
+    const candidates = evens.length > odds.length ? evens : odds;
+    return { move: 'coverNumber', args: [sample(candidates)!] };
+  }
+};

--- a/src/components/games/number-covering/number-covering.tsx
+++ b/src/components/games/number-covering/number-covering.tsx
@@ -1,7 +1,8 @@
-import { strategyGameFactory, type BotStrategy, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
-import { range, sum, sample } from 'lodash';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { range, sum } from 'lodash';
 import { useTranslation } from '../../../language';
-import { generateTestStartBoard, getRemaining, moves, type Board, COVERED, type Moves } from './gameplay';
+import { generateTestStartBoard, getRemaining, moves, type Board, COVERED } from './gameplay';
+import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
@@ -27,28 +28,6 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
       </p>
     </GameBoard>
   );
-};
-
-type Bot = BotStrategy<Board, Moves>
-
-const randomBotStrategy: Bot = ({ board }) =>
-  ({ move: 'coverNumber', args: [sample(getRemaining(board))!] });
-
-export const smartBotStrategy: Bot = ({ board, ctx }) => {
-  const remaining = getRemaining(board);
-  const evens = remaining.filter(i => i%2 === 0);
-  const odds = remaining.filter(i => i%2 === 1);
-  if (evens.length === odds.length || evens.length === 0 || odds.length === 0) {
-    return { move: 'coverNumber', args: [sample(remaining)!] };
-  } else if (ctx.currentPlayer === 0) {
-    // first player wants same-parity survivors -> remove from the smaller class
-    const candidates = evens.length < odds.length ? evens : odds;
-    return { move: 'coverNumber', args: [sample(candidates)!] };
-  } else {
-    // second player wants a mixed pair -> remove from the larger class
-    const candidates = evens.length > odds.length ? evens : odds;
-    return { move: 'coverNumber', args: [sample(candidates)!] };
-  }
 };
 
 const makeRule = (maxNumber: number) => ({

--- a/src/components/games/number-pyramid/board-client.tsx
+++ b/src/components/games/number-pyramid/board-client.tsx
@@ -1,6 +1,6 @@
 import { isEqual } from 'lodash';
 import { useTranslation } from '../../../language';
-import { hasActivePair, type Board } from './strategy';
+import { hasActivePair, type Board } from './gameplay';
 import { GameBoard, type BoardClientProps } from '../../strategy-game-factory';
 
 export type TurnState = { levelIdx: number; slotIdx: number } | null;

--- a/src/components/games/number-pyramid/bot-strategy.spec.ts
+++ b/src/components/games/number-pyramid/bot-strategy.spec.ts
@@ -1,4 +1,5 @@
-import { isP2WinningPosition, randomBotStrategy, smartBotStrategy, type Board, type Slot } from './strategy';
+import { isP2WinningPosition, randomBotStrategy, smartBotStrategy } from './bot-strategy';
+import type { Board, Slot } from './gameplay';
 import { botNextMoveArgs, makeCtx } from '../../../test-utils';
 
 const active = (value: number): Slot => ({ value, state: 'active' });

--- a/src/components/games/number-pyramid/bot-strategy.ts
+++ b/src/components/games/number-pyramid/bot-strategy.ts
@@ -1,16 +1,10 @@
-import { orderBy, random, range, sample, sampleSize, shuffle, sum } from 'lodash';
+import { orderBy, range, sample, sampleSize } from 'lodash';
 import type { BotMove, BotStrategy } from '../../strategy-game-factory';
-import type { Moves } from './gameplay';
+import {
+  activeSlotIndices, applyMoveToBoard, hasActivePair, type Board, type Level, type Moves
+} from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>
-
-export type Slot = { value: number; state: 'active' | 'consumed' };
-export type Level = (Slot | null)[];
-export type Board = {
-  levels: Level[];
-  target: number;
-  sortedInitial: number[];
-};
 
 export const randomBotStrategy: Bot = ({ board }) => {
   const win = findImmediateWin(board);
@@ -61,36 +55,6 @@ export const isP2WinningPosition = ({ sortedInitial, target }: Board): boolean =
   return s[0] + s[1] + s[6] + s[7] < target && s[2] + s[3] + s[4] + s[5] >= target;
 };
 
-export const generateStartBoard = (tries = 0): Board => {
-  if (tries >= 100) throw new Error('generateStartBoard: too many retries');
-  const nums = Array.from({ length: 8 }, () => random(2, 15));
-  nums.sort((a, b) => b - a);
-  const extremes = nums[0] + nums[1] + nums[6] + nums[7];
-  const innerSum = nums[2] + nums[3] + nums[4] + nums[5];
-  const total = sum(nums);
-  const topTwo = nums[0] + nums[1];
-
-  const p2Gens = extremes < innerSum ? [() => random(extremes + 1, innerSum)] : [];
-  const p1Gens = [() => random(innerSum + 1, total)];
-  const lowerP1Max = Math.min(extremes, innerSum);
-  if (topTwo + 1 <= lowerP1Max) p1Gens.push(() => random(topTwo + 1, lowerP1Max));
-
-  const pool = random(0, 1) === 0 ? p2Gens : p1Gens;
-  if (pool.length === 0) return generateStartBoard(tries + 1);
-  const target = sample(pool)!();
-
-  return {
-    levels: [
-      shuffle(nums).map((n): Slot => ({ value: n, state: 'active' })),
-      Array(4).fill(null),
-      Array(2).fill(null),
-      Array(1).fill(null)
-    ],
-    target,
-    sortedInitial: [...nums]
-  };
-};
-
 const findImmediateWin = ({ levels, target }: Board) => {
   for (const [levelIdx, level] of levels.entries()) {
     const indices = findWinningPair(level, target);
@@ -111,20 +75,6 @@ const findWinningPair = (level: Level, target: number) => {
   return null;
 };
 
-export const hasActivePair = (level: Level): boolean => activeSlotIndices(level).length >= 2;
-
-export const applyMoveToBoard = (
-  board: Board, levelIdx: number, indices: number[]
-): { nextBoard: Board; combinedValue: number } => {
-  const newLevels = board.levels.map(level => [...level]);
-  const level = newLevels[levelIdx];
-  const combinedValue = indices.reduce((acc, i) => acc + (level[i] as Slot).value, 0);
-  indices.forEach(i => { level[i] = { ...(level[i] as Slot), state: 'consumed' }; });
-  const emptyIdx = newLevels[levelIdx + 1].indexOf(null);
-  newLevels[levelIdx + 1][emptyIdx] = { value: combinedValue, state: 'active' };
-  return { nextBoard: { ...board, levels: newLevels }, combinedValue };
-};
-
 const canWin = (board: Board): boolean => {
   for (let li = 0; li < 3; li++) {
     const actives = activeSlotIndices(board.levels[li]);
@@ -138,21 +88,4 @@ const canWin = (board: Board): boolean => {
     }
   }
   return false;
-};
-
-// Slot states: null = empty placeholder, { value, state:'active'|'consumed' }
-const activeSlotIndices = (level: Level): number[] =>
-  level.flatMap((s, i) => (s?.state === 'active' ? [i] : []));
-
-// A move erases two distinct numbers that are still active on one level and
-// writes their sum one level up — so the level must have a level above it.
-// Both players combine on the same pyramid, so whose turn it is does not enter
-// into legality.
-export const isCombineAllowed = (board: Board, move: { levelIdx: number; indices: number[] }): boolean => {
-  if (!move) return false;
-  const { levelIdx, indices } = move;
-  if (!Number.isInteger(levelIdx) || levelIdx < 0 || levelIdx >= board.levels.length - 1) return false;
-  if (!Array.isArray(indices) || indices.length !== 2 || indices[0] === indices[1]) return false;
-  const actives = activeSlotIndices(board.levels[levelIdx]);
-  return indices.every(i => actives.includes(i));
 };

--- a/src/components/games/number-pyramid/gameplay.spec.ts
+++ b/src/components/games/number-pyramid/gameplay.spec.ts
@@ -1,5 +1,4 @@
-import { moves } from './gameplay';
-import { isCombineAllowed, applyMoveToBoard, type Board, type Slot } from './strategy';
+import { applyMoveToBoard, isCombineAllowed, moves, type Board, type Slot } from './gameplay';
 import { makeCtx } from '../../../test-utils';
 
 const active = (value: number): Slot => ({ value, state: 'active' });

--- a/src/components/games/number-pyramid/gameplay.ts
+++ b/src/components/games/number-pyramid/gameplay.ts
@@ -1,5 +1,43 @@
+import { random, sample, shuffle, sum } from 'lodash';
 import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
-import { applyMoveToBoard, isCombineAllowed, type Board } from './strategy';
+
+export type Slot = { value: number; state: 'active' | 'consumed' };
+export type Level = (Slot | null)[];
+export type Board = {
+  levels: Level[];
+  target: number;
+  sortedInitial: number[];
+};
+
+export const generateStartBoard = (tries = 0): Board => {
+  if (tries >= 100) throw new Error('generateStartBoard: too many retries');
+  const nums = Array.from({ length: 8 }, () => random(2, 15));
+  nums.sort((a, b) => b - a);
+  const extremes = nums[0] + nums[1] + nums[6] + nums[7];
+  const innerSum = nums[2] + nums[3] + nums[4] + nums[5];
+  const total = sum(nums);
+  const topTwo = nums[0] + nums[1];
+
+  const p2Gens = extremes < innerSum ? [() => random(extremes + 1, innerSum)] : [];
+  const p1Gens = [() => random(innerSum + 1, total)];
+  const lowerP1Max = Math.min(extremes, innerSum);
+  if (topTwo + 1 <= lowerP1Max) p1Gens.push(() => random(topTwo + 1, lowerP1Max));
+
+  const pool = random(0, 1) === 0 ? p2Gens : p1Gens;
+  if (pool.length === 0) return generateStartBoard(tries + 1);
+  const target = sample(pool)!();
+
+  return {
+    levels: [
+      shuffle(nums).map((n): Slot => ({ value: n, state: 'active' })),
+      Array(4).fill(null),
+      Array(2).fill(null),
+      Array(1).fill(null)
+    ],
+    target,
+    sortedInitial: [...nums]
+  };
+};
 
 export const moves = {
   combineTwo: {
@@ -22,3 +60,39 @@ export const moves = {
 };
 
 export type Moves = typeof moves;
+
+export const hasActivePair = (level: Level): boolean => activeSlotIndices(level).length >= 2;
+
+export const applyMoveToBoard = (
+  board: Board, levelIdx: number, indices: number[]
+): { nextBoard: Board; combinedValue: number } => {
+  const newLevels = board.levels.map(level => [...level]);
+  const level = newLevels[levelIdx];
+  const combinedValue = indices.reduce((acc, i) => acc + (level[i] as Slot).value, 0);
+  indices.forEach(i => { level[i] = { ...(level[i] as Slot), state: 'consumed' }; });
+  const emptyIdx = newLevels[levelIdx + 1].indexOf(null);
+  newLevels[levelIdx + 1][emptyIdx] = { value: combinedValue, state: 'active' };
+  return { nextBoard: { ...board, levels: newLevels }, combinedValue };
+};
+
+// Slot states: null = empty placeholder, { value, state:'active'|'consumed' }
+export const activeSlotIndices = (level: Level): number[] =>
+  level.flatMap((s, i) => (s?.state === 'active' ? [i] : []));
+
+// A move erases two distinct numbers that are still active on one level and
+// writes their sum one level up — so the level must have a level above it.
+// Both players combine on the same pyramid, so whose turn it is does not enter
+// into legality.
+
+// A move erases two distinct numbers that are still active on one level and
+// writes their sum one level up — so the level must have a level above it.
+// Both players combine on the same pyramid, so whose turn it is does not enter
+// into legality.
+export const isCombineAllowed = (board: Board, move: { levelIdx: number; indices: number[] }): boolean => {
+  if (!move) return false;
+  const { levelIdx, indices } = move;
+  if (!Number.isInteger(levelIdx) || levelIdx < 0 || levelIdx >= board.levels.length - 1) return false;
+  if (!Array.isArray(indices) || indices.length !== 2 || indices[0] === indices[1]) return false;
+  const actives = activeSlotIndices(board.levels[levelIdx]);
+  return indices.every(i => actives.includes(i));
+};

--- a/src/components/games/number-pyramid/number-pyramid.tsx
+++ b/src/components/games/number-pyramid/number-pyramid.tsx
@@ -1,7 +1,7 @@
 import { strategyGameFactory, type Ctx } from '../../strategy-game-factory';
-import { smartBotStrategy, generateStartBoard, randomBotStrategy } from './strategy';
+import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
+import { generateStartBoard, moves } from './gameplay';
 import { BoardClient, type TurnState } from './board-client';
-import { moves } from './gameplay';
 
 const rule = {
   hu: <>

--- a/src/components/games/pairs-of-numbers/bot-strategy.ts
+++ b/src/components/games/pairs-of-numbers/bot-strategy.ts
@@ -1,0 +1,30 @@
+import type { BotStrategy } from '../../strategy-game-factory';
+import { random } from 'lodash';
+import { type Board, type Moves } from './gameplay';
+
+type Bot = BotStrategy<Board, Moves>
+
+export const randomBotStrategy: Bot = () =>
+  random(0, 1) === 0 ? { move: 'add1' } : { move: 'subtract' };
+
+export const smartBotStrategy: Bot = ({ board }) => {
+  const [a, b] = board;
+  if (a <= b) {
+    return { move: 'subtract' };
+  }
+  if (a <= 2 * b) {
+    return { move: 'add1' };
+  }
+
+  if (a % 2 === 0 && b % 2 === 0) {
+    return { move: 'add1' };
+  }
+  if (a % 2 === 1 && b % 2 === 1) {
+    return { move: 'subtract' };
+  }
+  if (a % 2 === 1 && b % 2 === 0) {
+    return { move: 'subtract' };
+  }
+
+  return { move: 'add1' };
+};

--- a/src/components/games/pairs-of-numbers/pairs-of-numbers.tsx
+++ b/src/components/games/pairs-of-numbers/pairs-of-numbers.tsx
@@ -1,7 +1,7 @@
-import { strategyGameFactory, type BotStrategy, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
-import { random } from 'lodash';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
 import { useTranslation } from '../../../language';
-import { generateStartBoard, generateTestStartBoard, moves, type Board, type Moves } from './gameplay';
+import { generateStartBoard, generateTestStartBoard, moves, type Board } from './gameplay';
+import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
@@ -32,33 +32,6 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
       </div>
     </GameBoard>
   );
-};
-
-type Bot = BotStrategy<Board, Moves>
-
-const randomBotStrategy: Bot = () =>
-  random(0, 1) === 0 ? { move: 'add1' } : { move: 'subtract' };
-
-const smartBotStrategy: Bot = ({ board }) => {
-  const [a, b] = board;
-  if (a <= b) {
-    return { move: 'subtract' };
-  }
-  if (a <= 2 * b) {
-    return { move: 'add1' };
-  }
-
-  if (a % 2 === 0 && b % 2 === 0) {
-    return { move: 'add1' };
-  }
-  if (a % 2 === 1 && b % 2 === 1) {
-    return { move: 'subtract' };
-  }
-  if (a % 2 === 1 && b % 2 === 0) {
-    return { move: 'subtract' };
-  }
-
-  return { move: 'add1' };
 };
 
 const rule = {

--- a/src/components/games/remove-divisor-multiple/bot-strategy.ts
+++ b/src/components/games/remove-divisor-multiple/bot-strategy.ts
@@ -1,3 +1,6 @@
+import { isAllowed, type Board, type Moves } from './gameplay';
+import { range, sample } from 'lodash';
+import type { BotStrategy } from '../../strategy-game-factory';
 // generated with scripts/pre-generate-ai-moves/remove-divisor-multiple.py
 export const strategyDict = {
   "6": {
@@ -15990,3 +15993,36 @@ export const strategyDict = {
     "-1_32767": [11, 13]
   }
 };
+
+type Bot = BotStrategy<Board, Moves>
+
+export const randomBotStrategy: Bot = ({ board }) => {
+  const possibleMoves = range(1, board.numbersOnTable.length + 1)
+    .filter(n => isAllowed(board, n));
+  return { move: 'removeNumber', args: [sample(possibleMoves)!] };
+};
+
+export const smartBotStrategy: Bot = ({ board }) => {
+  const numCount = board.numbersOnTable.length;
+  const stateId = generateStateID(board);
+  const optimalMoves = strategyDict[numCount]
+    ? strategyDict[numCount][stateId]
+    : [];
+  if (optimalMoves.length) {
+    return { move: 'removeNumber', args: [sample(optimalMoves)!] };
+  } else {
+    const possibleMoves = range(1, numCount + 1)
+      .filter(n => isAllowed(board, n));
+    return { move: 'removeNumber', args: [sample(possibleMoves)!] };
+  }
+};
+
+const generateStateID = (board: Board) => {
+  let id = 0;
+  for (let i = 0; i < board.numbersOnTable.length; i++) {
+    if (board.numbersOnTable[i]){
+      id += 2**(i)
+    }
+  }
+  return (board.previousMove === null ? '-1' : board.previousMove) + "_" +id;
+}

--- a/src/components/games/remove-divisor-multiple/remove-divisor-multiple.tsx
+++ b/src/components/games/remove-divisor-multiple/remove-divisor-multiple.tsx
@@ -1,8 +1,8 @@
-import { strategyGameFactory, type BoardClientProps, type BotStrategy, GameBoard } from '../../strategy-game-factory';
-import { range, sample } from 'lodash';
-import { strategyDict } from './bot-strategy';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { range } from 'lodash';
 import { useTranslation } from '../../../language';
-import { generateStartBoard, generateTestStartBoard, isAllowed, moves, type Board, type Moves } from './gameplay';
+import { generateStartBoard, generateTestStartBoard, isAllowed, moves, type Board } from './gameplay';
+import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
@@ -38,39 +38,6 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
     </GameBoard>
   )
 };
-
-type Bot = BotStrategy<Board, Moves>
-
-const randomBotStrategy: Bot = ({ board }) => {
-  const possibleMoves = range(1, board.numbersOnTable.length + 1)
-    .filter(n => isAllowed(board, n));
-  return { move: 'removeNumber', args: [sample(possibleMoves)!] };
-};
-
-const smartBotStrategy: Bot = ({ board }) => {
-  const numCount = board.numbersOnTable.length;
-  const stateId = generateStateID(board);
-  const optimalMoves = strategyDict[numCount]
-    ? strategyDict[numCount][stateId]
-    : [];
-  if (optimalMoves.length) {
-    return { move: 'removeNumber', args: [sample(optimalMoves)!] };
-  } else {
-    const possibleMoves = range(1, numCount + 1)
-      .filter(n => isAllowed(board, n));
-    return { move: 'removeNumber', args: [sample(possibleMoves)!] };
-  }
-};
-
-const generateStateID = (board: Board) => {
-  let id = 0;
-  for (let i = 0; i < board.numbersOnTable.length; i++) {
-    if (board.numbersOnTable[i]){
-      id += 2**(i)
-    }
-  }
-  return (board.previousMove === null ? '-1' : board.previousMove) + "_" +id;
-}
 
 const rule = {
   hu: <>

--- a/src/components/games/single-number-increase/increment-or-double/bot-strategy.ts
+++ b/src/components/games/single-number-increase/increment-or-double/bot-strategy.ts
@@ -1,0 +1,23 @@
+import type { BotStrategy } from '../../../strategy-game-factory';
+import { sample } from 'lodash';
+import { type Board, type Moves } from './gameplay';
+
+// The mover wins exactly when the last number said is even, so the only winning
+// move is always x+1 (which hands the opponent an odd number). From 0 this plays
+// the forced opening 1. From an odd (losing) board both moves hand the opponent an
+// even, winning number, so play randomly to maximise the chance the human errs.
+export const getBotNextNumber = (board: Board): number => {
+  if (board % 2 === 0) return board + 1;
+  return sample([board + 1, board * 2])!;
+};
+
+type Bot = BotStrategy<Board, Moves>
+
+export const smartBotStrategy: Bot = ({ board }) => {
+  const next = getBotNextNumber(board);
+  if (next === board * 2) {
+    return { move: 'double' };
+  } else {
+    return { move: 'increment' };
+  }
+};

--- a/src/components/games/single-number-increase/increment-or-double/increment-or-double.tsx
+++ b/src/components/games/single-number-increase/increment-or-double/increment-or-double.tsx
@@ -1,11 +1,6 @@
-import {
-  strategyGameFactory,
-  type BotStrategy,
-  type BoardClientProps,
-  GameBoard
-} from '../../../strategy-game-factory';
-import { sample } from 'lodash';
-import { isLosing, moves, target, type Board, type Moves } from './gameplay';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../../strategy-game-factory';
+import { isLosing, moves, target, type Board } from './gameplay';
+import { smartBotStrategy } from './bot-strategy';
 
 const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
   const incResult = board + 1;
@@ -30,26 +25,6 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
       </div>
     </GameBoard>
   );
-};
-
-// The mover wins exactly when the last number said is even, so the only winning
-// move is always x+1 (which hands the opponent an odd number). From 0 this plays
-// the forced opening 1. From an odd (losing) board both moves hand the opponent an
-// even, winning number, so play randomly to maximise the chance the human errs.
-export const getBotNextNumber = (board: Board): number => {
-  if (board % 2 === 0) return board + 1;
-  return sample([board + 1, board * 2])!;
-};
-
-type Bot = BotStrategy<Board, Moves>
-
-const smartBotStrategy: Bot = ({ board }) => {
-  const next = getBotNextNumber(board);
-  if (next === board * 2) {
-    return { move: 'double' };
-  } else {
-    return { move: 'increment' };
-  }
 };
 
 const rule = {

--- a/src/components/games/single-number-increase/plus-one-two-three/bot-strategy.ts
+++ b/src/components/games/single-number-increase/plus-one-two-three/bot-strategy.ts
@@ -1,0 +1,12 @@
+import type { BotStrategy } from '../../../strategy-game-factory';
+import { random } from 'lodash';
+import { maxStep, type Board, type Moves } from './gameplay';
+
+type Bot = BotStrategy<Board, Moves>
+
+export const smartBotStrategy: Bot = ({ board }) => {
+  const nextBoard = board % (1 + maxStep) !== 0
+    ? board + (1 + maxStep) - board % (1 + maxStep)
+    : board + random(1, maxStep);
+  return { move: 'increaseTo', args: [nextBoard] };
+};

--- a/src/components/games/single-number-increase/plus-one-two-three/plus-one-two-three.tsx
+++ b/src/components/games/single-number-increase/plus-one-two-three/plus-one-two-three.tsx
@@ -1,11 +1,7 @@
-import {
-  strategyGameFactory,
-  type BotStrategy,
-  type BoardClientProps,
-  GameBoard
-} from '../../../strategy-game-factory';
-import { range, random } from 'lodash';
-import { maxStep, moves, target, type Board, type Moves } from './gameplay';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../../strategy-game-factory';
+import { range } from 'lodash';
+import { maxStep, moves, target, type Board } from './gameplay';
+import { smartBotStrategy } from './bot-strategy';
 
 const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
 
@@ -31,15 +27,6 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
     </div>
     </GameBoard>
   );
-};
-
-type Bot = BotStrategy<Board, Moves>
-
-const smartBotStrategy: Bot = ({ board }) => {
-  const nextBoard = board % (1 + maxStep) !== 0
-    ? board + (1 + maxStep) - board % (1 + maxStep)
-    : board + random(1, maxStep);
-  return { move: 'increaseTo', args: [nextBoard] };
 };
 
 const rule = {

--- a/src/components/games/single-pile-removal/doubling-reduction/bot-strategy.spec.ts
+++ b/src/components/games/single-pile-removal/doubling-reduction/bot-strategy.spec.ts
@@ -1,4 +1,5 @@
-import { lowestPow2, cap, isWinningTake, chooseSmartTake } from './doubling-reduction';
+import { cap } from '../gameplay';
+import { lowestPow2, isWinningTake, chooseSmartTake } from './bot-strategy';
 
 // Independent brute-force minimax: the mover with `stones` left and a cap of
 // `maxTake` wins iff some legal take either clears the pile or leaves the

--- a/src/components/games/single-pile-removal/doubling-reduction/bot-strategy.ts
+++ b/src/components/games/single-pile-removal/doubling-reduction/bot-strategy.ts
@@ -1,0 +1,60 @@
+import type { BotStrategy } from '../../../strategy-game-factory';
+import { range, random, minBy } from 'lodash';
+import { type Board, cap } from '../gameplay';
+import { type Moves } from './gameplay';
+
+// t(n): the largest power of 2 dividing n (its lowest set bit).
+export const lowestPow2 = (n: number): number => n & -n;
+
+// Taking k next hands the opponent the position (stones − k, maxTake 2k − 1).
+// A position (n, m) is losing for the mover exactly when m < t(n). So taking k
+// wins iff it clears the pile, or leaves the opponent with 2k − 1 below the
+// lowest set bit of what remains.
+export const isWinningTake = (stones: number, k: number): boolean =>
+  stones - k === 0 || 2 * k - 1 < lowestPow2(stones - k);
+
+// The count the optimal bot takes from `board`.
+export const chooseSmartTake = (board: Board): number => {
+  const { stones } = board;
+  const maxTakeable = cap(board);
+
+  // If the whole pile is within reach, clear it and win now rather than dragging
+  // the game out with a smaller "textbook" lowest-bit take.
+  if (stones <= maxTakeable) return stones;
+
+  // Otherwise the winning move (when one exists) removes the lowest power-of-2
+  // block, handing the opponent a losing position.
+  const winningTake = lowestPow2(stones);
+  if (winningTake <= maxTakeable) return winningTake;
+
+  // Losing position: every legal take loses to optimal play, so play a "trap"
+  // that makes the opponent actually earn the win.
+  //  1. Never hand them a one-move kill: exclude takes that leave a pile they
+  //     could clear next turn (their cap 2k − 1 would reach the whole remainder).
+  //  2. Among the rest, leave the position whose winning reply is hardest to
+  //     find (fewest winning replies), breaking ties toward the *larger* take so
+  //     the game keeps some substance instead of collapsing straight to 1-takes.
+  const takes = range(1, maxTakeable + 1);
+  const safe = takes.filter(k => stones - k > 2 * k - 1); // opponent cannot clear
+  const pool = safe.length > 0 ? safe : takes; // forced endgame: no safe take exists
+  return minBy(pool, k => {
+    const rem = stones - k;
+    const oppCap = Math.min(2 * k - 1, rem);
+    const winningReplies = range(1, oppCap + 1).filter(j => isWinningTake(rem, j)).length;
+    return winningReplies * 10000 - k; // primary: fewer winning replies; tie-break: larger take
+  })!;
+};
+
+type Bot = BotStrategy<Board, Moves>
+
+export const smartBotStrategy: Bot = ({ board }) =>
+  ({ move: 'take', args: [chooseSmartTake(board)] });
+
+// Test bot: takes the whole pile if that wins immediately, otherwise a random
+// legal amount.
+export const randomBotStrategy: Bot = ({ board }) => {
+  if (board.stones <= board.maxTake) {
+    return { move: 'take', args: [board.stones] };
+  }
+  return { move: 'take', args: [random(1, cap(board))] };
+};

--- a/src/components/games/single-pile-removal/doubling-reduction/doubling-reduction.tsx
+++ b/src/components/games/single-pile-removal/doubling-reduction/doubling-reduction.tsx
@@ -1,66 +1,8 @@
-import { strategyGameFactory, type BotStrategy } from '../../../strategy-game-factory';
-import { range, random, minBy } from 'lodash';
+import { strategyGameFactory } from '../../../strategy-game-factory';
 import { BoardClient, getPlayerStepDescription } from '../pebble-pile';
-import { type Board, cap } from '../gameplay';
-import { generateStartBoard, generateTestStartBoard, moves, type Moves } from './gameplay';
-
-export { cap };
-
-// t(n): the largest power of 2 dividing n (its lowest set bit).
-export const lowestPow2 = (n: number): number => n & -n;
-
-// Taking k next hands the opponent the position (stones − k, maxTake 2k − 1).
-// A position (n, m) is losing for the mover exactly when m < t(n). So taking k
-// wins iff it clears the pile, or leaves the opponent with 2k − 1 below the
-// lowest set bit of what remains.
-export const isWinningTake = (stones: number, k: number): boolean =>
-  stones - k === 0 || 2 * k - 1 < lowestPow2(stones - k);
-
-// The count the optimal bot takes from `board`.
-export const chooseSmartTake = (board: Board): number => {
-  const { stones } = board;
-  const maxTakeable = cap(board);
-
-  // If the whole pile is within reach, clear it and win now rather than dragging
-  // the game out with a smaller "textbook" lowest-bit take.
-  if (stones <= maxTakeable) return stones;
-
-  // Otherwise the winning move (when one exists) removes the lowest power-of-2
-  // block, handing the opponent a losing position.
-  const winningTake = lowestPow2(stones);
-  if (winningTake <= maxTakeable) return winningTake;
-
-  // Losing position: every legal take loses to optimal play, so play a "trap"
-  // that makes the opponent actually earn the win.
-  //  1. Never hand them a one-move kill: exclude takes that leave a pile they
-  //     could clear next turn (their cap 2k − 1 would reach the whole remainder).
-  //  2. Among the rest, leave the position whose winning reply is hardest to
-  //     find (fewest winning replies), breaking ties toward the *larger* take so
-  //     the game keeps some substance instead of collapsing straight to 1-takes.
-  const takes = range(1, maxTakeable + 1);
-  const safe = takes.filter(k => stones - k > 2 * k - 1); // opponent cannot clear
-  const pool = safe.length > 0 ? safe : takes; // forced endgame: no safe take exists
-  return minBy(pool, k => {
-    const rem = stones - k;
-    const oppCap = Math.min(2 * k - 1, rem);
-    const winningReplies = range(1, oppCap + 1).filter(j => isWinningTake(rem, j)).length;
-    return winningReplies * 10000 - k; // primary: fewer winning replies; tie-break: larger take
-  })!;
-};
-
-type Bot = BotStrategy<Board, Moves>
-
-const smartBotStrategy: Bot = ({ board }) =>
-  ({ move: 'take', args: [chooseSmartTake(board)] });
-
-// Test bot: takes the whole pile if that wins immediately, otherwise a random
-// legal amount.
-const randomBotStrategy: Bot = ({ board }) => {
-  if (board.stones <= board.maxTake) {
-    return { move: 'take', args: [board.stones] };
-  }
-  return { move: 'take', args: [random(1, cap(board))] };
-};
+import {  } from '../gameplay';
+import { generateStartBoard, generateTestStartBoard, moves } from './gameplay';
+import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 const rule = {
   hu: <>

--- a/src/components/games/single-pile-removal/prime-exponentials/bot-strategy.ts
+++ b/src/components/games/single-pile-removal/prime-exponentials/bot-strategy.ts
@@ -1,0 +1,30 @@
+import type { BotStrategy } from '../../../strategy-game-factory';
+import { sample } from 'lodash';
+import { allPrimePowers, type Board, type Moves } from './gameplay';
+
+type Bot = BotStrategy<Board, Moves>
+
+export const randomBotStrategy: Bot = ({ board }) => {
+  const validMoves = allPrimePowers.filter(e => e.value <= board);
+  const { prime, exponent } = sample(validMoves)!;
+  return { move: 'subtractPrimeExponent', args: [{ prime, exponent }] };
+};
+
+export const smartBotStrategy: Bot = ({ board }) => {
+  if (board === 1) {
+    return { move: 'subtractPrimeExponent', args: [{ prime: 2, exponent: 0 }] };
+  }
+
+  const validMoves = allPrimePowers.filter(({ value }) => value <= board);
+
+  let chosenPrime;
+  let chosenExponent;
+
+  if (board % 6 === 0) {
+    ({ prime: chosenPrime, exponent: chosenExponent } = sample(validMoves)!);
+  } else {
+    const possibleMoves = validMoves.filter(({ value }) => (board - value) % 6 === 0);
+    ({ prime: chosenPrime, exponent: chosenExponent } = sample(possibleMoves)!);
+  }
+  return { move: 'subtractPrimeExponent', args: [{ prime: chosenPrime, exponent: chosenExponent }] };
+};

--- a/src/components/games/single-pile-removal/prime-exponentials/prime-exponentials.tsx
+++ b/src/components/games/single-pile-removal/prime-exponentials/prime-exponentials.tsx
@@ -1,21 +1,13 @@
 import { useState } from 'react';
 import {
   strategyGameFactory,
-  type BotStrategy,
   type BoardClientProps,
   GameBoard,
   useHoverPreview
 } from '../../../strategy-game-factory';
-import { sample } from 'lodash';
 import { useTranslation } from '../../../../language';
-import {
-  allPrimePowers,
-  generateSmallStartBoard,
-  generateStartBoard,
-  moves,
-  type Board,
-  type Moves
-} from './gameplay';
+import { allPrimePowers, generateSmallStartBoard, generateStartBoard, moves, type Board } from './gameplay';
+import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 const PrimePowerButton = ({ entry, board, isEntryAllowed, chooseEntry, hoverProps }) => {
   const { prime, exponent, value } = entry;
@@ -94,33 +86,6 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
       />
     </GameBoard>
   );
-};
-
-type Bot = BotStrategy<Board, Moves>
-
-const randomBotStrategy: Bot = ({ board }) => {
-  const validMoves = allPrimePowers.filter(e => e.value <= board);
-  const { prime, exponent } = sample(validMoves)!;
-  return { move: 'subtractPrimeExponent', args: [{ prime, exponent }] };
-};
-
-const smartBotStrategy: Bot = ({ board }) => {
-  if (board === 1) {
-    return { move: 'subtractPrimeExponent', args: [{ prime: 2, exponent: 0 }] };
-  }
-
-  const validMoves = allPrimePowers.filter(({ value }) => value <= board);
-
-  let chosenPrime;
-  let chosenExponent;
-
-  if (board % 6 === 0) {
-    ({ prime: chosenPrime, exponent: chosenExponent } = sample(validMoves)!);
-  } else {
-    const possibleMoves = validMoves.filter(({ value }) => (board - value) % 6 === 0);
-    ({ prime: chosenPrime, exponent: chosenExponent } = sample(possibleMoves)!);
-  }
-  return { move: 'subtractPrimeExponent', args: [{ prime: chosenPrime, exponent: chosenExponent }] };
 };
 
 const getPlayerStepDescription = () => ({

--- a/src/components/games/single-pile-removal/primely-to-zero/bot-strategy.ts
+++ b/src/components/games/single-pile-removal/primely-to-zero/bot-strategy.ts
@@ -1,0 +1,25 @@
+import type { BotStrategy } from '../../../strategy-game-factory';
+import { sample } from 'lodash';
+import { isValidStep, validSteps, type Board, type Moves } from './gameplay';
+
+type Bot = BotStrategy<Board, Moves>
+
+export const randomBotStrategy: Bot = ({ board }) => {
+  const step = isValidStep(board) ? board : sample([...validSteps].filter(s => s < board))!;
+  return { move: 'moveTo', args: [board - step] };
+};
+
+export const smartBotStrategy: Bot = ({ board }) => {
+  const remainder = board % 4;
+  let step: number;
+  if (remainder !== 0) {
+    // all valid steps ≡ remainder (mod 4) land on a multiple of 4
+    const winningSteps = [...validSteps].filter(s => s <= board && (board - s) % 4 === 0);
+    step = sample(winningSteps)!;
+  } else {
+    // losing position: pick any valid step
+    const steps = [...validSteps].filter(s => s <= board);
+    step = sample(steps)!;
+  }
+  return { move: 'moveTo', args: [board - step] };
+};

--- a/src/components/games/single-pile-removal/primely-to-zero/primely-to-zero.tsx
+++ b/src/components/games/single-pile-removal/primely-to-zero/primely-to-zero.tsx
@@ -1,11 +1,7 @@
-import {
-  strategyGameFactory,
-  type BotStrategy,
-  type BoardClientProps,
-  GameBoard
-} from '../../../strategy-game-factory';
-import { range, sample } from 'lodash';
-import { generateStartBoard, isValidStep, maxStart, moves, validSteps, type Board, type Moves } from './gameplay';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../../strategy-game-factory';
+import { range } from 'lodash';
+import { generateStartBoard, maxStart, moves, type Board } from './gameplay';
+import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
   return (
@@ -29,28 +25,6 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
       </div>
     </GameBoard>
   );
-};
-
-type Bot = BotStrategy<Board, Moves>
-
-const randomBotStrategy: Bot = ({ board }) => {
-  const step = isValidStep(board) ? board : sample([...validSteps].filter(s => s < board))!;
-  return { move: 'moveTo', args: [board - step] };
-};
-
-const smartBotStrategy: Bot = ({ board }) => {
-  const remainder = board % 4;
-  let step: number;
-  if (remainder !== 0) {
-    // all valid steps ≡ remainder (mod 4) land on a multiple of 4
-    const winningSteps = [...validSteps].filter(s => s <= board && (board - s) % 4 === 0);
-    step = sample(winningSteps)!;
-  } else {
-    // losing position: pick any valid step
-    const steps = [...validSteps].filter(s => s <= board);
-    step = sample(steps)!;
-  }
-  return { move: 'moveTo', args: [board - step] };
 };
 
 const rule = {

--- a/src/components/games/single-pile-removal/take-1-or-halve/bot-strategy.ts
+++ b/src/components/games/single-pile-removal/take-1-or-halve/bot-strategy.ts
@@ -1,0 +1,25 @@
+import type { BotStrategy } from '../../../strategy-game-factory';
+import { random } from 'lodash';
+import { type Board, type Moves } from './gameplay';
+
+type Bot = BotStrategy<Board, Moves>
+
+export const randomBotStrategy: Bot = ({ board }) => {
+  if (board % 2 === 0 && random(0, 1) === 0) {
+    return { move: 'halve' };
+  } else {
+    return { move: 'take1' };
+  }
+};
+
+export const smartBotStrategy: Bot = ({ board }) => {
+  if (board !== 4 && board % 4 === 0) {
+    return { move: 'take1' };
+  } else if (board === 6) {
+    return { move: 'take1' };
+  } else if (board % 2 === 0) {
+    return { move: 'halve' };
+  } else {
+    return { move: 'take1' };
+  }
+};

--- a/src/components/games/single-pile-removal/take-1-or-halve/take-1-or-halve.tsx
+++ b/src/components/games/single-pile-removal/take-1-or-halve/take-1-or-halve.tsx
@@ -1,13 +1,13 @@
 import {
   strategyGameFactory,
-  type BotStrategy,
   type BoardClientProps,
   GameBoard,
   useHoverPreview
 } from '../../../strategy-game-factory';
 import { random, range } from 'lodash';
 import { useTranslation } from '../../../../language';
-import { moves, type Board, type HoveredAction, type Moves } from './gameplay';
+import { moves, type Board, type HoveredAction } from './gameplay';
+import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 const CoinPile = ({ count, hoveredAction }: { count: number, hoveredAction: HoveredAction }) => (
   <div className="flex flex-wrap justify-center gap-2 p-4" style={{ transform: 'scaleY(-1)' }}>
@@ -52,28 +52,6 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
       </div>
     </GameBoard>
   );
-};
-
-type Bot = BotStrategy<Board, Moves>
-
-const randomBotStrategy: Bot = ({ board }) => {
-  if (board % 2 === 0 && random(0, 1) === 0) {
-    return { move: 'halve' };
-  } else {
-    return { move: 'take1' };
-  }
-};
-
-const smartBotStrategy: Bot = ({ board }) => {
-  if (board !== 4 && board % 4 === 0) {
-    return { move: 'take1' };
-  } else if (board === 6) {
-    return { move: 'take1' };
-  } else if (board % 2 === 0) {
-    return { move: 'halve' };
-  } else {
-    return { move: 'take1' };
-  }
 };
 
 const rule = {

--- a/src/components/games/single-pile-removal/take-power-of-two/bot-strategy.ts
+++ b/src/components/games/single-pile-removal/take-power-of-two/bot-strategy.ts
@@ -1,0 +1,24 @@
+import type { BotStrategy } from '../../../strategy-game-factory';
+import { reverse, sample } from 'lodash';
+import { getAvailableExponents, type Board, type Moves } from './gameplay';
+
+type Bot = BotStrategy<Board, Moves>
+
+export const randomBotStrategy: Bot = ({ board }) =>
+  ({ move: 'subtractPowerOfTwo', args: [sample(getAvailableExponents(board))!] });
+
+export const smartBotStrategy: Bot = ({ board }) => {
+  if (board === 1) {
+    return { move: 'subtractPowerOfTwo', args: [0] };
+  }
+  const availableExponents = getAvailableExponents(board);
+  if (board % 3 === 0) {
+    return { move: 'subtractPowerOfTwo', args: [sample(availableExponents)!] };
+  } else {
+    // board % 3 is 1 or 2 here, and 2**e alternates 1, 2, 1, 2 (mod 3), so
+    // e = 0 or e = 1 always lands on a multiple of 3 — both are available
+    // whenever board >= 2, which the board === 1 branch above guarantees.
+    const optimalMove = reverse(availableExponents).find(e => (board - 2 ** e) % 3 === 0)!;
+    return { move: 'subtractPowerOfTwo', args: [optimalMove] };
+  }
+}

--- a/src/components/games/single-pile-removal/take-power-of-two/take-power-of-two.tsx
+++ b/src/components/games/single-pile-removal/take-power-of-two/take-power-of-two.tsx
@@ -1,20 +1,12 @@
 import {
   strategyGameFactory,
-  type BotStrategy,
   type BoardClientProps,
   GameBoard,
   useHoverPreview
 } from '../../../strategy-game-factory';
-import { reverse, sample } from 'lodash';
 import { useTranslation } from '../../../../language';
-import {
-  generateStartBoard,
-  generateTestStartBoard,
-  getAvailableExponents,
-  moves,
-  type Board,
-  type Moves
-} from './gameplay';
+import { generateStartBoard, generateTestStartBoard, getAvailableExponents, moves, type Board } from './gameplay';
+import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 const ExponentsTable = ({ isPowerAllowed, board, choosePower, hovered, hoverProps }) => {
   const { t } = useTranslation();
@@ -59,27 +51,6 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
       />
     </GameBoard>
   );
-}
-
-type Bot = BotStrategy<Board, Moves>
-
-const randomBotStrategy: Bot = ({ board }) =>
-  ({ move: 'subtractPowerOfTwo', args: [sample(getAvailableExponents(board))!] });
-
-const smartBotStrategy: Bot = ({ board }) => {
-  if (board === 1) {
-    return { move: 'subtractPowerOfTwo', args: [0] };
-  }
-  const availableExponents = getAvailableExponents(board);
-  if (board % 3 === 0) {
-    return { move: 'subtractPowerOfTwo', args: [sample(availableExponents)!] };
-  } else {
-    // board % 3 is 1 or 2 here, and 2**e alternates 1, 2, 1, 2 (mod 3), so
-    // e = 0 or e = 1 always lands on a multiple of 3 — both are available
-    // whenever board >= 2, which the board === 1 branch above guarantees.
-    const optimalMove = reverse(availableExponents).find(e => (board - 2 ** e) % 3 === 0)!;
-    return { move: 'subtractPowerOfTwo', args: [optimalMove] };
-  }
 }
 
 const getPlayerStepDescription = () => ({

--- a/src/components/games/single-pile-removal/three-more/bot-strategy.spec.ts
+++ b/src/components/games/single-pile-removal/three-more/bot-strategy.spec.ts
@@ -1,4 +1,5 @@
-import { cap, moverWins, isWinningTake, chooseSmartTake } from './three-more';
+import { cap } from '../gameplay';
+import { moverWins, isWinningTake, chooseSmartTake } from './bot-strategy';
 
 // Independent brute-force minimax: the mover with `stones` left and a cap of
 // `maxTake` wins iff some legal take either clears the pile or leaves the other

--- a/src/components/games/single-pile-removal/three-more/bot-strategy.ts
+++ b/src/components/games/single-pile-removal/three-more/bot-strategy.ts
@@ -1,0 +1,55 @@
+import type { BotStrategy } from '../../../strategy-game-factory';
+import { range, minBy } from 'lodash';
+import { type Board, cap } from '../gameplay';
+import { INCREMENT, type Moves } from './gameplay';
+
+// Memoised minimax: is the position (n stones, max-take m) a win for the mover?
+// The winning positions have a period-11 structure (from the opening the second
+// player wins exactly when n ≡ 0, 5 or 7 (mod 11)), but the value also depends on
+// the cap, so a small memoised search is both correct and simplest. `n` stays
+// small, so this is cheap.
+const winMemo = new Map<string, boolean>();
+export const moverWins = (stones: number, maxTake: number): boolean => {
+  if (stones === 0) return false;
+  const maxTakeable = Math.min(maxTake, stones);
+  const key = `${stones},${maxTakeable}`;
+  const cached = winMemo.get(key);
+  if (cached !== undefined) return cached;
+  let result = false;
+  for (let k = 1; k <= maxTakeable; k++) {
+    // After taking k the other player faces `stones - k` with a cap of k + 3.
+    if (!moverWins(stones - k, k + INCREMENT)) { result = true; break; }
+  }
+  winMemo.set(key, result);
+  return result;
+};
+
+// Taking k wins iff it clears the pile, or hands the other player a losing
+// position (their new cap becomes k + 3).
+export const isWinningTake = (stones: number, k: number): boolean =>
+  stones - k === 0 || !moverWins(stones - k, k + INCREMENT);
+
+// The count the optimal bot takes from `board`.
+export const chooseSmartTake = (board: Board): number => {
+  const { stones } = board;
+  const maxTakeable = cap(board);
+
+  // Winning position: play the smallest take that secures the win.
+  const winning = range(1, maxTakeable + 1).find(k => isWinningTake(stones, k));
+  if (winning !== undefined) return winning;
+
+  // Losing position: every legal take hands the other player a win, so play the
+  // "trap" that leaves them the fewest winning replies, breaking ties toward the
+  // smaller take (range is ascending and minBy keeps the first minimum) to drag
+  // the game out and give the human more chances to err.
+  return minBy(range(1, maxTakeable + 1), k => {
+    const rem = stones - k;
+    const oppCap = Math.min(k + INCREMENT, rem);
+    return range(1, oppCap + 1).filter(j => isWinningTake(rem, j)).length;
+  })!;
+};
+
+type Bot = BotStrategy<Board, Moves>
+
+export const smartBotStrategy: Bot = ({ board }) =>
+  ({ move: 'take', args: [chooseSmartTake(board)] });

--- a/src/components/games/single-pile-removal/three-more/three-more.tsx
+++ b/src/components/games/single-pile-removal/three-more/three-more.tsx
@@ -1,61 +1,8 @@
-import { strategyGameFactory, type BotStrategy } from '../../../strategy-game-factory';
-import { range, minBy } from 'lodash';
+import { strategyGameFactory } from '../../../strategy-game-factory';
 import { BoardClient, getPlayerStepDescription } from '../pebble-pile';
-import { type Board, cap } from '../gameplay';
-import { generateStartBoard, moves, INCREMENT, type Moves } from './gameplay';
-
-export { cap };
-
-// Memoised minimax: is the position (n stones, max-take m) a win for the mover?
-// The winning positions have a period-11 structure (from the opening the second
-// player wins exactly when n ≡ 0, 5 or 7 (mod 11)), but the value also depends on
-// the cap, so a small memoised search is both correct and simplest. `n` stays
-// small, so this is cheap.
-const winMemo = new Map<string, boolean>();
-export const moverWins = (stones: number, maxTake: number): boolean => {
-  if (stones === 0) return false;
-  const maxTakeable = Math.min(maxTake, stones);
-  const key = `${stones},${maxTakeable}`;
-  const cached = winMemo.get(key);
-  if (cached !== undefined) return cached;
-  let result = false;
-  for (let k = 1; k <= maxTakeable; k++) {
-    // After taking k the other player faces `stones - k` with a cap of k + 3.
-    if (!moverWins(stones - k, k + INCREMENT)) { result = true; break; }
-  }
-  winMemo.set(key, result);
-  return result;
-};
-
-// Taking k wins iff it clears the pile, or hands the other player a losing
-// position (their new cap becomes k + 3).
-export const isWinningTake = (stones: number, k: number): boolean =>
-  stones - k === 0 || !moverWins(stones - k, k + INCREMENT);
-
-// The count the optimal bot takes from `board`.
-export const chooseSmartTake = (board: Board): number => {
-  const { stones } = board;
-  const maxTakeable = cap(board);
-
-  // Winning position: play the smallest take that secures the win.
-  const winning = range(1, maxTakeable + 1).find(k => isWinningTake(stones, k));
-  if (winning !== undefined) return winning;
-
-  // Losing position: every legal take hands the other player a win, so play the
-  // "trap" that leaves them the fewest winning replies, breaking ties toward the
-  // smaller take (range is ascending and minBy keeps the first minimum) to drag
-  // the game out and give the human more chances to err.
-  return minBy(range(1, maxTakeable + 1), k => {
-    const rem = stones - k;
-    const oppCap = Math.min(k + INCREMENT, rem);
-    return range(1, oppCap + 1).filter(j => isWinningTake(rem, j)).length;
-  })!;
-};
-
-type Bot = BotStrategy<Board, Moves>
-
-const smartBotStrategy: Bot = ({ board }) =>
-  ({ move: 'take', args: [chooseSmartTake(board)] });
+import {  } from '../gameplay';
+import { generateStartBoard, moves } from './gameplay';
+import { smartBotStrategy } from './bot-strategy';
 
 const rule = {
   hu: <>

--- a/src/components/games/single-pile-removal/waning-stones/bot-strategy.spec.ts
+++ b/src/components/games/single-pile-removal/waning-stones/bot-strategy.spec.ts
@@ -1,4 +1,5 @@
-import { lowestPow2, cap, isWinningTake, chooseSmartTake } from './waning-stones';
+import { cap } from '../gameplay';
+import { lowestPow2, isWinningTake, chooseSmartTake } from './bot-strategy';
 
 // Independent brute-force minimax: the mover with `stones` left and a cap of
 // `maxTake` wins iff some legal take either clears the pile or leaves the

--- a/src/components/games/single-pile-removal/waning-stones/bot-strategy.ts
+++ b/src/components/games/single-pile-removal/waning-stones/bot-strategy.ts
@@ -1,0 +1,46 @@
+import type { BotStrategy } from '../../../strategy-game-factory';
+import { range, random, minBy } from 'lodash';
+import { type Board, cap } from '../gameplay';
+import { type Moves } from './gameplay';
+
+// t(n): the largest power of 2 dividing n (its lowest set bit).
+export const lowestPow2 = (n: number): number => n & -n;
+
+// A position (n stones, m max-take) is losing for the mover exactly when m < t(n).
+// So taking k wins iff it clears the pile, or hands the opponent such a losing
+// position (their new cap k is below the lowest set bit of what remains).
+export const isWinningTake = (stones: number, k: number): boolean =>
+  stones - k === 0 || k < lowestPow2(stones - k);
+
+// The count the optimal bot takes from `board`.
+export const chooseSmartTake = (board: Board): number => {
+  const { stones } = board;
+  const maxTakeable = cap(board);
+
+  const winningTake = lowestPow2(stones);
+  if (winningTake <= maxTakeable) return winningTake;
+
+  // Losing position: every legal take hands the opponent a win, so play the
+  // "trap" that leaves them the fewest winning replies, breaking ties toward the
+  // smaller take (range is ascending and minBy keeps the first minimum) to drag
+  // the game out and give the human more chances to err.
+  return minBy(range(1, maxTakeable + 1), k => {
+    const rem = stones - k;
+    const oppCap = Math.min(k, rem);
+    return range(1, oppCap + 1).filter(j => isWinningTake(rem, j)).length;
+  })!;
+};
+
+type Bot = BotStrategy<Board, Moves>
+
+export const smartBotStrategy: Bot = ({ board }) =>
+  ({ move: 'take', args: [chooseSmartTake(board)] });
+
+// Test bot: takes the whole pile if that wins immediately, otherwise a random
+// legal amount.
+export const randomBotStrategy: Bot = ({ board }) => {
+  if (board.stones <= board.maxTake) {
+    return { move: 'take', args: [board.stones] };
+  }
+  return { move: 'take', args: [random(1, cap(board))] };
+};

--- a/src/components/games/single-pile-removal/waning-stones/waning-stones.tsx
+++ b/src/components/games/single-pile-removal/waning-stones/waning-stones.tsx
@@ -1,52 +1,8 @@
-import { strategyGameFactory, type BotStrategy } from '../../../strategy-game-factory';
-import { range, random, minBy } from 'lodash';
+import { strategyGameFactory } from '../../../strategy-game-factory';
 import { BoardClient, getPlayerStepDescription } from '../pebble-pile';
-import { type Board, cap } from '../gameplay';
-import { generateStartBoard, generateTestStartBoard, moves, type Moves } from './gameplay';
-
-export { cap };
-
-// t(n): the largest power of 2 dividing n (its lowest set bit).
-export const lowestPow2 = (n: number): number => n & -n;
-
-// A position (n stones, m max-take) is losing for the mover exactly when m < t(n).
-// So taking k wins iff it clears the pile, or hands the opponent such a losing
-// position (their new cap k is below the lowest set bit of what remains).
-export const isWinningTake = (stones: number, k: number): boolean =>
-  stones - k === 0 || k < lowestPow2(stones - k);
-
-// The count the optimal bot takes from `board`.
-export const chooseSmartTake = (board: Board): number => {
-  const { stones } = board;
-  const maxTakeable = cap(board);
-
-  const winningTake = lowestPow2(stones);
-  if (winningTake <= maxTakeable) return winningTake;
-
-  // Losing position: every legal take hands the opponent a win, so play the
-  // "trap" that leaves them the fewest winning replies, breaking ties toward the
-  // smaller take (range is ascending and minBy keeps the first minimum) to drag
-  // the game out and give the human more chances to err.
-  return minBy(range(1, maxTakeable + 1), k => {
-    const rem = stones - k;
-    const oppCap = Math.min(k, rem);
-    return range(1, oppCap + 1).filter(j => isWinningTake(rem, j)).length;
-  })!;
-};
-
-type Bot = BotStrategy<Board, Moves>
-
-const smartBotStrategy: Bot = ({ board }) =>
-  ({ move: 'take', args: [chooseSmartTake(board)] });
-
-// Test bot: takes the whole pile if that wins immediately, otherwise a random
-// legal amount.
-const randomBotStrategy: Bot = ({ board }) => {
-  if (board.stones <= board.maxTake) {
-    return { move: 'take', args: [board.stones] };
-  }
-  return { move: 'take', args: [random(1, cap(board))] };
-};
+import {  } from '../gameplay';
+import { generateStartBoard, generateTestStartBoard, moves } from './gameplay';
+import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 const rule = {
   hu: <>

--- a/src/components/games/stones-remove-one-not-twice-from-left/bot-strategy.ts
+++ b/src/components/games/stones-remove-one-not-twice-from-left/bot-strategy.ts
@@ -1,0 +1,83 @@
+import type { BotStrategy } from '../../strategy-game-factory';
+import { random } from 'lodash';
+import { type Board, type Moves } from './gameplay';
+
+type Bot = BotStrategy<Board, Moves>
+
+export const randomBotStrategy: Bot = ({ board, ctx }) =>
+  ({ move: 'removeStone', args: [getPileOfRandomAllowedMove(board, ctx)] });
+
+export const smartBotStrategy: Bot = ({ board, ctx }) => {
+  if (board.leftRestriction[ctx.currentPlayer!]) {
+    return { move: 'removeStone', args: [1] };
+  }
+  const optimalMove = getOptimalMove(board, ctx);
+  const botMove = optimalMove !== undefined
+    ? optimalMove
+    : getPileOfRandomAllowedMove(board, ctx);
+  return { move: 'removeStone', args: [botMove] };
+};
+
+// return undefined if there is no winning move
+const getOptimalMove = (board, ctx) => {
+  const otherPlayer = 1 - ctx.currentPlayer;
+  const parity = [board.piles[0] % 2 === 0, board.piles[1] % 2 === 0]
+
+  if (parity[0] && parity[1]) {
+    if (!board.leftRestriction[otherPlayer]) {
+      return undefined;
+    } else if (board.leftRestriction[ctx.currentPlayer]) {
+      console.error("Unexpected internal state, please report.")
+      return undefined;
+    } else {
+      /*
+      If we take right, the other must take right, then we are in an even-even
+      position without any restriction which is a losing position. Check winning
+      move in next round if we take left (and the other must take right). If
+      there is a winning move next round it means taking from left now is also a
+      winning move. Otherwise we do not have a winning move.
+      */
+      const nextRestriction = [false, false];
+      nextRestriction[ctx.currentPlayer] = true;
+      nextRestriction[1 -ctx.currentPlayer] = false;
+      const nextBoard = {
+        piles: [board.piles[0] - 1, board.piles[1] - 1],
+        leftRestriction: nextRestriction
+      }
+      const optimalMoveInNextRound = getOptimalMove(nextBoard, ctx);
+      return optimalMoveInNextRound !== undefined ? 0 : undefined;
+    }
+  }
+  if (parity[0] && !parity[1]) {
+    return 1;
+  }
+  if (!parity[0] && !parity[1]) {
+    if (board.piles[0] > board.piles[1]) {
+      return 1;
+    } else {
+      return undefined;
+    }
+  }
+  if (!parity[0] && parity[1]) {
+    if (board.piles[0] <= (board.piles[0] + 1)) {
+      if (!board.leftRestriction[ctx.currentPlayer]) {
+        return 0;
+      } else {
+        console.error("Unexpected internal state, please report.")
+        return undefined;
+      }
+    } else {
+      return undefined;
+    }
+  }
+
+  // we should not reach this branch;
+  return undefined;
+}
+
+const getPileOfRandomAllowedMove = (board, ctx) => {
+  if (board.piles[0] === 0) return 1;
+  if (board.piles[1] === 0) return 0;
+  if (board.leftRestriction[ctx.currentPlayer]) return 1;
+  return random(0, 1);
+}

--- a/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
+++ b/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
@@ -1,13 +1,8 @@
-import {
-  strategyGameFactory,
-  type BotStrategy,
-  type BoardClientProps,
-  GameBoard,
-  useHoverPreview
-} from '../../strategy-game-factory';
-import { random, range } from 'lodash';
+import { strategyGameFactory, type BoardClientProps, GameBoard, useHoverPreview } from '../../strategy-game-factory';
+import { range } from 'lodash';
 import { useTranslation } from '../../../language';
-import { generateStartBoard, generateTestStartBoard, moves, type Board, type Moves } from './gameplay';
+import { generateStartBoard, generateTestStartBoard, moves, type Board } from './gameplay';
+import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 const StonePile = ({ count, onClick, disabled, restricted, hovered, hoverProps }) => {
   return (
@@ -60,86 +55,6 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     </GameBoard>
   );
 };
-
-type Bot = BotStrategy<Board, Moves>
-
-const randomBotStrategy: Bot = ({ board, ctx }) =>
-  ({ move: 'removeStone', args: [getPileOfRandomAllowedMove(board, ctx)] });
-
-const smartBotStrategy: Bot = ({ board, ctx }) => {
-  if (board.leftRestriction[ctx.currentPlayer!]) {
-    return { move: 'removeStone', args: [1] };
-  }
-  const optimalMove = getOptimalMove(board, ctx);
-  const botMove = optimalMove !== undefined
-    ? optimalMove
-    : getPileOfRandomAllowedMove(board, ctx);
-  return { move: 'removeStone', args: [botMove] };
-};
-
-// return undefined if there is no winning move
-const getOptimalMove = (board, ctx) => {
-  const otherPlayer = 1 - ctx.currentPlayer;
-  const parity = [board.piles[0] % 2 === 0, board.piles[1] % 2 === 0]
-
-  if (parity[0] && parity[1]) {
-    if (!board.leftRestriction[otherPlayer]) {
-      return undefined;
-    } else if (board.leftRestriction[ctx.currentPlayer]) {
-      console.error("Unexpected internal state, please report.")
-      return undefined;
-    } else {
-      /*
-      If we take right, the other must take right, then we are in an even-even
-      position without any restriction which is a losing position. Check winning
-      move in next round if we take left (and the other must take right). If
-      there is a winning move next round it means taking from left now is also a
-      winning move. Otherwise we do not have a winning move.
-      */
-      const nextRestriction = [false, false];
-      nextRestriction[ctx.currentPlayer] = true;
-      nextRestriction[1 -ctx.currentPlayer] = false;
-      const nextBoard = {
-        piles: [board.piles[0] - 1, board.piles[1] - 1],
-        leftRestriction: nextRestriction
-      }
-      const optimalMoveInNextRound = getOptimalMove(nextBoard, ctx);
-      return optimalMoveInNextRound !== undefined ? 0 : undefined;
-    }
-  }
-  if (parity[0] && !parity[1]) {
-    return 1;
-  }
-  if (!parity[0] && !parity[1]) {
-    if (board.piles[0] > board.piles[1]) {
-      return 1;
-    } else {
-      return undefined;
-    }
-  }
-  if (!parity[0] && parity[1]) {
-    if (board.piles[0] <= (board.piles[0] + 1)) {
-      if (!board.leftRestriction[ctx.currentPlayer]) {
-        return 0;
-      } else {
-        console.error("Unexpected internal state, please report.")
-        return undefined;
-      }
-    } else {
-      return undefined;
-    }
-  }
-
-  // we should not reach this branch;
-  return undefined;
-}
-
-const getPileOfRandomAllowedMove = (board, ctx) => {
-  if (board.piles[0] === 0) return 1;
-  if (board.piles[1] === 0) return 0;
-  if (board.leftRestriction[ctx.currentPlayer]) return 1;
-  return random(0, 1);
-}
 
 const rule = {
   hu: <>

--- a/src/components/games/sum-fifteen/bot-strategy.ts
+++ b/src/components/games/sum-fifteen/bot-strategy.ts
@@ -1,0 +1,14 @@
+import type { BotStrategy } from '../../strategy-game-factory';
+import { chooseSmartMove, chooseTestMove, currentPlayerFromOwner, type Board, type Moves } from './gameplay';
+
+type Bot = BotStrategy<Board, Moves>
+
+export const smartBotStrategy: Bot = ({ board, ctx }) => {
+  const player = (ctx.currentPlayer ?? currentPlayerFromOwner(board.owner)) as 0 | 1;
+  return { move: 'chooseNumber', args: [chooseSmartMove(board.owner, player)] };
+};
+
+export const randomBotStrategy: Bot = ({ board, ctx }) => {
+  const player = (ctx.currentPlayer ?? currentPlayerFromOwner(board.owner)) as 0 | 1;
+  return { move: 'chooseNumber', args: [chooseTestMove(board.owner, player)] };
+};

--- a/src/components/games/sum-fifteen/sum-fifteen.tsx
+++ b/src/components/games/sum-fifteen/sum-fifteen.tsx
@@ -1,17 +1,7 @@
-import { strategyGameFactory, type BotStrategy, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
 import { useTranslation } from '../../../language';
-import {
-  allNumbers,
-  chooseSmartMove,
-  chooseTestMove,
-  currentPlayerFromOwner,
-  findWinningTriple,
-  generateStartBoard,
-  moves,
-  numbersOwnedBy,
-  type Board,
-  type Moves
-} from './gameplay';
+import { allNumbers, findWinningTriple, generateStartBoard, moves, numbersOwnedBy, type Board } from './gameplay';
+import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 const ownedLabel = (owner: Board['owner'], player: 0 | 1): string => {
   const nums = numbersOwnedBy(owner, player);
@@ -80,18 +70,6 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
       }
     </GameBoard>
   );
-};
-
-type Bot = BotStrategy<Board, Moves>
-
-const smartBotStrategy: Bot = ({ board, ctx }) => {
-  const player = (ctx.currentPlayer ?? currentPlayerFromOwner(board.owner)) as 0 | 1;
-  return { move: 'chooseNumber', args: [chooseSmartMove(board.owner, player)] };
-};
-
-const randomBotStrategy: Bot = ({ board, ctx }) => {
-  const player = (ctx.currentPlayer ?? currentPlayerFromOwner(board.owner)) as 0 | 1;
-  return { move: 'chooseNumber', args: [chooseTestMove(board.owner, player)] };
 };
 
 const rule = {

--- a/src/components/games/ten-coins/bot-strategy.spec.ts
+++ b/src/components/games/ten-coins/bot-strategy.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { uniq, range } from 'lodash';
 import { playBotMove } from '../../../test-utils';
-import { smartBotStrategy } from './ten-coins';
+import { smartBotStrategy } from './bot-strategy';
 import { moves as gameMoves } from './gameplay';
 
 type Vals = number[];

--- a/src/components/games/ten-coins/bot-strategy.ts
+++ b/src/components/games/ten-coins/bot-strategy.ts
@@ -1,0 +1,67 @@
+import { uniq, sample } from 'lodash';
+import type { BotStrategy } from '../../strategy-game-factory';
+import { type Board, type Moves } from './gameplay';
+
+type Move = { k: number, l: number, resultSet: number[] }
+
+export const distinctValues = (board: Board): number[] => uniq(board).sort((a, b) => a - b);
+
+const movesFromSet = (set: number[]): Move[] => {
+  const result: Move[] = [];
+  for (const k of set) {
+    for (let l = 1; l < k; l++) {
+      const resultSet = uniq([...set.filter(v => v !== k), l]).sort((a, b) => a - b);
+      result.push({ k, l, resultSet });
+    }
+  }
+  return result;
+};
+
+const isWinningMove = (move: Move): boolean =>
+  // reaching a single value wins immediately; otherwise a move is winning when it
+  // leaves the opponent in a losing position.
+  move.resultSet.length === 1 || !playerToMoveWins(move.resultSet);
+
+const winMemo: Record<string, boolean> = {};
+const playerToMoveWins = (set: number[]): boolean => {
+  const key = set.join(',');
+  if (key in winMemo) return winMemo[key];
+  // Guard against self-reference before the result is memoised (the recursion is
+  // acyclic since every move strictly decreases the coin values, but be safe).
+  winMemo[key] = false;
+  const wins = movesFromSet(set).some(isWinningMove);
+  return (winMemo[key] = wins);
+};
+
+// Smart bot: play the winning move when one exists (drive towards a losing
+// position, or merge to a single value). In a losing position, make the reply
+// that leaves the opponent with the most ways to blunder.
+type Bot = BotStrategy<Board, Moves>
+
+export const smartBotStrategy: Bot = ({ board }) => {
+  const candidateMoves = movesFromSet(distinctValues(board));
+
+  const winningMoves = candidateMoves.filter(isWinningMove);
+  if (winningMoves.length > 0) {
+    const move = sample(winningMoves)!;
+    return { move: 'convert', args: [move.k, move.l] };
+  }
+
+  const blunderRoom = (move: Move) => {
+    const opponentMoves = movesFromSet(move.resultSet);
+    return opponentMoves.filter(m => !isWinningMove(m)).length;
+  };
+  const rooms = candidateMoves.map(blunderRoom);
+  const maxRoom = Math.max(...rooms);
+  const bestMoves = candidateMoves.filter((_, i) => rooms[i] === maxRoom);
+  const move = sample(bestMoves)!;
+  return { move: 'convert', args: [move.k, move.l] };
+};
+
+// Test bot: play a random legal move, but grab an immediate win when available.
+export const randomBotStrategy: Bot = ({ board }) => {
+  const candidateMoves = movesFromSet(distinctValues(board));
+  const winningNow = candidateMoves.filter(m => m.resultSet.length === 1);
+  const move = sample(winningNow.length > 0 ? winningNow : candidateMoves)!;
+  return { move: 'convert', args: [move.k, move.l] };
+};

--- a/src/components/games/ten-coins/ten-coins.tsx
+++ b/src/components/games/ten-coins/ten-coins.tsx
@@ -1,50 +1,13 @@
-import { uniq, sample, range } from 'lodash';
-import { strategyGameFactory, type BotStrategy, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { range } from 'lodash';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
 import { useTranslation } from '../../../language';
-import {
-  generateStartBoardC,
-  generateStartBoardD,
-  generateTestStartBoard,
-  moves,
-  type Board,
-  type Moves
-} from './gameplay';
+import { generateStartBoardC, generateStartBoardD, generateTestStartBoard, moves, type Board } from './gameplay';
+import { distinctValues, randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 // --- Exact solver over the non-empty subsets of the present values ------------
 // A move picks a present value K and turns *all* K-coins into some L < K, so the
 // set of distinct values goes from S to (S \ {K}) ∪ {L}. You win when only one
 // distinct value remains after your move.
-
-type Move = { k: number, l: number, resultSet: number[] }
-
-const distinctValues = (board: Board): number[] => uniq(board).sort((a, b) => a - b);
-
-const movesFromSet = (set: number[]): Move[] => {
-  const result: Move[] = [];
-  for (const k of set) {
-    for (let l = 1; l < k; l++) {
-      const resultSet = uniq([...set.filter(v => v !== k), l]).sort((a, b) => a - b);
-      result.push({ k, l, resultSet });
-    }
-  }
-  return result;
-};
-
-const isWinningMove = (move: Move): boolean =>
-  // reaching a single value wins immediately; otherwise a move is winning when it
-  // leaves the opponent in a losing position.
-  move.resultSet.length === 1 || !playerToMoveWins(move.resultSet);
-
-const winMemo: Record<string, boolean> = {};
-const playerToMoveWins = (set: number[]): boolean => {
-  const key = set.join(',');
-  if (key in winMemo) return winMemo[key];
-  // Guard against self-reference before the result is memoised (the recursion is
-  // acyclic since every move strictly decreases the coin values, but be safe).
-  winMemo[key] = false;
-  const wins = movesFromSet(set).some(isWinningMove);
-  return (winMemo[key] = wins);
-};
 
 // Losing positions (second player to move wins): {1,2,3} for values 1..4; and
 // {1,2,3}, {1,4,5}, {2,3,4,5}, {1,2,3,4,5} for values 1..5. Everything else is a
@@ -148,39 +111,6 @@ const Coin = ({ value }: { value: number }) => (
     {value}
   </div>
 );
-
-// Smart bot: play the winning move when one exists (drive towards a losing
-// position, or merge to a single value). In a losing position, make the reply
-// that leaves the opponent with the most ways to blunder.
-type Bot = BotStrategy<Board, Moves>
-
-export const smartBotStrategy: Bot = ({ board }) => {
-  const candidateMoves = movesFromSet(distinctValues(board));
-
-  const winningMoves = candidateMoves.filter(isWinningMove);
-  if (winningMoves.length > 0) {
-    const move = sample(winningMoves)!;
-    return { move: 'convert', args: [move.k, move.l] };
-  }
-
-  const blunderRoom = (move: Move) => {
-    const opponentMoves = movesFromSet(move.resultSet);
-    return opponentMoves.filter(m => !isWinningMove(m)).length;
-  };
-  const rooms = candidateMoves.map(blunderRoom);
-  const maxRoom = Math.max(...rooms);
-  const bestMoves = candidateMoves.filter((_, i) => rooms[i] === maxRoom);
-  const move = sample(bestMoves)!;
-  return { move: 'convert', args: [move.k, move.l] };
-};
-
-// Test bot: play a random legal move, but grab an immediate win when available.
-const randomBotStrategy: Bot = ({ board }) => {
-  const candidateMoves = movesFromSet(distinctValues(board));
-  const winningNow = candidateMoves.filter(m => m.resultSet.length === 1);
-  const move = sample(winningNow.length > 0 ? winningNow : candidateMoves)!;
-  return { move: 'convert', args: [move.k, move.l] };
-};
 
 const getPlayerStepDescription = ({ ctx }) => {
   if (ctx.turnState !== null) {

--- a/src/components/games/ten-digit-number/bot-strategy.ts
+++ b/src/components/games/ten-digit-number/bot-strategy.ts
@@ -1,0 +1,68 @@
+import { sample } from 'lodash';
+import type { BotStrategy } from '../../strategy-game-factory';
+import { availableDigits, totalDigits, type Board, type Moves } from './gameplay';
+
+// Precompute winner(sumMod9, turnsLeft): 0 = Jenő wins, 1 = Béla wins, with optimal play.
+// Jenő is player 0 (first mover), Béla is player 1.
+// Béla wins iff the final digit sum ≡ 0 (mod 9).
+const winnerFromState = (() => {
+  const memo = {};
+  const compute = (sumMod9, turnsLeft) => {
+    const key = `${sumMod9},${turnsLeft}`;
+    if (key in memo) return memo[key];
+    if (turnsLeft === 0) return (memo[key] = sumMod9 === 0 ? 1 : 0);
+    const currentPlayer = (totalDigits - turnsLeft) % 2;
+    for (const d of availableDigits) {
+      if (compute((sumMod9 + d) % 9, turnsLeft - 1) === currentPlayer) {
+        return (memo[key] = currentPlayer);
+      }
+    }
+    return (memo[key] = 1 - currentPlayer);
+  };
+  for (let t = 0; t <= totalDigits; t++) for (let s = 0; s < 9; s++) compute(s, t);
+  return (sumMod9, turnsLeft) => memo[`${sumMod9},${turnsLeft}`];
+})();
+
+type Bot = BotStrategy<Board, Moves>
+
+export const randomBotStrategy: Bot = ({ board }) => {
+  const turnsLeft = totalDigits - board.digits.length;
+  const currentPlayer = (totalDigits - turnsLeft) % 2;
+
+  if (turnsLeft === 1) {
+    const winningDigits = availableDigits.filter(
+      d => winnerFromState((board.sumMod9 + d) % 9, 0) === currentPlayer
+    );
+    return {
+      move: 'chooseDigit',
+      args: [sample(winningDigits.length > 0 ? winningDigits : availableDigits)!]
+    };
+  }
+
+  return { move: 'chooseDigit', args: [sample(availableDigits)!] };
+};
+
+export const smartBotStrategy: Bot = ({ board }) => {
+  const turnsLeft = totalDigits - board.digits.length;
+  const currentPlayer = (totalDigits - turnsLeft) % 2;
+
+  const winningDigits = availableDigits.filter(
+    d => winnerFromState((board.sumMod9 + d) % 9, turnsLeft - 1) === currentPlayer
+  );
+  if (winningDigits.length > 0) {
+    return { move: 'chooseDigit', args: [sample(winningDigits)!] };
+  }
+
+  // Losing position: minimise opponent's winning replies, pick randomly among equally bad moves.
+  const opponentWinCount = d => {
+    const nextSumMod9 = (board.sumMod9 + d) % 9;
+    if (turnsLeft < 2) return 0;
+    return availableDigits.filter(
+      d2 => winnerFromState((nextSumMod9 + d2) % 9, turnsLeft - 2) === (1 - currentPlayer)
+    ).length;
+  };
+  const counts = availableDigits.map(opponentWinCount);
+  const minCount = Math.min(...counts);
+  const leastBadDigits = availableDigits.filter((_, i) => counts[i] === minCount);
+  return { move: 'chooseDigit', args: [sample(leastBadDigits)!] };
+};

--- a/src/components/games/ten-digit-number/ten-digit-number.tsx
+++ b/src/components/games/ten-digit-number/ten-digit-number.tsx
@@ -1,28 +1,7 @@
-import { sample } from 'lodash';
-import { strategyGameFactory, type BotStrategy, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
 import { useTranslation } from '../../../language';
-import { availableDigits, moves, totalDigits, type Board, type Moves } from './gameplay';
-
-// Precompute winner(sumMod9, turnsLeft): 0 = Jenő wins, 1 = Béla wins, with optimal play.
-// Jenő is player 0 (first mover), Béla is player 1.
-// Béla wins iff the final digit sum ≡ 0 (mod 9).
-const winnerFromState = (() => {
-  const memo = {};
-  const compute = (sumMod9, turnsLeft) => {
-    const key = `${sumMod9},${turnsLeft}`;
-    if (key in memo) return memo[key];
-    if (turnsLeft === 0) return (memo[key] = sumMod9 === 0 ? 1 : 0);
-    const currentPlayer = (totalDigits - turnsLeft) % 2;
-    for (const d of availableDigits) {
-      if (compute((sumMod9 + d) % 9, turnsLeft - 1) === currentPlayer) {
-        return (memo[key] = currentPlayer);
-      }
-    }
-    return (memo[key] = 1 - currentPlayer);
-  };
-  for (let t = 0; t <= totalDigits; t++) for (let s = 0; s < 9; s++) compute(s, t);
-  return (sumMod9, turnsLeft) => memo[`${sumMod9},${turnsLeft}`];
-})();
+import { availableDigits, moves, totalDigits, type Board } from './gameplay';
+import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
@@ -77,50 +56,6 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
       </div>
     </GameBoard>
   );
-};
-
-type Bot = BotStrategy<Board, Moves>
-
-const randomBotStrategy: Bot = ({ board }) => {
-  const turnsLeft = totalDigits - board.digits.length;
-  const currentPlayer = (totalDigits - turnsLeft) % 2;
-
-  if (turnsLeft === 1) {
-    const winningDigits = availableDigits.filter(
-      d => winnerFromState((board.sumMod9 + d) % 9, 0) === currentPlayer
-    );
-    return {
-      move: 'chooseDigit',
-      args: [sample(winningDigits.length > 0 ? winningDigits : availableDigits)!]
-    };
-  }
-
-  return { move: 'chooseDigit', args: [sample(availableDigits)!] };
-};
-
-const smartBotStrategy: Bot = ({ board }) => {
-  const turnsLeft = totalDigits - board.digits.length;
-  const currentPlayer = (totalDigits - turnsLeft) % 2;
-
-  const winningDigits = availableDigits.filter(
-    d => winnerFromState((board.sumMod9 + d) % 9, turnsLeft - 1) === currentPlayer
-  );
-  if (winningDigits.length > 0) {
-    return { move: 'chooseDigit', args: [sample(winningDigits)!] };
-  }
-
-  // Losing position: minimise opponent's winning replies, pick randomly among equally bad moves.
-  const opponentWinCount = d => {
-    const nextSumMod9 = (board.sumMod9 + d) % 9;
-    if (turnsLeft < 2) return 0;
-    return availableDigits.filter(
-      d2 => winnerFromState((nextSumMod9 + d2) % 9, turnsLeft - 2) === (1 - currentPlayer)
-    ).length;
-  };
-  const counts = availableDigits.map(opponentWinCount);
-  const minCount = Math.min(...counts);
-  const leastBadDigits = availableDigits.filter((_, i) => counts[i] === minCount);
-  return { move: 'chooseDigit', args: [sample(leastBadDigits)!] };
 };
 
 const rule = {

--- a/src/components/games/three-piles-rebuild/bot-strategy.ts
+++ b/src/components/games/three-piles-rebuild/bot-strategy.ts
@@ -1,0 +1,13 @@
+import type { BotMove, BotStrategy } from '../../strategy-game-factory';
+import { getRandomBotStep, getSmartBotStep, type Board, type Moves } from './gameplay';
+
+type Bot = BotStrategy<Board, Moves>
+
+const asTurn = ({ keepId, parts }: { keepId: number; parts: number[] }): BotMove<Moves>[] => [
+  { move: 'keepPile', args: [keepId] },
+  { move: 'splitPile', args: [parts] }
+];
+
+export const smartBotStrategy: Bot = ({ board }) => asTurn(getSmartBotStep(board));
+
+export const randomBotStrategy: Bot = ({ board }) => asTurn(getRandomBotStep(board));

--- a/src/components/games/three-piles-rebuild/three-piles-rebuild.tsx
+++ b/src/components/games/three-piles-rebuild/three-piles-rebuild.tsx
@@ -1,24 +1,16 @@
 import { useEffect, useState } from 'react';
-import {
-  strategyGameFactory,
-  type BoardClientProps,
-  type BotStrategy,
-  type BotMove,
-  GameBoard
-} from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
 import { useTranslation } from '../../../language';
 import {
   canSplit,
   generateStartBoard,
   generateTestStartBoard,
-  getRandomBotStep,
-  getSmartBotStep,
   isSplitAllowed,
   moves,
   withOtherPilesDiscarded,
-  type Board,
-  type Moves
+  type Board
 } from './gameplay';
+import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 // A part is valid if it is a positive integer (the cap keeps arithmetic exact).
 const parsePart = (raw: string): number | null => {
@@ -172,17 +164,6 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
 
 // "Keep, then split" is one decision, so the turn is named as a whole (mirrors
 // the pile-splitting games).
-const asTurn = ({ keepId, parts }: { keepId: number; parts: number[] }): BotMove<Moves>[] => [
-  { move: 'keepPile', args: [keepId] },
-  { move: 'splitPile', args: [parts] }
-];
-
-type Bot = BotStrategy<Board, Moves>
-
-const smartBotStrategy: Bot = ({ board }) => asTurn(getSmartBotStep(board));
-
-const randomBotStrategy: Bot = ({ board }) => asTurn(getRandomBotStep(board));
-
 const getPlayerStepDescription = () => ({
   hu: 'Válaszd ki, melyik kupacot tartod meg (a másik kettőt eldobod), majd oszd három új kupacra.',
   en: 'Choose which pile to keep (the other two are discarded), then split it into three new piles.'

--- a/src/components/games/triangle-coloring/bot-strategy.ts
+++ b/src/components/games/triangle-coloring/bot-strategy.ts
@@ -1,0 +1,30 @@
+import type { BotStrategy } from '../../strategy-game-factory';
+import { sample, shuffle } from 'lodash';
+import { getAllowedMoves, withTriangleColored, type Board, type Moves } from './gameplay';
+
+type Bot = BotStrategy<Board, Moves>
+
+export const randomBotStrategy: Bot = ({ board }) =>
+  ({ move: 'colorTriangle', args: [sample(getAllowedMoves(board))!] });
+
+export const smartBotStrategy: Bot = ({ board }) => {
+  const allowedMoves = getAllowedMoves(board);
+  const optimalPlace = shuffle(allowedMoves).find(
+    i => isWinningState(withTriangleColored(board, i))
+  );
+
+  return { move: 'colorTriangle', args: [optimalPlace ?? sample(allowedMoves)!] };
+};
+
+// given board *after* your step, are you set up to win the game for sure?
+const isWinningState = (board: Board) => {
+  const allowedPlacesForOther = getAllowedMoves(board);
+  if (allowedPlacesForOther.length === 0) {
+    return true;
+  }
+
+  const optimalPlaceForOther = allowedPlacesForOther.find(
+    i => isWinningState(withTriangleColored(board, i))
+  );
+  return optimalPlaceForOther === undefined;
+};

--- a/src/components/games/triangle-coloring/triangle-coloring.tsx
+++ b/src/components/games/triangle-coloring/triangle-coloring.tsx
@@ -1,9 +1,7 @@
-import { strategyGameFactory, type BotStrategy, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
-import { range, sample, shuffle } from 'lodash';
-import {
-  ALLOWED, COLORED, FORBIDDEN, getAllowedMoves, moves, triangles, withTriangleColored,
-  type Board, type Moves
-} from './gameplay';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { range } from 'lodash';
+import { ALLOWED, COLORED, FORBIDDEN, moves, triangles, type Board } from './gameplay';
+import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 // triangles
 //          0
@@ -86,33 +84,6 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
       </svg>
     </GameBoard>
   );
-};
-
-type Bot = BotStrategy<Board, Moves>
-
-const randomBotStrategy: Bot = ({ board }) =>
-  ({ move: 'colorTriangle', args: [sample(getAllowedMoves(board))!] });
-
-const smartBotStrategy: Bot = ({ board }) => {
-  const allowedMoves = getAllowedMoves(board);
-  const optimalPlace = shuffle(allowedMoves).find(
-    i => isWinningState(withTriangleColored(board, i))
-  );
-
-  return { move: 'colorTriangle', args: [optimalPlace ?? sample(allowedMoves)!] };
-};
-
-// given board *after* your step, are you set up to win the game for sure?
-const isWinningState = (board: Board) => {
-  const allowedPlacesForOther = getAllowedMoves(board);
-  if (allowedPlacesForOther.length === 0) {
-    return true;
-  }
-
-  const optimalPlaceForOther = allowedPlacesForOther.find(
-    i => isWinningState(withTriangleColored(board, i))
-  );
-  return optimalPlaceForOther === undefined;
 };
 
 const rule = {

--- a/src/components/games/twelve-squares/bot-strategy.ts
+++ b/src/components/games/twelve-squares/bot-strategy.ts
@@ -1,0 +1,18 @@
+import type { BotStrategy } from '../../strategy-game-factory';
+import { random, sample } from 'lodash';
+import { isValidStep, type Board, type Moves } from './gameplay';
+
+type Bot = BotStrategy<Board, Moves>
+
+export const randomBotStrategy: Bot = ({ board }) => {
+  const validSteps = [1, 2].filter(step => isValidStep(board, step));
+  return { move: 'step', args: [sample(validSteps)!] };
+};
+
+export const optimalBotStrategy: Bot = ({ board: { left, right } }) => {
+  const dst = right-left;
+  if(dst === 1) return { move: 'step', args: [2] };
+  if(dst === 2) return { move: 'step', args: [1] };
+  if(dst % 3 === 2) return { move: 'step', args: [random(1,2)] };
+  return { move: 'step', args: [(dst+1) % 3] };
+};

--- a/src/components/games/twelve-squares/twelve-squares.tsx
+++ b/src/components/games/twelve-squares/twelve-squares.tsx
@@ -1,9 +1,8 @@
-import {
-  strategyGameFactory, type BotStrategy, type BoardClientProps, GameBoard
-} from '../../strategy-game-factory';
-import { range, random, sample } from 'lodash';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { range } from 'lodash';
 import { ChessBishopSvg } from '../chess-bishops/chess-bishop-svg';
-import { generateStartBoard, isValidStep, moves, type Board, type Moves } from './gameplay';
+import { generateStartBoard, moves, type Board } from './gameplay';
+import { optimalBotStrategy, randomBotStrategy } from './bot-strategy';
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const potentialStep = i => {
@@ -44,21 +43,6 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     </div>
   </GameBoard>
   );
-};
-
-type Bot = BotStrategy<Board, Moves>
-
-const randomBotStrategy: Bot = ({ board }) => {
-  const validSteps = [1, 2].filter(step => isValidStep(board, step));
-  return { move: 'step', args: [sample(validSteps)!] };
-};
-
-const optimalBotStrategy: Bot = ({ board: { left, right } }) => {
-  const dst = right-left;
-  if(dst === 1) return { move: 'step', args: [2] };
-  if(dst === 2) return { move: 'step', args: [1] };
-  if(dst % 3 === 2) return { move: 'step', args: [random(1,2)] };
-  return { move: 'step', args: [(dst+1) % 3] };
 };
 
 const rule = {

--- a/src/components/games/two-of-three-takeaway/bot-strategy.ts
+++ b/src/components/games/two-of-three-takeaway/bot-strategy.ts
@@ -1,0 +1,14 @@
+import type { BotStrategy } from '../../strategy-game-factory';
+import { getRandomBotMove, getSmartBotMove, type Board, type Moves } from './gameplay';
+
+type Bot = BotStrategy<Board, Moves>
+
+export const smartBotStrategy: Bot = ({ board }) => {
+  const [i, j] = getSmartBotMove(board);
+  return { move: 'takeChips', args: [i, j] };
+};
+
+export const randomBotStrategy: Bot = ({ board }) => {
+  const [i, j] = getRandomBotMove(board);
+  return { move: 'takeChips', args: [i, j] };
+};

--- a/src/components/games/two-of-three-takeaway/two-of-three-takeaway.tsx
+++ b/src/components/games/two-of-three-takeaway/two-of-three-takeaway.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react';
 import { range } from 'lodash';
-import { strategyGameFactory, type BotStrategy, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
 import { useTranslation } from '../../../language';
-import { generateStartBoard, getRandomBotMove, getSmartBotMove, moves, type Board, type Moves } from './gameplay';
+import { generateStartBoard, moves, type Board } from './gameplay';
+import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 const Pile = ({ count, index, selected, selectable, onClick }: {
   count: number; index: number; selected: boolean; selectable: boolean; onClick: () => void;
@@ -88,18 +89,6 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
       )}
     </GameBoard>
   );
-};
-
-type Bot = BotStrategy<Board, Moves>
-
-const smartBotStrategy: Bot = ({ board }) => {
-  const [i, j] = getSmartBotMove(board);
-  return { move: 'takeChips', args: [i, j] };
-};
-
-const randomBotStrategy: Bot = ({ board }) => {
-  const [i, j] = getRandomBotMove(board);
-  return { move: 'takeChips', args: [i, j] };
 };
 
 const rule = {


### PR DESCRIPTION
## Summary

Refactor bot strategy logic out of game component files into dedicated `bot-strategy.ts` modules. This improves code organization, testability, and maintainability by separating game UI concerns from AI logic.

## Key Changes

- **Created new `bot-strategy.ts` files** for 25+ games, each exporting `randomBotStrategy` and/or `smartBotStrategy` functions
- **Moved strategy logic** from game `.tsx` files to dedicated modules:
  - Game-specific helper functions (e.g., `grundy`, `xorSum`, `getOptimalMove`)
  - Type definitions used only by strategies (e.g., `Move`, `Bot`)
  - Memoization and precomputation logic
- **Updated imports** in game components to import strategies from `bot-strategy.ts` instead of defining them locally
- **Moved gameplay utilities** where appropriate:
  - `number-pyramid`: Moved `generateStartBoard` and board type definitions from `bot-strategy.ts` to `gameplay.ts` (the source of truth for game rules)
  - `number-pyramid`: Updated `bot-strategy.ts` to import these from `gameplay.ts`
- **Updated test files** to import from new `bot-strategy.ts` modules (renamed `*.spec.ts` files where strategies moved)
- **Updated documentation** in `AGENTS.md` to reflect the new structure where bot logic lives in `bot-strategy.ts`

## Notable Implementation Details

- All strategy exports maintain their original type signatures and behavior
- Games with strategies in `gameplay.ts` (e.g., `three-piles-rebuild`, `four-piles-two-grabs`) now have dedicated `bot-strategy.ts` files that re-export from gameplay
- The refactoring preserves all existing game logic and AI behavior—this is purely a structural reorganization
- `number-pyramid` is the only game where gameplay definitions were moved between files (to `gameplay.ts` as the single source of truth)

https://claude.ai/code/session_01MgKsSPf9CbvBkKhZKC94yN