### PR TITLE
Add SessionStart hook: npm ci for Claude Code web sessions

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only needed on Claude Code on the web, where the container starts without
+# node_modules; local and devcontainer setups run npm ci themselves.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+# Exact versions are pinned (save-exact + package-lock), so npm ci is the
+# right install. Skip it when node_modules already exists — the container
+# state is cached between sessions, so this keeps repeat startups fast.
+if [ ! -d node_modules ]; then
+  npm ci
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Requested in the review of #398: web/agent sessions start from a fresh container without `node_modules`, so tests and lint are unrunnable until a manual `npm ci`. This adds a `SessionStart` hook that removes that friction.

## Changes

- `.claude/hooks/session-start.sh` — runs `npm ci` at session start. Web-only (`CLAUDE_CODE_REMOTE` guard, so local/devcontainer setups are untouched), and skipped when `node_modules` already exists, which keeps repeat startups on a cached container fast. `npm ci` rather than `npm install` because the repo pins exact versions (`save-exact` + lockfile).
- `.claude/settings.json` — registers the hook (file did not exist before).

## Validation

- Fresh-install path: with `node_modules` removed, the hook installs 259 packages successfully.
- Idempotent rerun: second invocation is a no-op.
- Non-remote invocation: exits immediately without touching anything.
- After the hook: `npx eslint` on a sample file and a sample vitest spec (15 tests) both pass.

The hook runs synchronously: the session waits for the install to finish, which guarantees dependencies exist before any test/lint command runs. It can be switched to async mode for faster startup if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Lg8UokewKvCAACeyKGChz

---
_Generated by [Claude Code](https://claude.ai/code/session_012Lg8UokewKvCAACeyKGChz)_