### PR TITLE
Cover the chess-ducks bot, which had no spec of any kind

### DIFF
--- a/src/components/games/chess-ducks/bot-strategy.spec.ts
+++ b/src/components/games/chess-ducks/bot-strategy.spec.ts
@@ -1,0 +1,109 @@
+import { range } from 'lodash';
+import { runMatch, type MatchResult } from '../../strategy-game-factory';
+import {
+  getAllowedMoves, isPlacementAllowed, withDuckPlaced, moves, type Board, type Field
+} from './gameplay';
+import {
+  smartBotStrategy, randomBotStrategy, smartBotOptimalSecondSteps, smartBotOptimalThirdSteps
+} from './bot-strategy';
+import { botNextMoveArgs, makeCtx } from '../../../test-utils';
+
+const emptyBoard = (rows: number, cols: number): Board =>
+  range(rows).map(() => range(cols).map(() => null));
+
+const boardWithDucks = (cols: number, ...ducks: Field[]): Board =>
+  ducks.reduce(withDuckPlaced, emptyBoard(4, cols));
+
+// Play a real game through the engine: the same moves, validator and win
+// detection the site runs on.
+const play = (
+  board: Board, strategies: [typeof smartBotStrategy, typeof smartBotStrategy]
+): MatchResult<Board> => runMatch({ gameplay: { moves }, strategies, startBoard: board });
+
+const askSmartBot = (board: Board): Field =>
+  botNextMoveArgs(smartBotStrategy({ board, ctx: makeCtx({ currentPlayer: 0 }) }))[0];
+
+const at = (key: string): Field => {
+  const [row, col] = key.split(';').map(Number);
+  return { row: row!, col: col! };
+};
+
+// Both board sizes are a win for the second player, so that is the side whose
+// optimality can be asserted; as the mover the bot is already lost and can only
+// win when the opponent errs.
+describe('smartBotStrategy', () => {
+  // A searching bot on a board this size is why the variant is listed out of
+  // plays-to-an-end.spec.ts, so these play a few boards rather than sweeping.
+  it.each([[4, 6], [4, 7]])('wins as the replier on %ix%i against the random bot', (rows, cols) => {
+    for (let trial = 0; trial < 3; trial++) {
+      expect(play(emptyBoard(rows, cols), [randomBotStrategy, smartBotStrategy]).winnerIndex).toBe(1);
+    }
+  }, 20000);
+
+  it.each([[4, 6], [4, 7]])('wins as the replier on %ix%i in optimal-vs-optimal play', (rows, cols) => {
+    expect(play(emptyBoard(rows, cols), [smartBotStrategy, smartBotStrategy]).winnerIndex).toBe(1);
+  }, 20000);
+});
+
+// The 4x7 opening books are generated offline by
+// scripts/pre-generate-ai-moves/, because searching those positions live takes
+// seconds — a single isWinningState call from a three-duck board runs for
+// several. That price is also the limit of what these tests can claim: proving
+// an entry *optimal* needs exactly the search the book exists to avoid, so
+// nothing here re-derives the values. What is pinned instead is everything
+// around them — that every entry names a placement the game allows, that the
+// lookup keys still match the positions they are built from (a format change
+// would silently drop the bot to its random fallback), and that the symmetry
+// inversion hands back the mirrored answer for a mirrored position.
+describe('opening books', () => {
+  it('recommends a legal placement from every reachable position they cover', () => {
+    for (const first of getAllowedMoves(emptyBoard(4, 7))) {
+      const afterFirst = withDuckPlaced(emptyBoard(4, 7), first);
+      expect(isPlacementAllowed(afterFirst, askSmartBot(afterFirst))).toBe(true);
+
+      for (const second of getAllowedMoves(afterFirst)) {
+        const afterSecond = withDuckPlaced(afterFirst, second);
+        expect(isPlacementAllowed(afterSecond, askSmartBot(afterSecond))).toBe(true);
+      }
+    }
+  });
+
+  it('still finds its second-step entry for every duck it covers', () => {
+    for (const [duck, answer] of Object.entries(smartBotOptimalSecondSteps)) {
+      expect(askSmartBot(boardWithDucks(7, at(duck)))).toEqual(answer);
+    }
+  });
+
+  it('still finds its third-step entry for every pair it covers', () => {
+    for (const [pair, answer] of Object.entries(smartBotOptimalThirdSteps)) {
+      const [first, second] = pair.split(' - ').map(at);
+      expect(askSmartBot(boardWithDucks(7, first!, second!))).toEqual(answer);
+    }
+  });
+
+  // getOptimalThirdStep looks a position up under four transformations and
+  // inverts whichever one hit, so a mirrored position must get the mirrored
+  // answer. A position that is its own mirror is excluded: there both the
+  // answer and its mirror are optimal, and the book names only one of them.
+  it('mirrors its third-step answer for a mirrored position', () => {
+    const flip = ({ row, col }: Field): Field => ({ row, col: 6 - col });
+
+    for (const [pair, answer] of Object.entries(smartBotOptimalThirdSteps)) {
+      const [first, second] = pair.split(' - ').map(at);
+      const mirrored = boardWithDucks(7, flip(first!), flip(second!));
+      if (JSON.stringify(mirrored) === JSON.stringify(boardWithDucks(7, first!, second!))) continue;
+      expect(askSmartBot(mirrored)).toEqual(flip(answer));
+    }
+  });
+});
+
+describe('randomBotStrategy', () => {
+  it('only ever names a placement the game allows', () => {
+    let board = emptyBoard(4, 6);
+    while (getAllowedMoves(board).length > 0) {
+      const field = botNextMoveArgs(randomBotStrategy({ board, ctx: makeCtx({ currentPlayer: 0 }) }))[0];
+      expect(isPlacementAllowed(board, field)).toBe(true);
+      board = withDuckPlaced(board, field);
+    }
+  });
+});

