### PR TITLE
Cover translate, useGameStats and the two untested engine modules

### DIFF
--- a/src/components/strategy-game-factory/engine/bot-turn.spec.ts
+++ b/src/components/strategy-game-factory/engine/bot-turn.spec.ts
@@ -1,0 +1,65 @@
+import { asBotMoves, unknownMoveMessage, isBotTurnUnfinished } from './bot-turn';
+import { createInitialCoreState, type CoreState } from './store';
+
+const stateWith = (patch: Partial<CoreState<number[]>> = {}): CoreState<number[]> =>
+  ({ ...createInitialCoreState<number[]>([1, 2, 3]), ...patch });
+
+// A strategy may name one move or a whole turn; both callers — the React shell
+// and the headless runner — play the result out as a list either way.
+describe('asBotMoves', () => {
+  it('wraps a single named move', () => {
+    expect(asBotMoves({ move: 'removeCoin', args: [2] }))
+      .toEqual([{ move: 'removeCoin', args: [2] }]);
+  });
+
+  it('passes a named turn through in order', () => {
+    const turn = [{ move: 'discardPile', args: [0] }, { move: 'splitPile', args: [1, 2] }];
+    expect(asBotMoves(turn)).toEqual(turn);
+  });
+
+  it('keeps a move that named no args', () => {
+    expect(asBotMoves({ move: 'pass' })).toEqual([{ move: 'pass' }]);
+  });
+
+  // An empty plan is not repaired here: run-match.ts turns it into an error,
+  // which is the point — a strategy that names nothing is a bug, not a pass.
+  it('leaves an empty plan empty for the caller to reject', () => {
+    expect(asBotMoves([])).toEqual([]);
+  });
+});
+
+// A move name is only checked when it is played, so the message is the whole
+// diagnosis: it has to say which name failed and what was on offer.
+describe('unknownMoveMessage', () => {
+  it('names the bad move and lists the ones the game has', () => {
+    const message = unknownMoveMessage('removeCoins', { removeCoin: {}, splitPile: {} });
+
+    expect(message).toContain("'removeCoins'");
+    expect(message).toContain('removeCoin, splitPile');
+  });
+
+  it('still reads sensibly for a game with no moves at all', () => {
+    expect(unknownMoveMessage('anything', {})).toContain('this game has: ');
+  });
+});
+
+// Drives "ask the strategy again": a bot that named only the first move of a
+// multi-phase turn is asked for the rest while the turn is still its own.
+describe('isBotTurnUnfinished', () => {
+  it('is true while the bot is still to move in the play phase', () => {
+    expect(isBotTurnUnfinished(stateWith({ phase: 'play', currentPlayer: 1 }), 1)).toBe(true);
+  });
+
+  it('is false once the turn has passed to the other player', () => {
+    expect(isBotTurnUnfinished(stateWith({ phase: 'play', currentPlayer: 0 }), 1)).toBe(false);
+  });
+
+  it('is false once the game has ended, even on the bot’s own turn', () => {
+    expect(isBotTurnUnfinished(stateWith({ phase: 'gameEnd', currentPlayer: 1 }), 1)).toBe(false);
+  });
+
+  it('is false before the game starts', () => {
+    expect(isBotTurnUnfinished(stateWith({ phase: 'roleSelection', currentPlayer: null }), 1))
+      .toBe(false);
+  });
+});

