### PR TITLE
Cover the five-squares and ropes-10 bots, which had no spec of any kind

### DIFF
--- a/src/components/games/distinct-squares/five-squares/bot-strategy.spec.ts
+++ b/src/components/games/distinct-squares/five-squares/bot-strategy.spec.ts
@@ -1,0 +1,74 @@
+import { range, uniq } from 'lodash';
+import { runMatch, type MatchResult } from '../../../strategy-game-factory';
+import { moves, generateStartBoard, type Board } from './gameplay';
+import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
+import { makeCtx } from '../../../../test-utils';
+
+const startBoardOn = (square: number): Board => {
+  const board = Array(5).fill(0);
+  board[square] = 1;
+  return board;
+};
+
+// Play a real game through the engine: the same moves, validator and win
+// detection the site runs on.
+const play = (
+  board: Board, strategies: [typeof smartBotStrategy, typeof smartBotStrategy]
+): MatchResult<Board> => runMatch({ gameplay: { moves }, strategies, startBoard: board });
+
+const namedSquares = (strategy: typeof smartBotStrategy, board: Board, currentPlayer: number) => {
+  const named = strategy({ board, ctx: makeCtx({ currentPlayer }) });
+  return (Array.isArray(named) ? named : [named]).map(({ args }) => args![0] as number);
+};
+
+// The second player wins exactly when the ten pieces end up spread over five
+// distinct counts, and with best play they always can — from every start square,
+// so that is the side whose optimality can be asserted. The first player is
+// already lost and can only win on a mistake.
+describe('smartBotStrategy', () => {
+  // The minimax runs unmemoised over the whole game tree, which is why
+  // FiveSquares[1] is listed out of plays-to-an-end.spec.ts; five matches is
+  // the exhaustive argument here, since the start board is one piece on one of
+  // the five squares.
+  it('wins as the replier from every start square in optimal-vs-optimal play', () => {
+    for (const square of range(5)) {
+      const { winnerIndex, board } = play(startBoardOn(square), [smartBotStrategy, smartBotStrategy]);
+      expect(winnerIndex).toBe(1);
+      // its win condition, read off the final board rather than assumed
+      expect(uniq(board).length).toBe(5);
+    }
+  }, 20000);
+
+  it('wins as the replier against the random bot', () => {
+    for (let trial = 0; trial < 3; trial++) {
+      expect(play(generateStartBoard(), [randomBotStrategy, smartBotStrategy]).winnerIndex).toBe(1);
+    }
+  }, 20000);
+});
+
+// A turn is one placement for the first player and two for the second, and the
+// bots name a whole turn at once — so the count of names, not just their
+// values, is part of the contract the engine plays out.
+describe.each([
+  ['smartBotStrategy', smartBotStrategy],
+  ['randomBotStrategy', randomBotStrategy]
+])('%s', (_name, strategy) => {
+  // late enough that the smart bot's search is shallow: these are about the
+  // shape of what it names, not which square it picks
+  const latePosition: Board = [2, 2, 1, 1, 1];
+
+  it('names one placement as the first player and two as the second', () => {
+    expect(namedSquares(strategy, latePosition, 0)).toHaveLength(1);
+    expect(namedSquares(strategy, latePosition, 1)).toHaveLength(2);
+  });
+
+  it('only ever names a square that exists', () => {
+    for (const currentPlayer of [0, 1]) {
+      for (const square of namedSquares(strategy, latePosition, currentPlayer)) {
+        expect(Number.isInteger(square)).toBe(true);
+        expect(square).toBeGreaterThanOrEqual(0);
+        expect(square).toBeLessThan(5);
+      }
+    }
+  });
+});

