### PR TITLE
Annotate move arguments so the bot pinning actually checks them

### DIFF
--- a/src/components/games/add-reduce-double/gameplay.ts
+++ b/src/components/games/add-reduce-double/gameplay.ts
@@ -3,11 +3,12 @@ import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
 
 export type Board = number[];
 export type Piece = { pileId: number; pieceId: number };
+export type Transfer = { pileId: number; pieceCount: number };
 
 // An even number of pieces, at least two, and no more than the pile holds —
 // half of them then go to the other pile. Both players draw on the same two
 // piles, so whose turn it is does not enter into legality.
-export const isTransferAllowed = (board: Board, { pileId, pieceCount }): boolean =>
+export const isTransferAllowed = (board: Board, { pileId, pieceCount }: Transfer): boolean =>
   (pileId === 0 || pileId === 1)
     && Number.isInteger(pieceCount)
     && pieceCount >= 2
@@ -16,8 +17,8 @@ export const isTransferAllowed = (board: Board, { pileId, pieceCount }): boolean
 
 export const moves = {
   moveHalvedPieces: {
-    validate: (board: Board, _, piece) => isTransferAllowed(board, piece),
-    apply: (board: Board, { ctx }: { ctx: Ctx }, { pileId, pieceCount }): MoveOutcome<Board> => {
+    validate: (board: Board, _, piece: Transfer) => isTransferAllowed(board, piece),
+    apply: (board: Board, { ctx }: { ctx: Ctx }, { pileId, pieceCount }: Transfer): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard[pileId] -= pieceCount;
       nextBoard[1 - pileId] += pieceCount / 2;

--- a/src/components/games/architect-and-bandits/architect-and-bandits-a/gameplay.ts
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-a/gameplay.ts
@@ -26,7 +26,7 @@ export const moves = {
       ctx.currentPlayer === ARCHITECT && isArchitectStepAllowed(board, targetVertex, KM_PER_DAY),
     // The architect keeps walking within the day, so the turn stays open until
     // `endDay`.
-    apply: (board: Board, _, targetVertex): MoveOutcome<Board> => {
+    apply: (board: Board, _, targetVertex: number): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard.architectPosition = targetVertex;
       nextBoard.towers[targetVertex] = true;
@@ -50,7 +50,7 @@ export const moves = {
   destroyTower: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, vertex: number) =>
       ctx.currentPlayer === BANDITS && isDestructionAllowed(board, vertex),
-    apply: (board: Board, _, vertex): MoveOutcome<Board> => {
+    apply: (board: Board, _, vertex: number): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard.towers[vertex] = false;
       return { nextBoard, autoEndOfTurn: true };

--- a/src/components/games/architect-and-bandits/architect-and-bandits-b/gameplay.ts
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-b/gameplay.ts
@@ -22,7 +22,7 @@ export const moves = {
       ctx.currentPlayer === ARCHITECT && isArchitectStepAllowed(board, targetVertex, KM_PER_DAY),
     // The architect keeps walking within the day, so the turn stays open until
     // `endDay`.
-    apply: (board: Board, _, targetVertex): MoveOutcome<Board> => {
+    apply: (board: Board, _, targetVertex: number): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard.architectPosition = targetVertex;
       nextBoard.towers[targetVertex] = true;
@@ -47,7 +47,7 @@ export const moves = {
   destroyTower: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, vertex: number) =>
       ctx.currentPlayer === BANDITS && isDestructionAllowed(board, vertex),
-    apply: (board: Board, _, vertex): MoveOutcome<Board> => {
+    apply: (board: Board, _, vertex: number): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard.towers[vertex] = false;
       return { nextBoard, autoEndOfTurn: true };

--- a/src/components/games/bacteria/bacteria.tsx
+++ b/src/components/games/bacteria/bacteria.tsx
@@ -143,7 +143,7 @@ const BoardClient = ({ board: { bacteria, goals }, ctx, moves }: BoardClientProp
     const count = bacteria[row][col] || 0;
     const goal = isGoal({ row, col });
     if (attackRow !== null && isAllowedAttack({ row, col })) {
-      const attack = { attackRow, attackCol, row, col };
+      const attack = { attackRow, attackCol: attackCol!, row, col };
       const previewCount = isJump(attack) ? 1 : bacteria[attackRow!][attackCol!];
       return <BacteriaDisplay count={previewCount} onGoal={goal} dimmed />;
     }

--- a/src/components/games/bacteria/gameplay.ts
+++ b/src/components/games/bacteria/gameplay.ts
@@ -2,6 +2,9 @@ import { cloneDeep, last } from "lodash";
 import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
 
 export type Board = { bacteria: number[][], goals: number[] };
+export type Cell = { row: number; col: number };
+// A cell paired with the attacking cell it is being judged against.
+export type AttackZone = Cell & { attackRow: number; attackCol: number };
 
 // Board geometry ------------------------------------------------------------
 // Rows are indexed from the bottom (row 0 = start row, last row = goal row).
@@ -82,7 +85,7 @@ export const [ATTACKER, DEFENDER] = [0, 1];
 
 // Every move of either player starts from a cell that holds at least one
 // bacterium.
-export const hasBacterium = (board: Board, { row, col }): boolean =>
+export const hasBacterium = (board: Board, { row, col }: Cell): boolean =>
   inBoard(board, row, col) && board.bacteria[row][col] >= 1;
 
 // An attack additionally needs somewhere to go: the sideways step, the two-row
@@ -97,9 +100,9 @@ export const isAttackAllowed = (board: Board, { type, row, col }: AttackMove): b
 };
 
 const attackerMove = (type: MoveType) => ({
-  validate: (board: Board, { ctx }, { row, col }) =>
+  validate: (board: Board, { ctx }: { ctx: Ctx }, { row, col }: Cell) =>
     ctx.currentPlayer === ATTACKER && isAttackAllowed(board, { type, row, col }),
-  apply: (board: Board, { ctx }: { ctx: Ctx }, { row, col }): MoveOutcome<Board> => {
+  apply: (board: Board, { ctx }: { ctx: Ctx }, { row, col }: Cell): MoveOutcome<Board> => {
     const { nextBoard, reachedGoal } = applyAttackMove(board, { type, row, col });
     if (reachedGoal) return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
     return { nextBoard, isTurnEnd: true };
@@ -108,9 +111,9 @@ const attackerMove = (type: MoveType) => ({
 
 export const moves = {
   defend: {
-    validate: (board: Board, { ctx }, cell) =>
+    validate: (board: Board, { ctx }: { ctx: Ctx }, cell: Cell) =>
       ctx.currentPlayer === DEFENDER && hasBacterium(board, cell),
-    apply: (board: Board, { ctx }: { ctx: Ctx }, { row, col }): MoveOutcome<Board> => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, { row, col }: Cell): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard.bacteria[row][col] -= 1;
 
@@ -128,26 +131,26 @@ export const moves = {
 
 export type Moves = typeof moves;
 
-export const isShiftRight = ({ attackRow, attackCol, row, col }) => {
+export const isShiftRight = ({ attackRow, attackCol, row, col }: AttackZone) => {
   return attackRow === row && (col === (attackCol + 1));
 };
 
-export const isShiftLeft = ({ attackRow, attackCol, row, col }) => {
+export const isShiftLeft = ({ attackRow, attackCol, row, col }: AttackZone) => {
   return attackRow === row && (col === (attackCol - 1));
 };
 
-export const isSpread = ({ attackRow, attackCol, row, col }) => {
+export const isSpread = ({ attackRow, attackCol, row, col }: AttackZone) => {
   return (
     row === attackRow + 1 &&
     (col === attackCol || col === attackCol + (-1) ** (1 + attackRow))
   );
 };
 
-export const isJump = ({ attackRow, attackCol, row, col }) => {
+export const isJump = ({ attackRow, attackCol, row, col }: AttackZone) => {
   return row === attackRow + 2 && col === attackCol;
 };
 
-const areAllBacteriaRemoved = (bacteria) => {
+const areAllBacteriaRemoved = (bacteria: number[][]) => {
   for (let row = 0; row < bacteria.length; row++) {
     for (let col = 0; col <= lastCol(bacteria, row); col++) {
       if (bacteria[row][col] > 0) return false;
@@ -156,14 +159,14 @@ const areAllBacteriaRemoved = (bacteria) => {
   return true;
 };
 
-export const lastCol = (bacteria, row) => bacteria[0].length - 0.5 - 0.5 * (-1) ** row;
+export const lastCol = (bacteria: number[][], row: number) => bacteria[0].length - 0.5 - 0.5 * (-1) ** row;
 
 /* Currently only correct for board with adjacent goals */
-export const isDangerous = (board: Board, { row, col }) => {
+export const isDangerous = (board: Board, { row, col }: Cell) => {
   return distanceFromDangerousAttackZone(board, { row, col }).dist === 0;
 };
 
-export const distanceFromDangerousAttackZone = (board: Board, { row, col }) => {
+export const distanceFromDangerousAttackZone = (board: Board, { row, col }: Cell) => {
   const boardWidth = board.bacteria[0].length;
   const goalRowIdx = board.bacteria.length - 1;
   const finalLeft = board.goals[0] === 0 ? 0 : board.goals[0] - 1;
@@ -189,5 +192,5 @@ export const distanceFromDangerousAttackZone = (board: Board, { row, col }) => {
   };
 };
 
-export const isOddEdge = (bacteria, { row, col }) =>
+export const isOddEdge = (bacteria: number[][], { row, col }: Cell) =>
   (col === 0 || col === lastCol(bacteria, row)) && row % 2 === 0;

--- a/src/components/games/bank-robbers/gameplay.ts
+++ b/src/components/games/bank-robbers/gameplay.ts
@@ -5,8 +5,8 @@ export type Board = { circle: boolean[], lastMove: number | null, firstMove: num
 
 export const moves = {
   rob: {
-    validate: (board: Board, _, index) => isRobbable(board, index),
-    apply: (board: Board, { ctx }: { ctx: Ctx }, index): MoveOutcome<Board> => {
+    validate: (board: Board, _, index: number) => isRobbable(board, index),
+    apply: (board: Board, { ctx }: { ctx: Ctx }, index: number): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       // so that ai strategy can be simpler: first move is always the same
       const transformedMove = board.firstMove === null ? 0 : index;

--- a/src/components/games/cube-coloring/bot-strategy.ts
+++ b/src/components/games/cube-coloring/bot-strategy.ts
@@ -27,9 +27,9 @@ export const smartBotStrategy: Bot = ({ board, ctx }) => {
 const makeOptimalStepAsFirst = (board: Board) => {
   const mainDiagonal = shuffle([2, 4]);
   const otherVertices = shuffle([0, 1, 3, 5, 6, 7]);
-  const vertexToColor = [...mainDiagonal, ...otherVertices].find(v => !isColored(board, v));
+  const vertexToColor = [...mainDiagonal, ...otherVertices].find(v => !isColored(board, v))!;
   const allowedColors = colors.filter(c => isAllowedStep(board, vertexToColor, c));
-  return { vertex: vertexToColor, color: sample(allowedColors) };
+  return { vertex: vertexToColor, color: sample(allowedColors)! };
 };
 
 const makeOptimalStepAsSecond = (board: Board) => {

--- a/src/components/games/cube-coloring/gameplay.ts
+++ b/src/components/games/cube-coloring/gameplay.ts
@@ -9,8 +9,8 @@ export const isColored = (board: Board, i: number) => board[i] !== '';
 // The logic-side palette; `nodeColors` in cube-coloring.tsx adds the styling.
 export const colors = ['red', 'blue', 'yellow'];
 
-export const isAllowedStep = (board: Board, vertex, color) => {
-  if (!colors.includes(color)) return false;
+export const isAllowedStep = (board: Board, vertex: number, color: string | null) => {
+  if (!color || !colors.includes(color)) return false;
   if (isColored(board, vertex)) return false;
   return every(neighbours[vertex], i => (!isColored(board, i)) || board[i] !== color);
 };
@@ -46,7 +46,7 @@ export const neighbours: Record<number, number[]> = edges.reduce((acc, [a, b]) =
 }, {} as Record<number, number[]>);
 
 const isGameEnd = (board: Board) => {
-  const canUseColor = color => some(range(0, 8), v => isAllowedStep(board, v, color));
+  const canUseColor = (color: string) => some(range(0, 8), v => isAllowedStep(board, v, color));
   return every(colors, color => !canUseColor(color));
 };
 
@@ -54,7 +54,7 @@ export const moves = {
   colorVertex: {
     validate: (board: Board, _, { vertex, color }: { vertex: number; color: string | null }) =>
       isAllowedStep(board, vertex, color),
-    apply: (board: Board, _, { vertex, color }): MoveOutcome<Board> => {
+    apply: (board: Board, _, { vertex, color }: { vertex: number; color: string }): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard[vertex] = color;
       if (isGameEnd(nextBoard)) {

--- a/src/components/games/discs-flip-or-remove/gameplay.ts
+++ b/src/components/games/discs-flip-or-remove/gameplay.ts
@@ -29,8 +29,8 @@ export const isFlipAllowed = (board: Board, count: number): boolean =>
 
 export const moves = {
   removeDiscs: {
-    validate: (board: Board, _, count) => isRemovalAllowed(board, count),
-    apply: (board: Board, { ctx }: { ctx: Ctx }, count): MoveOutcome<Board> => {
+    validate: (board: Board, _, count: number) => isRemovalAllowed(board, count),
+    apply: (board: Board, { ctx }: { ctx: Ctx }, count: number): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard[0] -= count;
       if (isEqual(nextBoard, [0, 0])) {
@@ -40,8 +40,8 @@ export const moves = {
     }
   },
   turnDiscs: {
-    validate: (board: Board, _, count) => isFlipAllowed(board, count),
-    apply: (board: Board, { ctx }: { ctx: Ctx }, count): MoveOutcome<Board> => {
+    validate: (board: Board, _, count: number) => isFlipAllowed(board, count),
+    apply: (board: Board, { ctx }: { ctx: Ctx }, count: number): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard[1] -= count;
       nextBoard[0] += count;

--- a/src/components/games/distinct-squares/two-times-two/gameplay.ts
+++ b/src/components/games/distinct-squares/two-times-two/gameplay.ts
@@ -8,8 +8,8 @@ export const generateStartBoard = (): Board => [0, 0, 0, 0];
 
 export const moves = {
   addPiece: {
-    validate: (board: Board, _, pileId) => isPlacementAllowed(board, pileId),
-    apply: (board: Board, _, pileId): MoveOutcome<Board> => {
+    validate: (board: Board, _, pileId: number) => isPlacementAllowed(board, pileId),
+    apply: (board: Board, _, pileId: number): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard[pileId] += 1;
       if (sum(nextBoard) === 6) {

--- a/src/components/games/four-piles-spread-ahead/gameplay.ts
+++ b/src/components/games/four-piles-spread-ahead/gameplay.ts
@@ -21,7 +21,11 @@ export const moves = {
   spreadPieces: {
     validate: (board: Board, _, { pileId, pieceCount }: { pileId: number; pieceCount: number }) =>
       isSpreadAllowed(board, pileId, pieceCount),
-    apply: (board: Board, { ctx }: { ctx: Ctx }, { pileId, pieceCount }): MoveOutcome<Board> => {
+    apply: (
+      board: Board,
+      { ctx }: { ctx: Ctx },
+      { pileId, pieceCount }: { pileId: number; pieceCount: number }
+    ): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard[pileId] = board[pileId] - pieceCount;
       for (let i = pileId - pieceCount; i < pileId; i++) {

--- a/src/components/games/magic-box/magic-box-a/gameplay.ts
+++ b/src/components/games/magic-box/magic-box-a/gameplay.ts
@@ -32,7 +32,7 @@ export const isGameEnd = hasFullLine;
 export const moves = {
   placeStone: {
     validate: (board: Board, _, id: number) => isPlacementAllowed(board, id),
-    apply: (board: Board, { ctx }: { ctx: Ctx }, id): MoveOutcome<Board> => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, id: number): MoveOutcome<Board> => {
       const nextBoard = placeStone(board, id);
       // The box breaks under the stone just placed, so the mover loses.
       if (isGameEnd(nextBoard)) {

--- a/src/components/games/magic-box/magic-box-b/bot-strategy.ts
+++ b/src/components/games/magic-box/magic-box-b/bot-strategy.ts
@@ -9,7 +9,7 @@ type Bot = BotStrategy<Board, Moves>
 const asTurn = (pendingLine: number | null, cell: number | undefined, line: number): BotMove<Moves>[] =>
   pendingLine === null
     ? [{ move: 'designateLine', args: [line] }]
-    : [{ move: 'placeStone', args: [cell] }, { move: 'designateLine', args: [line] }];
+    : [{ move: 'placeStone', args: [cell!] }, { move: 'designateLine', args: [line] }];
 
 export const randomBotStrategy: Bot = ({ board }) => {
   const { stones, pendingLine } = board;

--- a/src/components/games/magic-box/magic-box-b/gameplay.ts
+++ b/src/components/games/magic-box/magic-box-b/gameplay.ts
@@ -47,7 +47,7 @@ export const moves = {
     validate: (board: Board, _, cellId: number) => isPlacementAllowed(board, cellId),
     // First half of the turn: place a stone, then designate a line — the turn
     // stays open in between.
-    apply: (board: Board, _, cellId): MoveOutcome<Board> => {
+    apply: (board: Board, _, cellId: number): MoveOutcome<Board> => {
       const nextBoard: Board = { stones: placeStoneAt(board.stones, cellId), pendingLine: null };
       return { nextBoard };
     }
@@ -55,7 +55,7 @@ export const moves = {
 
   designateLine: {
     validate: (board: Board, _, lineIndex: number) => isDesignationAllowed(board, lineIndex),
-    apply: (board: Board, { ctx }: { ctx: Ctx }, lineIndex): MoveOutcome<Board> => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, lineIndex: number): MoveOutcome<Board> => {
       const nextBoard: Board = { stones: board.stones, pendingLine: lineIndex };
       // A full designated line leaves the other player nowhere to place.
       if (isLineFull(nextBoard.stones, lineIndex)) {

--- a/src/components/games/number-covering/gameplay.ts
+++ b/src/components/games/number-covering/gameplay.ts
@@ -15,7 +15,7 @@ export const isCoveringAllowed = (board: Board, number: number): boolean =>
 export const moves = {
   coverNumber: {
     validate: (board: Board, _, number: number) => isCoveringAllowed(board, number),
-    apply: (board: Board, _, number): MoveOutcome<Board> => {
+    apply: (board: Board, _, number: number): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard[number-1] = COVERED;
 

--- a/src/components/games/number-pyramid/gameplay.ts
+++ b/src/components/games/number-pyramid/gameplay.ts
@@ -41,11 +41,11 @@ export const generateStartBoard = (tries = 0): Board => {
 
 export const moves = {
   combineTwo: {
-    validate: (board: Board, _, move) => isCombineAllowed(board, move),
+    validate: (board: Board, _, move: { levelIdx: number; indices: number[] }) => isCombineAllowed(board, move),
     apply: (
       board: Board,
       { ctx }: { ctx: Ctx },
-      { levelIdx, indices }
+      { levelIdx, indices }: { levelIdx: number; indices: number[] }
     ): MoveOutcome<Board> => {
       const { nextBoard, combinedValue } = applyMoveToBoard(board, levelIdx, indices);
 

--- a/src/components/games/pile-splitting-games/pile-splitter-3/gameplay.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter-3/gameplay.ts
@@ -22,7 +22,11 @@ export const moves = {
   splitPile: {
     validate: (board: Board, _, { pileId, pieceCount }: { pileId: number; pieceCount: number }) =>
       isSplitAllowed(board, pileId, pieceCount),
-    apply: (board: Board, { ctx }: { ctx: Ctx }, { pileId, pieceCount }): MoveOutcome<Board> => {
+    apply: (
+      board: Board,
+      { ctx }: { ctx: Ctx },
+      { pileId, pieceCount }: { pileId: number; pieceCount: number }
+    ): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       // the slot emptied earlier this turn takes the other half of the split
       const removedPileId = emptiedPileId(nextBoard)!;

--- a/src/components/games/pile-splitting-games/pile-splitter-4/gameplay.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter-4/gameplay.ts
@@ -88,7 +88,11 @@ export const moves = {
   splitPile: {
     validate: (board: Board, _, { pileId, pieceCount }: { pileId: number; pieceCount: number }) =>
       isSplitAllowed(board, pileId, pieceCount),
-    apply: (board: Board, { ctx }: { ctx: Ctx }, { pileId, pieceCount }): MoveOutcome<Board> => {
+    apply: (
+      board: Board,
+      { ctx }: { ctx: Ctx },
+      { pileId, pieceCount }: { pileId: number; pieceCount: number }
+    ): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       // the slot emptied earlier this turn takes the other half of the split
       const removedPileId = emptiedPileId(nextBoard)!;

--- a/src/components/games/pile-splitting-games/pile-splitter/gameplay.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter/gameplay.ts
@@ -10,13 +10,17 @@ export const moves = {
     validate: (board: Board, _, pileId: number) => isRemovalAllowed(board, pileId),
     // First half of the turn: discard a pile, then split the other — the turn
     // stays open in between.
-    apply: (board: Board, _, pileId): MoveOutcome<Board> =>
+    apply: (board: Board, _, pileId: number): MoveOutcome<Board> =>
       ({ nextBoard: withPileRemoved(board, pileId) })
   },
   splitPile: {
     validate: (board: Board, _, { pileId, pieceCount }: { pileId: number; pieceCount: number }) =>
       isSplitAllowed(board, pileId, pieceCount),
-    apply: (board: Board, { ctx }: { ctx: Ctx }, { pileId, pieceCount }): MoveOutcome<Board> => {
+    apply: (
+      board: Board,
+      { ctx }: { ctx: Ctx },
+      { pileId, pieceCount }: { pileId: number; pieceCount: number }
+    ): MoveOutcome<Board> => {
       const nextBoard = [pieceCount, board[pileId] - pieceCount];
       // Two single-piece piles cannot be split, so the opponent is stuck.
       if (isEqual(nextBoard, [1, 1])) {

--- a/src/components/games/pile-union/gameplay.ts
+++ b/src/components/games/pile-union/gameplay.ts
@@ -16,8 +16,8 @@ export const isMergeAllowed = (board: Board, piles: number[]): boolean =>
 
 export const moves = {
   removeOne: {
-    validate: (board: Board, _, pileIndex) => isPile(board, pileIndex),
-    apply: (board: Board, { ctx }: { ctx: Ctx }, pileIndex): MoveOutcome<Board> => {
+    validate: (board: Board, _, pileIndex: number) => isPile(board, pileIndex),
+    apply: (board: Board, { ctx }: { ctx: Ctx }, pileIndex: number): MoveOutcome<Board> => {
       const newSize = board[pileIndex] - 1;
       const nextBoard = [
         ...board.slice(0, pileIndex),
@@ -33,7 +33,7 @@ export const moves = {
   },
   mergePiles: {
     validate: (board: Board, _, piles: number[]) => isMergeAllowed(board, piles),
-    apply: (board: Board, _, [pileIndex1, pileIndex2]): MoveOutcome<Board> => {
+    apply: (board: Board, _, [pileIndex1, pileIndex2]: number[]): MoveOutcome<Board> => {
       const [firstIdx, secondIdx] = [pileIndex1, pileIndex2].sort((a, b) => a - b);
       const merged = board[firstIdx] + board[secondIdx];
       const nextBoard = board.filter((_, i) => i !== firstIdx && i !== secondIdx);

--- a/src/components/games/remove-divisor-multiple/gameplay.ts
+++ b/src/components/games/remove-divisor-multiple/gameplay.ts
@@ -8,7 +8,7 @@ export type Board = { numbersOnTable: boolean[], previousMove: number | null }
 // on-the-table check used to be skipped for the opening move, where every
 // number is still there anyway; hoisting it above the previousMove branch
 // changes nothing for a real opening move but keeps a bogus argument out.
-export const isAllowed = (board: Board, n) => {
+export const isAllowed = (board: Board, n: number) => {
   if (!Number.isInteger(n) || n < 1 || n > board.numbersOnTable.length) return false;
   if (board.numbersOnTable[n - 1] === false) return false;
   if (board.previousMove === null) {
@@ -24,8 +24,8 @@ export const isAllowed = (board: Board, n) => {
 
 export const moves = {
   removeNumber: {
-    validate: (board: Board, _, n) => isAllowed(board, n),
-    apply: (board: Board, { ctx }: { ctx: Ctx }, n): MoveOutcome<Board> => {
+    validate: (board: Board, _, n: number) => isAllowed(board, n),
+    apply: (board: Board, { ctx }: { ctx: Ctx }, n: number): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard.numbersOnTable[n - 1] = false;
       nextBoard.previousMove = n;

--- a/src/components/games/single-number-increase/plus-one-two-three/gameplay.ts
+++ b/src/components/games/single-number-increase/plus-one-two-three/gameplay.ts
@@ -12,7 +12,7 @@ export const isIncreaseValid = ({ board, number }: { board: Board; number: numbe
 export const moves = {
   increaseTo: {
     validate: (board: Board, _, number: number) => isIncreaseValid({ board, number }),
-    apply: (board: Board, { ctx }: { ctx: Ctx }, number): MoveOutcome<Board> => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, number: number): MoveOutcome<Board> => {
       if (number > target) {
         return { nextBoard: number, gameEnd: { winnerIndex: 1 - ctx.currentPlayer! } };
       }

--- a/src/components/games/single-number-increase/superstitious-counting/gameplay.ts
+++ b/src/components/games/single-number-increase/superstitious-counting/gameplay.ts
@@ -25,7 +25,7 @@ export const generateTestStartBoard = (): Board => {
 export const moves = {
   step: {
     validate: (board: Board, _, step: number) => isStepAllowed(board, step),
-    apply: (board: Board, { ctx }: { ctx: Ctx }, step): MoveOutcome<Board> => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, step: number): MoveOutcome<Board> => {
       const numberAfterStep = board.current + step;
       const nextBoard = { current: numberAfterStep, target: board.target, restricted: 13 - step };
       if (numberAfterStep >= board.target) {

--- a/src/components/games/single-pile-removal/prime-exponentials/gameplay.ts
+++ b/src/components/games/single-pile-removal/prime-exponentials/gameplay.ts
@@ -49,7 +49,11 @@ export const moves = {
   subtractPrimeExponent: {
     validate: (board: Board, _, entry: { prime: number; exponent: number }) =>
       isSubtractionAllowed(board, entry),
-    apply: (board: Board, { ctx }: { ctx: Ctx }, { prime, exponent }): MoveOutcome<Board> => {
+    apply: (
+      board: Board,
+      { ctx }: { ctx: Ctx },
+      { prime, exponent }: { prime: number; exponent: number }
+    ): MoveOutcome<Board> => {
       const nextBoard = board - prime ** exponent;
       if (nextBoard === 0) {
         return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };

--- a/src/components/games/stones-remove-one-not-twice-from-left/gameplay.ts
+++ b/src/components/games/stones-remove-one-not-twice-from-left/gameplay.ts
@@ -14,9 +14,9 @@ export const isRemovalAllowed = (board: Board, player: number, pileId: number): 
 
 export const moves = {
   removeStone: {
-    validate: (board: Board, { ctx }: { ctx: Ctx }, pileId) =>
+    validate: (board: Board, { ctx }: { ctx: Ctx }, pileId: number) =>
       isRemovalAllowed(board, ctx.currentPlayer!, pileId),
-    apply: (board: Board, { ctx }: { ctx: Ctx }, pileId): MoveOutcome<Board> => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, pileId: number): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard.piles[pileId] = board.piles[pileId] - 1;
       nextBoard.leftRestriction[ctx.currentPlayer!] = (pileId === 0);
@@ -30,11 +30,11 @@ export const moves = {
 
 export type Moves = typeof moves;
 
-const isGameEnd = (board, ctx) => {
+const isGameEnd = (board: Board, ctx: Ctx) => {
   if (isEqual(board.piles, [0, 0])) {
     return true;
   }
-  if (board.piles[1] === 0 && board.leftRestriction[1 - ctx.currentPlayer]) {
+  if (board.piles[1] === 0 && board.leftRestriction[1 - ctx.currentPlayer!]) {
     return true;
   }
   return false;

--- a/src/components/games/ten-coins/gameplay.ts
+++ b/src/components/games/ten-coins/gameplay.ts
@@ -18,8 +18,8 @@ export const isConversionAllowed = (board: Board, k: number, l: number): boolean
 
 export const moves = {
   convert: {
-    validate: (board: Board, _, k, l) => isConversionAllowed(board, k, l),
-    apply: (board: Board, { ctx }: { ctx: Ctx }, k, l): MoveOutcome<Board> => {
+    validate: (board: Board, _, k: number, l: number) => isConversionAllowed(board, k, l),
+    apply: (board: Board, { ctx }: { ctx: Ctx }, k: number, l: number): MoveOutcome<Board> => {
       const nextBoard = board.map(v => (v === k ? l : v)).sort((a, b) => a - b);
       if (uniq(nextBoard).length === 1) {
         return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };

--- a/src/components/games/ten-digit-number/gameplay.ts
+++ b/src/components/games/ten-digit-number/gameplay.ts
@@ -13,8 +13,8 @@ export const isDigitChoiceAllowed = (board: Board, digit: number): boolean =>
 
 export const moves = {
   chooseDigit: {
-    validate: (board: Board, _, digit) => isDigitChoiceAllowed(board, digit),
-    apply: (board: Board, _, digit): MoveOutcome<Board> => {
+    validate: (board: Board, _, digit: number) => isDigitChoiceAllowed(board, digit),
+    apply: (board: Board, _, digit: number): MoveOutcome<Board> => {
       const newDigits = [...board.digits, digit];
       const newSumMod9 = (board.sumMod9 + digit) % 9;
       const nextBoard = { digits: newDigits, sumMod9: newSumMod9 };

--- a/src/components/games/tictactoe-alikes/anti-tictactoe/gameplay.ts
+++ b/src/components/games/tictactoe-alikes/anti-tictactoe/gameplay.ts
@@ -24,7 +24,7 @@ export const hasFirstPlayerWon = (board: Board) => {
 export const moves = {
   placePiece: {
     validate: validatePlacement,
-    apply: (board: Board, { ctx }: { ctx: Ctx }, id): MoveOutcome<Board> => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, id: number): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard[id] = ctx.currentPlayer === 0 ? 'red' : 'blue';
       if (isGameEnd(nextBoard)) {

--- a/src/components/games/tictactoe-alikes/gameplay.ts
+++ b/src/components/games/tictactoe-alikes/gameplay.ts
@@ -16,7 +16,7 @@ export const generateEmptyTicTacToeBoard = () => Array(9).fill(null);
 export const validatePlacement = (board: Board, _, id: number): boolean =>
   Number.isInteger(id) && id >= 0 && id < board.length && board[id] === null;
 
-export const hasWinningSubset = (indices) => {
+export const hasWinningSubset = (indices: number[]) => {
   const winningIndexSets = [
     [0, 1, 2],
     [3, 4, 5],
@@ -27,6 +27,6 @@ export const hasWinningSubset = (indices) => {
     [0, 4, 8],
     [2, 4, 6]
   ];
-  const isSubsetOfIndices = s => difference(s, indices).length === 0;
+  const isSubsetOfIndices = (s: number[]) => difference(s, indices).length === 0;
   return some(winningIndexSets, isSubsetOfIndices);
 };

--- a/src/components/games/tictactoe-alikes/tictactoe-doublestart/bot-strategy.ts
+++ b/src/components/games/tictactoe-alikes/tictactoe-doublestart/bot-strategy.ts
@@ -8,12 +8,12 @@ type Bot = BotStrategy<Board, Moves>
 const emptyCells = (board: Board) => range(0, 9).filter(i => isNull(board[i]));
 
 // The opening turn places two pieces, named together as one decision.
-const placements = (...cells: (number | undefined)[]): BotMove<Moves>[] =>
+const placements = (...cells: number[]): BotMove<Moves>[] =>
   cells.map(cell => ({ move: 'placePiece', args: [cell] }));
 
 export const randomBotStrategy: Bot = ({ board }) => {
   const allowedPlaces = emptyCells(board);
-  if (allowedPlaces.length < 9) return placements(sample(allowedPlaces));
+  if (allowedPlaces.length < 9) return placements(sample(allowedPlaces)!);
   const [first, second] = sampleSize(allowedPlaces, 2);
   return placements(first, second);
 };
@@ -24,7 +24,7 @@ export const smartBotStrategy: Bot = ({ board, ctx }) => {
     const opening = sample([[0, 2], [2, 8], [6, 8], [0, 6]])!;
     return placements(opening[0], opening[1]);
   }
-  return placements(getOptimalBotPlacingPosition(board, ctx.chosenRoleIndex));
+  return placements(getOptimalBotPlacingPosition(board, ctx.chosenRoleIndex)!);
 };
 
 const getOptimalBotPlacingPosition = (board: Board, chosenRoleIndex) => {

--- a/src/components/games/tictactoe-alikes/tictactoe-doublestart/gameplay.ts
+++ b/src/components/games/tictactoe-alikes/tictactoe-doublestart/gameplay.ts
@@ -15,7 +15,7 @@ export const hasFirstPlayerWon = (board: Board) => {
 export const isGameEnd = (board: Board) =>
   board.filter(c => c).length === 9 || hasWinningSubsetForPlayer(board, 1);
 
-const hasWinningSubsetForPlayer = (board: Board, roleIndex) =>
+const hasWinningSubsetForPlayer = (board: Board, roleIndex: number) =>
   hasWinningSubset(range(0, 9).filter(i => board[i] === roleColors[roleIndex]));
 
 export const isDuringFirstMove = (board: Board) => board.filter(c => c).length <= 1;
@@ -23,7 +23,7 @@ export const isDuringFirstMove = (board: Board) => board.filter(c => c).length <
 export const moves = {
   placePiece: {
     validate: validatePlacement,
-    apply: (board: Board, { ctx }: { ctx: Ctx }, id): MoveOutcome<Board> => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, id: number): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard[id] = ctx.currentPlayer === 0 ? 'red' : 'blue';
 

--- a/src/components/games/tictactoe-alikes/tictactoe/bot-strategy.ts
+++ b/src/components/games/tictactoe-alikes/tictactoe/bot-strategy.ts
@@ -37,7 +37,7 @@ export const smartBotStrategy: Bot = ({ board }) => {
 const getOptimalBotPlacingPosition = (board: Board) => {
   const allowedPlaces = getAllowedPlaces({ board, amIBot: true });
 
-  if (allowedPlaces.length === 9) return(sample([0, 2, 4, 6, 8]));
+  if (allowedPlaces.length === 9) return sample([0, 2, 4, 6, 8])!;
 
   const instantWinningPlace = allowedPlaces.find((i) => {
     const localBoard = [...board];
@@ -59,9 +59,9 @@ const getOptimalBotPlacingPosition = (board: Board) => {
     return isWinningState(boardCopy, true);
   });
 
-  if (optimalPlaces.length > 0) return sample(optimalPlaces);
+  if (optimalPlaces.length > 0) return sample(optimalPlaces)!;
 
-  return sample(allowedPlaces);
+  return sample(allowedPlaces)!;
 };
 
 const getOptimalBotFlippingPosition = (board: Board) => {
@@ -75,9 +75,9 @@ const getOptimalBotFlippingPosition = (board: Board) => {
 
   // if you can win symmetrically, try to do so (only for beauty)
   if (optimalPlaces.find(i => i === 4) !== undefined) return 4;
-  if (optimalPlaces.length > 0) return sample(optimalPlaces);
+  if (optimalPlaces.length > 0) return sample(optimalPlaces)!;
 
-  return sample(allowedPlaces);
+  return sample(allowedPlaces)!;
 };
 
 const isWinningStateCache = new Map();

--- a/src/components/games/tictactoe-alikes/tictactoe/gameplay.ts
+++ b/src/components/games/tictactoe-alikes/tictactoe/gameplay.ts
@@ -15,12 +15,12 @@ export const botColor = 'red';
 
 export const inPlacingPhase = (board: Board) => board.find(isNull) !== undefined;
 
-export const currentPlayerColor = (ctx) =>
+export const currentPlayerColor = (ctx: Ctx) =>
   ctx.isHumanVsHumanGame
     ? (ctx.currentPlayer === 0 ? 'blue' : 'red')
     : (ctx.currentPlayer === ctx.chosenRoleIndex ? pColor : botColor);
 
-export const otherPlayerColor = (ctx) =>
+export const otherPlayerColor = (ctx: Ctx) =>
   ctx.isHumanVsHumanGame
     ? (ctx.currentPlayer === 0 ? 'red' : 'blue')
     : (ctx.currentPlayer === ctx.chosenRoleIndex ? botColor : pColor);
@@ -30,13 +30,13 @@ export const otherPlayerColor = (ctx) =>
 // phase check is what stops a player from whitening mid-placement; for placing,
 // "the cell is empty" already implies the placing phase, so that move needs no
 // phase check of its own.
-export const isWhiteningAllowed = (board: Board, ctx, id: number) =>
+export const isWhiteningAllowed = (board: Board, ctx: Ctx, id: number) =>
   !inPlacingPhase(board) && board[id] === otherPlayerColor(ctx);
 
 export const moves = {
   placePiece: {
     validate: validatePlacement,
-    apply: (board: Board, { ctx }: { ctx: Ctx }, id): MoveOutcome<Board> => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, id: number): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard[id] = currentPlayerColor(ctx);
       if (isGameEnd(nextBoard)) {
@@ -47,7 +47,7 @@ export const moves = {
   },
   whitenPiece: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, id: number) => isWhiteningAllowed(board, ctx, id),
-    apply: (board: Board, { ctx }: { ctx: Ctx }, id): MoveOutcome<Board> => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, id: number): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard[id] = 'white';
       if (isGameEnd(nextBoard)) {

--- a/src/components/games/totem-poles/triangular-grid-ropes-10/gameplay.ts
+++ b/src/components/games/totem-poles/triangular-grid-ropes-10/gameplay.ts
@@ -43,11 +43,11 @@ export const isGameEnd = (board: Board) => {
   return allowedMoves.length === 0;
 };
 
-export const getAllowedSuperset = (board: Board, { from, to }) => {
+export const getAllowedSuperset = (board: Board, { from, to }: { from: number | null; to: number | null }) => {
   if (from == null || to == null || from === to) return null;
   if (!isAllowed(board, { from, to })) return { from, to };
   const edgeSupsersets = superSets[`${from}-${to}`] || superSets[`${to}-${from}`] || [];
-  const allowedSupersets = edgeSupsersets.filter(e => isAllowed(board, { from: e[0], to: e[1] }));
+  const allowedSupersets = edgeSupsersets.filter((e: number[]) => isAllowed(board, { from: e[0], to: e[1] }));
   if (allowedSupersets.length > 0) {
     const e = last(allowedSupersets)!;
     return { from: e[0], to: e[1] };
@@ -167,7 +167,7 @@ export const getTrivialMoves = (board: Board) => {
 export const moves = {
   stretchRope: {
     validate: (board: Board, _, edge: Edge) => isAllowed(board, edge),
-    apply: (board: Board, { ctx }: { ctx: Ctx }, { from, to }): MoveOutcome<Board> => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, { from, to }: Edge): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       // A rope is stretched as far as it legally reaches, not just between the
       // two nodes that were clicked.

--- a/src/components/games/totem-poles/triangular-grid-ropes-15/gameplay.ts
+++ b/src/components/games/totem-poles/triangular-grid-ropes-15/gameplay.ts
@@ -179,7 +179,7 @@ export const isGameEnd = (board: Board) => {
 export const moves = {
   stretchRope: {
     validate: (board: Board, _, edge: Edge) => isAllowed(board, edge),
-    apply: (board: Board, { ctx }: { ctx: Ctx }, { from, to }): MoveOutcome<Board> => {
+    apply: (board: Board, { ctx }: { ctx: Ctx }, { from, to }: Edge): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       // A rope is stretched as far as it legally reaches, not just between the
       // two nodes that were clicked.

--- a/src/components/games/twelve-squares/gameplay.ts
+++ b/src/components/games/twelve-squares/gameplay.ts
@@ -7,13 +7,13 @@ export const generateStartBoard = (): Board => ({ left: 1, right: 12 });
 // A piece advances one or two squares; landing exactly on the other piece is
 // the one thing forbidden. Both players step by the same rule, so whose turn it
 // is does not enter into legality — only which piece the step then moves.
-export const isValidStep = (board: Board, step) =>
+export const isValidStep = (board: Board, step: number) =>
   (step === 1 || step === 2) && step !== board.right - board.left;
 
 export const moves = {
   step: {
-    validate: (board: Board, _, step) => isValidStep(board, step),
-    apply: (board: Board, { ctx }: { ctx: Ctx }, step): MoveOutcome<Board> => {
+    validate: (board: Board, _, step: number) => isValidStep(board, step),
+    apply: (board: Board, { ctx }: { ctx: Ctx }, step: number): MoveOutcome<Board> => {
       const nextBoard = ctx.currentPlayer === 0
         ? { left: board.left + step, right: board.right }
         : { left: board.left, right: board.right - step };


### PR DESCRIPTION
## Summary

`BotStrategy<Board, Moves>` derives each move's argument list from its `apply` signature — but with `noImplicitAny: false`, an unannotated parameter types as `any`, so for ~40% of moves the pinning checked the move *name* and nothing else. This annotates every move argument, plus the `gameplay.ts` helpers those arguments flow through, across 32 games.

Per the review of #398, `noImplicitAny` stays **off**: whether to enforce it repo-wide is a separate decision, and outside move signatures it may be more noise than value. This PR gets the benefit where it counts without that commitment.

## Bugs the restored types caught

The sweep is mostly mechanical, but re-typing these signatures immediately surfaced five places where a bot could hand a move an `undefined` argument — previously invisible:

- **cube-coloring** — `makeOptimalStepAsFirst` returned a possibly-undefined vertex and colour
- **magic-box-b** — `placeStone` could be named with an undefined cell
- **tictactoe** and **tictactoe-doublestart** — the placing/flipping helpers returned `sample()` results without asserting the pick
- **bacteria** — the attack preview passed a nullable `attackCol` into a zone check

Each is a genuine invariant (the bot is only asked while a legal move exists), so they're asserted at the point that knows it rather than widened away. One type correction rather than an assertion: `getAllowedSuperset` is typed as a nullable pair instead of `Edge`, which is what its own first line already assumes — it's called with the hover preview's nullable state.

## Verification

- `npm test` (lint + typecheck + 1446 unit tests) and `npm run build` pass.
- Untyped move-argument parameters in `gameplay.ts`: **114 → 0**. The 8 remaining `--noImplicitAny` findings there are `TS7053` index-expression noise on lookup tables, a different category.
- Checked the pinning now bites: temporarily passing `['1']` where a move takes a number fails typecheck at the bot, naming `[step: number]`. Before this change it compiled silently.

The `_` ctx placeholders are deliberately left alone — they're the separate style question noted in the review doc, and touching 97 of them would bury this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Lg8UokewKvCAACeyKGChz

---
_Generated by [Claude Code](https://claude.ai/code/session_012Lg8UokewKvCAACeyKGChz)_