### PR TITLE
Gate three BoardClients on their validator instead of restating it

### DIFF
--- a/src/components/games/pile-union/pile-union.tsx
+++ b/src/components/games/pile-union/pile-union.tsx
@@ -36,7 +36,9 @@ const BoardClient = ({ board, ctx, setTurnState, moves }: BoardClientProps<Board
         <MoveTypeSelector
           moveType={moveType}
           isClientMoveAllowed={ctx.isClientMoveAllowed}
-          canMerge={board.length >= 2}
+          // any two distinct piles may merge, so the first pair answers whether
+          // merging is on offer at all
+          canMerge={moves.mergePiles.isAllowed(board, [0, 1])}
           onSelect={(type) => { setMoveType(type); setTurnState(null); }}
         />
       )}

--- a/src/components/games/remove-row-or-column/board-client.tsx
+++ b/src/components/games/remove-row-or-column/board-client.tsx
@@ -54,7 +54,10 @@ export const BoardClient = ({ board, ctx, setTurnState, moves }: BoardClientProp
                         en: `disc row ${r + 1} column ${c + 1}`
                       })}
                       className="size-9 sm:size-11 flex items-center justify-center"
-                      disabled={!ctx.isClientMoveAllowed || !grid[r][c]}
+                      // every disc's row and its column are removable, so either
+                      // orientation answers "can a move start here"; which one it is
+                      // gets chosen on the next click
+                      disabled={!moves.removeLine.isAllowed(board, { r, c, orientation: 'row' })}
                       onClick={() => clickDisc(r, c)}
                     >
                       {grid[r][c] && (

--- a/src/components/games/two-of-three-takeaway/two-of-three-takeaway.tsx
+++ b/src/components/games/two-of-three-takeaway/two-of-three-takeaway.tsx
@@ -53,8 +53,12 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     setFirstSelected(null);
   }, [ctx.moveCount]);
 
+  // A pile can start a move when some other pile can partner it — the pair is
+  // what the validator judges, so ask it rather than restate "not empty".
+  const canTakeFrom = (i: number) => board.some((_, j) => moves.takeChips.isAllowed(board, i, j));
+
   const clickPile = (i: number) => {
-    if (!ctx.isClientMoveAllowed || board[i] === 0) return;
+    if (!canTakeFrom(i)) return;
     if (firstSelected === null) {
       setFirstSelected(i);
       return;
@@ -75,7 +79,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
             count={count}
             index={i}
             selected={firstSelected === i}
-            selectable={ctx.isClientMoveAllowed && count > 0}
+            selectable={canTakeFrom(i)}
             onClick={() => clickPile(i)}
           />
         ))}


### PR DESCRIPTION
The `isAllowed` half of §6 in `docs/project-review-2026-08.md`, after #406 covered the pacing half.

The validate layer is meant to be the single source of legality — the engine enforces it, and a client reads it back through `moves.<name>.isAllowed` to drive `disabled`. Three clients had drifted into restating a piece of it by hand:

- **remove-row-or-column** asked "is there a disc here", which is exactly what `isRemovalAllowed` asks.
- **two-of-three-takeaway** asked "is this pile non-empty", which is only *half* of `isTakeAllowed`. The pair is what the validator judges, so it now asks whether some other pile can partner this one.
- **pile-union** offered the merge mode on `board.length >= 2`, restating what makes a merge legal.

## Correction to the review's count

The review doc listed six. On inspection three of them do not need this, and I would rather say so than convert them for symmetry:

- **chocolate-breaking** and **number-pyramid** already go through `gameplay.ts`'s own `safeBreaks` and `hasActivePair`. Those answer questions a per-move validator cannot — *enumerate the legal cuts*, *is any pair still available in this level* — so they are already single-source, just not through `isAllowed`.
- **pairs-of-numbers** has no validator to route to, because both of its moves are unconditionally legal. The absence is correct, not an omission.

I will fix the count in the review doc if you would like, though it may read better as a note than an edit.

## Verification

- `npm test` green: 1500 tests.
- Driven in the browser as well: all three games load, select and play, with no console errors. two-of-three-takeaway correctly highlights the first pile and prompts for the second.

One small behavioural sharpening in two-of-three-takeaway: a pile with no legal partner is no longer selectable, where `count > 0` would have let you select it and then find nothing to pair it with. That position is terminal anyway, so this is the predicate getting more honest rather than a fix to something users hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Lg8UokewKvCAACeyKGChz

---
_Generated by [Claude Code](https://claude.ai/code/session_012Lg8UokewKvCAACeyKGChz)_