--- a/src/components/games/totem-poles/triangular-grid-ropes-10/bot-strategy.spec.ts
+++ b/src/components/games/totem-poles/triangular-grid-ropes-10/bot-strategy.spec.ts
@@ -1,0 +1,88 @@
+import { isEqual } from 'lodash';
+import { runMatch, type MatchResult } from '../../../strategy-game-factory';
+import {
+  getAllowedMoves, isAllowed, edgeDirection, mirrorNodes, moves, type Board, type Edge
+} from './gameplay';
+import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
+import { botNextMoveArgs, makeCtx } from '../../../../test-utils';
+
+// Play a real game through the engine: the same moves, validator and win
+// detection the site runs on.
+const play = (
+  strategies: [typeof smartBotStrategy, typeof smartBotStrategy]
+): MatchResult<Board> =>
+  runMatch({ gameplay: { moves }, strategies, startBoard: [] as Board });
+
+// A bot reads its own seat off ctx.chosenRoleIndex, which holds the seat the
+// human took — so the mover is the bot whose human sits second.
+const askMover = (board: Board): Edge =>
+  botNextMoveArgs(smartBotStrategy({ board, ctx: makeCtx({ currentPlayer: 0, chosenRoleIndex: 1 }) }))[0];
+
+const mirrorOf = (direction: keyof typeof mirrorNodes, { from, to }: Edge): Edge =>
+  ({ from: mirrorNodes[direction][from]!, to: mirrorNodes[direction][to]! });
+
+const isSameEdge = (a: Edge, b: Edge) => isEqual(a, b) || isEqual(a, { from: b.to, to: b.from });
+
+const SYMMETRY_OPENINGS: Edge[] = [{ from: 3, to: 5 }, { from: 1, to: 8 }, { from: 2, to: 7 }];
+
+// The mover wins this grid, by opening on a symmetry axis and answering into
+// it; the replier is lost and can only win on a mistake. The searching half of
+// the strategy runs unmemoised, which is why TriangularGridRopes[1] is listed
+// out of plays-to-an-end.spec.ts, so these play a few games rather than sweep.
+describe('smartBotStrategy', () => {
+  it('wins as the mover against the random bot', () => {
+    for (let trial = 0; trial < 3; trial++) {
+      expect(play([smartBotStrategy, randomBotStrategy]).winnerIndex).toBe(0);
+    }
+  }, 20000);
+
+  // This also runs the searching half of the strategy, which is what the bot
+  // uses from the replier's seat. Nothing is asserted about the replier
+  // winning: that seat is lost, and once the search finds no winning move the
+  // bot falls back to a random legal one — so against a random opponent it
+  // wins only when that opponent errs, which is not every game.
+  it('wins as the mover in optimal-vs-optimal play', () => {
+    expect(play([smartBotStrategy, smartBotStrategy]).winnerIndex).toBe(0);
+  }, 20000);
+});
+
+// As the mover the bot never searches: it opens on an axis and keeps the
+// position balanced, which is cheap enough to state exhaustively.
+describe('the mirroring half of the strategy', () => {
+  it('opens on one of the three symmetry axes', () => {
+    for (let trial = 0; trial < 20; trial++) {
+      const opened = askMover([]);
+      expect(SYMMETRY_OPENINGS.some(opening => isSameEdge(opened, opening))).toBe(true);
+    }
+  });
+
+  it('answers an axis reply on the axis, and every other reply with its mirror', () => {
+    for (const opening of SYMMETRY_OPENINGS) {
+      const direction = edgeDirection(opening)!;
+
+      for (const reply of getAllowedMoves([opening])) {
+        const answer = askMover([opening, reply]);
+        expect(isAllowed([opening, reply], answer)).toBe(true);
+
+        if (edgeDirection(reply) === direction) {
+          // an axis edge has no free mirror to answer with — another axis edge
+          // is what keeps the count even
+          expect(edgeDirection(answer)).toBe(direction);
+        } else {
+          expect(isSameEdge(answer, mirrorOf(direction, reply))).toBe(true);
+        }
+      }
+    }
+  });
+});
+
+describe('randomBotStrategy', () => {
+  it('only ever names an edge the game allows', () => {
+    let board: Board = [];
+    while (getAllowedMoves(board).length > 0) {
+      const edge = botNextMoveArgs(randomBotStrategy({ board, ctx: makeCtx({ currentPlayer: 0 }) }))[0];
+      expect(isAllowed(board, edge)).toBe(true);
+      board = [...board, edge];
+    }
+  });
+});


### PR DESCRIPTION
The remaining zero-coverage bots from §4a of `docs/project-review-2026-08.md`, after #403 (chess-ducks). Two games in one PR since it is the same shape of work.

`FiveSquares[1]` and `TriangularGridRopes[1]` are listed out of `plays-to-an-end.spec.ts` because their bots search, and the comment there says what the sweep loses is "coverage that bot's own spec has". Neither had one. **With #403 that claim becomes true of every variant the set lists** — I checked all ten.

## five-squares

A second-player win from every start square, so that seat's optimality is the assertable one. The smart bot wins as the replier from all five starts in optimal-vs-optimal play — five matches is the exhaustive argument, since the start board is one piece on one of five squares. The final board is checked to be all-distinct, which is its *actual* win condition, rather than trusting the winner index alone.

Also pinned: the shape of a named turn — one placement for the first player, two for the second — since the engine plays those out as a unit and a miscount would be a real bug.

## ropes-10

A mover win, by opening on a symmetry axis and answering into it. That mirroring half never searches, so it is stated exhaustively: for all three openings and every one of the 36 replies, an axis reply is answered on the axis and every other reply with its exact mirror. That also proves the `console.error('Unexpected state, falling back')` path is unreachable from those positions.

Worth noting for the engine: this bot reads `ctx.chosenRoleIndex` to work out which seat it holds, and `runMatch`'s per-turn rewrite of that field gives it the right answer in both seats. The divergence I flagged in §5 of the review doc is benign here.

## What is deliberately not claimed

Nothing about either bot from its losing seat. Once ropes-10's search finds no winning move it falls back to a random legal one, so it beats the random bot only when that bot errs — not every game. An earlier draft asserted it always did and was flaky; the comment now records why that assertion cannot exist.

## Verification

- `npm test` green: 156 files, 1457 tests (+11). Both specs stable across repeated isolated runs and 14 consecutive full-suite runs.
- Match-based tests carry explicit 20s timeouts; the default 5s is not enough for a searching bot, which is the same reason these variants are excluded from the sweep.
- One transient failure appeared in a single full-suite run and did not recur in the 14 runs after it, so I could not identify it; it looks like a timeout under parallel load rather than a logic fault, but I would rather flag it than claim it away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Lg8UokewKvCAACeyKGChz

---
_Generated by [Claude Code](https://claude.ai/code/session_012Lg8UokewKvCAACeyKGChz)_