--- a/src/components/games/chess-ducks/bot-strategy.ts
+++ b/src/components/games/chess-ducks/bot-strategy.ts
@@ -130,7 +130,7 @@ const isWinningState = (board: Board): boolean => {
 };
 
 // see scripts/pre-generate-ai-moves/chess-ducks-optimal-2nd-moves.cjs
-const smartBotOptimalSecondSteps: Record<string, Field> = {
+export const smartBotOptimalSecondSteps: Record<string, Field> = {
   '0;0': { row: 0, col: 6 },
   '0;1': { row: 3, col: 1 },
   '0;2': { row: 3, col: 1 },
@@ -162,7 +162,7 @@ const smartBotOptimalSecondSteps: Record<string, Field> = {
 };
 
 // see scripts/pre-generate-ai-moves/chess-ducks-optimal-3rd-moves.cjs
-const smartBotOptimalThirdSteps: Record<string, Field> = {
+export const smartBotOptimalThirdSteps: Record<string, Field> = {
   '0;0 - 0;2': { row: 1, col: 5 },
   '0;0 - 0;3': { row: 3, col: 2 },
   '0;0 - 0;4': { row: 3, col: 0 },


### PR DESCRIPTION
First of the zero-coverage bots from the review backlog (§4a of `docs/project-review-2026-08.md`).

## Why this one first

`ChessDucks[1]` and `[2]` are listed out of `plays-to-an-end.spec.ts` because their bot searches, and the comment there says what the sweep loses is "coverage that bot's own spec has". For chess-ducks there was no such spec — the 203-line strategy, including two opening books generated offline by `scripts/pre-generate-ai-moves/`, had nothing asserting any of it.

## What is asserted

**Optimality.** Both board sizes turn out to be second-player wins, so that is the side whose optimality can be stated: the smart bot wins as the replier on 4×6 and 4×7, both against the random bot and against itself, played through `runMatch` (real moves, real validator, real win detection). As the *mover* it starts from a theoretically lost position and can only win on an opponent's mistake — it genuinely loses some games there — so nothing is claimed for that side.

**The opening books.** Proving an entry optimal needs exactly the search the books exist to avoid: one `isWinningState` call from a three-duck board runs for ~4s, so re-deriving 65 entries is not affordable in a test suite. What the spec pins instead is everything around the values:

- every reachable one- and two-duck position on 4×7 — 694 of them, in 20ms — gets a legal placement back
- the lookup keys still match the positions they are built from, so a key-format change can't silently drop the bot to its random fallback
- the symmetry inversion returns the mirrored answer for a mirrored position (self-mirror positions excluded, where both an answer and its mirror are optimal and the book names one)

The two tables are exported so the spec can walk them.

**Worth being explicit about the limit:** because the key tests read the expected value from the same table, they verify the *wiring*, not the generated numbers — corrupting an entry to another legal square is not caught. The comment in the spec says so rather than leaving a reader to assume more. Genuinely validating the values would need an offline job re-running the generator, which feels like the right home for it if it's wanted.

## Verification

- `npm test` green: 155 files, 1455 tests (+9), suite duration unchanged at ~12s.
- Stable across repeated runs. The match-based tests carry explicit 20s timeouts — the default 5s tripped intermittently, which is the same reason the variant is excluded from the sweep.
- Mutation-checked: breaking `invertTransformation` fails two of the new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Lg8UokewKvCAACeyKGChz

---
_Generated by [Claude Code](https://claude.ai/code/session_012Lg8UokewKvCAACeyKGChz)_