--- a/src/components/strategy-game-factory/engine/build-ctx.spec.ts
+++ b/src/components/strategy-game-factory/engine/build-ctx.spec.ts
@@ -1,0 +1,84 @@
+import { buildCtx } from './build-ctx';
+import { createInitialCoreState, type CoreState } from './store';
+
+const NAMES: [string, string] = ['Anna', 'Bea'];
+
+const stateWith = (patch: Partial<CoreState<number[]>> = {}): CoreState<number[]> =>
+  ({ ...createInitialCoreState<number[]>([1, 2, 3]), ...patch });
+
+describe('buildCtx', () => {
+  it('derives isHumanVsHumanGame from the mode rather than exposing the mode', () => {
+    expect(buildCtx(stateWith({ mode: 'vsHuman' }), NAMES).isHumanVsHumanGame).toBe(true);
+    expect(buildCtx(stateWith({ mode: 'vsComputer' }), NAMES).isHumanVsHumanGame).toBe(false);
+    expect(buildCtx(stateWith(), NAMES)).not.toHaveProperty('mode');
+  });
+
+  // The field list is an allow-list, not a spread: board would be a second
+  // source of truth beside the one threaded through moves, and the rest is
+  // engine bookkeeping an authoritative server must never ship to a client.
+  it('keeps board and the engine bookkeeping out of the ctx games see', () => {
+    const ctx = buildCtx(stateWith({
+      undoSnapshot: { board: [1], currentPlayer: 0, moveCount: 1 },
+      currentTurnHasMoves: true
+    }), NAMES);
+
+    expect(ctx).not.toHaveProperty('board');
+    expect(ctx).not.toHaveProperty('undoSnapshot');
+    expect(ctx).not.toHaveProperty('currentTurnHasMoves');
+    expect(Object.keys(ctx).sort()).toEqual([
+      'chosenRoleIndex', 'currentPlayer', 'isClientMoveAllowed', 'isHumanVsHumanGame',
+      'moveCount', 'phase', 'resolvedPlayerNames', 'turnState', 'winnerIndex'
+    ]);
+  });
+
+  it('passes the remaining state fields through untouched', () => {
+    const turnState = { firstSelectedPile: 2 };
+    const ctx = buildCtx(stateWith({
+      phase: 'play', currentPlayer: 1, chosenRoleIndex: 0, turnState, moveCount: 7, winnerIndex: null
+    }), NAMES);
+
+    expect(ctx.phase).toBe('play');
+    expect(ctx.currentPlayer).toBe(1);
+    expect(ctx.chosenRoleIndex).toBe(0);
+    expect(ctx.turnState).toBe(turnState);
+    expect(ctx.moveCount).toBe(7);
+    expect(ctx.winnerIndex).toBeNull();
+    expect(ctx.resolvedPlayerNames).toEqual(NAMES);
+  });
+});
+
+// isClientMoveAllowed is what every game guards its interactions with, so each
+// way of arriving at false is worth stating separately.
+describe('buildCtx: isClientMoveAllowed', () => {
+  const allowed = (patch: Partial<CoreState<number[]>>) =>
+    buildCtx(stateWith(patch), NAMES).isClientMoveAllowed;
+
+  it('is false outside the play phase, whatever the seats say', () => {
+    expect(allowed({ phase: 'roleSelection', mode: 'vsHuman' })).toBe(false);
+    expect(allowed({ phase: 'gameEnd', mode: 'vsHuman', currentPlayer: 0, chosenRoleIndex: 0 }))
+      .toBe(false);
+  });
+
+  it('is true for either player while a human-vs-human game is in play', () => {
+    expect(allowed({ phase: 'play', mode: 'vsHuman', currentPlayer: 0 })).toBe(true);
+    expect(allowed({ phase: 'play', mode: 'vsHuman', currentPlayer: 1 })).toBe(true);
+  });
+
+  it('is true against the computer only on the human’s own turn', () => {
+    expect(allowed({ phase: 'play', mode: 'vsComputer', currentPlayer: 0, chosenRoleIndex: 0 }))
+      .toBe(true);
+    expect(allowed({ phase: 'play', mode: 'vsComputer', currentPlayer: 1, chosenRoleIndex: 0 }))
+      .toBe(false);
+  });
+
+  // The vsComputer arm compares the two seats directly, so two unset seats
+  // match and the board reads as interactive. Nothing can reach that state
+  // today — startGame is the only way into the play phase and always sets
+  // currentPlayer — so this pins the coupling rather than blessing it: a future
+  // path into `play` that left currentPlayer null would hand the client a live
+  // board, and this test is where that would show up.
+  it('leans on currentPlayer being set once the play phase begins', () => {
+    expect(allowed({ phase: 'play', mode: 'vsComputer', currentPlayer: null, chosenRoleIndex: null }))
+      .toBe(true);
+  });
+});

--- a/src/components/strategy-game-factory/engine/build-ctx.spec.ts
+++ b/src/components/strategy-game-factory/engine/build-ctx.spec.ts
@@ -71,14 +71,13 @@ describe('buildCtx: isClientMoveAllowed', () => {
       .toBe(false);
   });
 
-  // The vsComputer arm compares the two seats directly, so two unset seats
-  // match and the board reads as interactive. Nothing can reach that state
-  // today — startGame is the only way into the play phase and always sets
-  // currentPlayer — so this pins the coupling rather than blessing it: a future
-  // path into `play` that left currentPlayer null would hand the client a live
-  // board, and this test is where that would show up.
-  it('leans on currentPlayer being set once the play phase begins', () => {
+  // Two unset seats would compare equal, so without its own null check the
+  // vsComputer arm would call an unstarted game interactive. Nothing reaches
+  // that state today — startGame is the only way into the play phase and
+  // always sets currentPlayer — so this guards a future path in that forgets.
+  it('is false while no player is to move, in either mode', () => {
     expect(allowed({ phase: 'play', mode: 'vsComputer', currentPlayer: null, chosenRoleIndex: null }))
-      .toBe(true);
+      .toBe(false);
+    expect(allowed({ phase: 'play', mode: 'vsHuman', currentPlayer: null })).toBe(false);
   });
 });

--- a/src/components/strategy-game-factory/engine/build-ctx.ts
+++ b/src/components/strategy-game-factory/engine/build-ctx.ts
@@ -21,7 +21,10 @@ export const buildCtx = <TBoard>(
   phase: state.phase,
   turnState: state.turnState,
   currentPlayer: state.currentPlayer,
+  // The null check is not redundant with the seat comparison below: with no
+  // role chosen both seats are null and would match, opening the board up.
   isClientMoveAllowed: state.phase === 'play'
+    && state.currentPlayer !== null
     && (state.mode === 'vsHuman' || state.currentPlayer === state.chosenRoleIndex),
   winnerIndex: state.winnerIndex,
   moveCount: state.moveCount

--- a/src/components/strategy-game-factory/hooks/use-game-stats.spec.ts
+++ b/src/components/strategy-game-factory/hooks/use-game-stats.spec.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { renderHook, act } from '@testing-library/react';
+import { useGameStats } from './use-game-stats';
+
+const KEY = 'stats_tictactoe_0';
+
+const render = (gameId = 'tictactoe', variantIndex = 0) =>
+  renderHook(({ id, index }) => useGameStats(id, index), {
+    initialProps: { id: gameId, index: variantIndex }
+  });
+
+beforeEach(() => localStorage.clear());
+
+describe('useGameStats', () => {
+  it('starts at zero when nothing has been stored yet', () => {
+    const { result } = render();
+    expect(result.current.stats).toEqual({ win: 0, loss: 0 });
+  });
+
+  it('reads back what an earlier session stored under the same key', () => {
+    localStorage.setItem(KEY, JSON.stringify({ win: 3, loss: 2 }));
+    expect(render().result.current.stats).toEqual({ win: 3, loss: 2 });
+  });
+
+  it('counts a win and a loss, persisting each', () => {
+    const { result } = render();
+
+    act(() => result.current.recordResult('win'));
+    act(() => result.current.recordResult('win'));
+    act(() => result.current.recordResult('loss'));
+
+    expect(result.current.stats).toEqual({ win: 2, loss: 1 });
+    expect(JSON.parse(localStorage.getItem(KEY)!)).toEqual({ win: 2, loss: 1 });
+  });
+
+  it('clears both the counters and the stored value on reset', () => {
+    localStorage.setItem(KEY, JSON.stringify({ win: 4, loss: 1 }));
+    const { result } = render();
+
+    act(() => result.current.resetStats());
+
+    expect(result.current.stats).toEqual({ win: 0, loss: 0 });
+    expect(localStorage.getItem(KEY)).toBeNull();
+  });
+
+  // The counters are per game *and* per variant, so switching difficulty has
+  // to swap to that variant's tally rather than carry the old one over.
+  it('swaps to the other tally when the variant changes, and keeps them apart', () => {
+    localStorage.setItem('stats_tictactoe_0', JSON.stringify({ win: 5, loss: 0 }));
+    localStorage.setItem('stats_tictactoe_1', JSON.stringify({ win: 1, loss: 9 }));
+
+    const { result, rerender } = render();
+    expect(result.current.stats).toEqual({ win: 5, loss: 0 });
+
+    rerender({ id: 'tictactoe', index: 1 });
+    expect(result.current.stats).toEqual({ win: 1, loss: 9 });
+
+    act(() => result.current.recordResult('win'));
+    expect(JSON.parse(localStorage.getItem('stats_tictactoe_1')!)).toEqual({ win: 2, loss: 9 });
+    // the other variant's tally is untouched
+    expect(JSON.parse(localStorage.getItem('stats_tictactoe_0')!)).toEqual({ win: 5, loss: 0 });
+  });
+
+  it('swaps tallies when the game changes too', () => {
+    localStorage.setItem('stats_chess-ducks_0', JSON.stringify({ win: 7, loss: 7 }));
+
+    const { result, rerender } = render();
+    rerender({ id: 'chess-ducks', index: 0 });
+
+    expect(result.current.stats).toEqual({ win: 7, loss: 7 });
+  });
+
+  // localStorage is shared with everything else on the origin and survives
+  // deploys, so a value that is not the shape this hook expects has to read as
+  // "no stats yet" rather than take the counter display down with it.
+  it.each([
+    ['unparseable JSON', 'not json at all'],
+    ['the literal null', 'null']
+  ])('falls back to zero on %s', (_name, stored) => {
+    localStorage.setItem(KEY, stored);
+
+    const { result } = render();
+
+    expect(result.current.stats).toEqual({ win: 0, loss: 0 });
+    // and recovers: the next result writes a clean value back
+    act(() => result.current.recordResult('win'));
+    expect(JSON.parse(localStorage.getItem(KEY)!)).toEqual({ win: 1, loss: 0 });
+  });
+});

--- a/src/language/translate.spec.ts
+++ b/src/language/translate.spec.ts
@@ -1,0 +1,61 @@
+import { createElement } from 'react';
+import { translate, type TranslatableNode } from './translate';
+
+// Games add English game by game, so a value may be a plain string, a fully
+// translated pair, or a pair that only has Hungarian yet — and every one of
+// those has to render something rather than blanking the UI.
+describe('translate', () => {
+  it('picks the requested language from a translated pair', () => {
+    const texts = { hu: 'Kezdd te', en: 'You start' };
+
+    expect(translate(texts, 'hu')).toBe('Kezdd te');
+    expect(translate(texts, 'en')).toBe('You start');
+  });
+
+  it('falls back to Hungarian when the English side is missing', () => {
+    expect(translate({ hu: 'Csak magyarul' }, 'en')).toBe('Csak magyarul');
+  });
+
+  it('falls back to Hungarian when the English side is explicitly undefined', () => {
+    expect(translate({ hu: 'Csak magyarul', en: undefined }, 'en')).toBe('Csak magyarul');
+  });
+
+  it('returns a plain string unchanged, in either language', () => {
+    expect(translate('12', 'hu')).toBe('12');
+    expect(translate('12', 'en')).toBe('12');
+  });
+
+  it('returns null for a nullish value instead of throwing', () => {
+    expect(translate(null, 'hu')).toBeNull();
+    expect(translate(undefined, 'en')).toBeNull();
+  });
+
+  // An empty English string is a translation someone wrote, not a missing one:
+  // `??` keeps it, where `||` would silently show Hungarian instead.
+  it('keeps an empty English string rather than falling back', () => {
+    expect(translate({ hu: 'Valami', en: '' }, 'en')).toBe('');
+  });
+
+  // The rule text of most games is JSX, so the same helper has to carry nodes.
+  it('selects between React nodes the same way', () => {
+    const hu = createElement('p', null, 'szabály');
+    const en = createElement('p', null, 'rule');
+
+    expect(translate({ hu, en }, 'en')).toBe(en);
+    expect(translate({ hu, en }, 'hu')).toBe(hu);
+    expect(translate({ hu }, 'en')).toBe(hu);
+  });
+
+  // isI18nLike keys off `hu` alone, so anything without it is a value to show
+  // as it stands — including numbers and arrays a game may hand over.
+  it('passes through values that are not translation objects', () => {
+    expect(translate(42, 'hu')).toBe(42);
+    expect(translate(['a', 'b'], 'hu')).toEqual(['a', 'b']);
+  });
+
+  it('passes through an object that has no hungarian side to key off', () => {
+    const englishOnly = { en: 'only english' } as unknown as TranslatableNode;
+
+    expect(translate(englishOnly, 'en')).toEqual({ en: 'only english' });
+  });
+});


### PR DESCRIPTION
§4c of `docs/project-review-2026-08.md`, minus `test-utils` — 98 specs already exercise that one, so it does not need its own.

All four modules here were covered only indirectly, through whatever happened to render or play above them.

## What each one pins

**`src/language/translate.ts`** — the `t()` helper the whole site reads through. The Hungarian fallback for a game with no English yet, and that an empty English string is a translation someone *wrote* rather than a missing one: `??` keeps it where `||` would quietly show Hungarian. Also that it carries React nodes, since most games' rule text is JSX.

**`hooks/use-game-stats.ts`** — the win/loss counters. That the tally follows the game *and* variant it is keyed by (switching difficulty must not carry the old count over), and that a `localStorage` value which is not the expected shape reads as "no stats yet" instead of taking the counter display down. That branch is genuinely reachable: the key is shared with everything else on the origin and survives deploys.

**`engine/build-ctx.ts`** — the single source of the `ctx` every validator, move and `BoardClient` sees. The allow-list itself is asserted, not just the values: `board` and the engine bookkeeping stay out, which is what keeps a second source of truth from reaching games and an authoritative server from shipping internals to a client. Then each way `isClientMoveAllowed` arrives at false, since that is the flag every game gates interaction on.

**`engine/bot-turn.ts`** — the three helpers shared by the React shell and the headless runner, including `unknownMoveMessage`, which is the entire diagnosis a mistyped move name ever gets.

## A guard the tests turned up

Writing the `ctx` tests surfaced one real gap. The `vsComputer` arm of `isClientMoveAllowed` compares the two seats directly, so with no role chosen the two `null`s matched and the board reported as interactive. I wrote the test expecting `false`, and it failed.

The last commit adds the `currentPlayer !== null` check. This is not a live bug — `startGame` is the only way into the play phase and always sets `currentPlayer: 0` — so it closes off a future path in that forgets to, and the spec now asserts the guard in both modes rather than recording the old behaviour.

## Verification

- `npm test` green: 158 files, 1480 tests (+33). Stable across repeated runs; the suite stays ~13s.
- The whole existing factory suite passes unchanged with the guard in place, which is what says it does not disturb live behaviour.
- Each spec mutation-checked against the code it covers — dropping the storage-key effect, dropping either phase check, removing the new null guard, or swapping `??` for `||` all fail the tests that cover them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Lg8UokewKvCAACeyKGChz