### PR TITLE
Pin the shell and headless bot turns to each other with an agreement test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,13 +225,20 @@ playing it: no move wrappers, no board to thread, no `setTimeout`. Naming a
 whole turn at once is the right shape when the turn is one decision made of
 several moves (`pile-splitter`: discard a pile, split another; `magic-box`:
 place a stone, designate a line); naming one move and being asked again with
-the updated `board`/`ctx` is equally fine (`take-and-point`). The engine
-(`engine/bot-turn.ts`) plays the named moves out — with `STEP_DELAY`
-(`engine/timing.ts`)
-between them in the browser so the bot appears to think, immediately in a
-headless match — and asks the strategy again while the turn is still its own.
-Naming a move after the turn ended is a bug (dev: throw); naming moves the
-game-winning move made moot is fine (they are dropped).
+the updated `board`/`ctx` is equally fine (`take-and-point`). The engine plays
+the named moves out — with `stepDelay()` (`engine/timing.ts`) between them in
+the browser so the bot appears to think, immediately in a headless match — and
+asks the strategy again while the turn is still its own. Naming a move after the
+turn ended is a bug (dev: throw); naming moves the game-winning move made moot
+is fine (they are dropped).
+
+Two hosts play a named turn out: the browser shell in
+`strategy-game-factory.tsx` and the headless runner in `engine/run-match.ts`.
+They differ deliberately in pacing and in how loudly they complain — a bad
+strategy must not crash the site in production, while headless it should throw
+— but *which* moves land has to be identical.
+`engine/bot-turn-agreement.spec.tsx` plays the same turn through both and
+compares, so the two cannot drift apart on what counts as a bug.
 
 Left unpinned, `BotMove` is `{ move: string, args?: unknown[] }`, so neither a
 mistyped name nor wrong arguments surface until the bot plays the move (dev:

--- a/docs/project-review-2026-08.md
+++ b/docs/project-review-2026-08.md
@@ -14,11 +14,13 @@ the legacy move contract, zero React imports in `gameplay.ts` or the engine,
 the themes below, ordered by priority. Each item is sized as a small PR per
 [AGENTS.md § Pull request size](../AGENTS.md#pull-request-size).
 
-Items marked ✅ were fixed on the branch that introduced this document.
+Items marked ✅ have since been fixed; the PR that did it is named inline.
+Where acting on an item showed the review had got it wrong, the correction is
+recorded rather than quietly dropped.
 
 ---
 
-## 1. Docs out of sync with the refactor ✅ (done)
+## 1. Docs out of sync with the refactor ✅ (#398)
 
 - ✅ AGENTS.md placed the factory and `game-parts/` inside
   `src/components/games/`; they live in the sibling
@@ -34,7 +36,7 @@ Items marked ✅ were fixed on the branch that introduced this document.
   the references it anchored (AGENTS.md, README, engine comments) now pointing
   at issue #313.
 
-## 2. Migration leftovers in the toolchain ✅ (done)
+## 2. Migration leftovers in the toolchain ✅ (#398)
 
 `src/` has zero `.js`/`.jsx` files, but the toolchain still catered for them:
 `index.html` loading `/src/main.js`, `allowJs`/`checkJs` in tsconfig, `{js,jsx}`
@@ -44,7 +46,7 @@ Tailwind-v3 `tailwind.config.js`. All removed. (The commented-out
 gitignore entry are *not* leftovers: they document an occasionally-used,
 uncommitted bundle-analysis tool and stay.)
 
-## 3. Type-safety: the pinning is silently hollow for ~40% of moves
+## 3. Type-safety: the pinning is silently hollow for ~40% of moves ✅ (#402)
 
 `tsconfig.json` sets `"noImplicitAny": false` next to `"strict": true`. So an
 unannotated `apply`/`validate` parameter types as `any` — and
@@ -56,16 +58,16 @@ least one untyped move argument (e.g.
 `cube-coloring/gameplay.ts` `{ vertex, color }`,
 `totem-poles/*/gameplay.ts` `{ from, to }`), plus 11 `validate` declarations.
 
-**Plan:** a mechanical sweep annotating the ~49 untyped parameters. No
-behaviour change; typecheck is the review. Whether to then flip
-`"noImplicitAny": true` repo-wide is a separate, open decision — outside move
-signatures the flag may be more noise than value (utils, specs), and annotated
-moves plus review may be enough. Decide after the sweep, when the remaining
-fallout is visible.
+**Done in #402**: the untyped parameters are annotated, so
+`BotStrategy<Board, Moves>` now checks arguments as well as names everywhere.
+
+Whether to then flip `"noImplicitAny": true` repo-wide remains a separate,
+open decision — outside move signatures the flag may be more noise than value
+(utils, specs), and annotated moves plus review may be enough.
 
 ## 4. Test gaps in core logic
 
-### 4a. Bots with zero coverage of any kind (highest value)
+### 4a. Bots with zero coverage of any kind (highest value) ✅ (#403, #404)
 
 `games/plays-to-an-end.spec.ts` excludes slow variants by name, with a comment
 saying what is lost is "coverage that bot's own spec has". For four excluded
@@ -77,10 +79,20 @@ variants that is not true — they have **no bot spec either**:
 | `FiveSquares[1]` | `distinct-squares/five-squares/` | real minimax |
 | `TriangularGridRopes[1]` | `totem-poles/triangular-grid-ropes-10/` | search |
 
-**Plan:** one PR per game adding a `bot-strategy.spec.ts` on the
-`runMatch`-based pattern (`coins-in-3-piles`, `remove-row-or-column`): smart
-bot wins as mover from a winning board and as replier from a losing one.
-Until then, at least correct the sweep's comment.
+**Done** — chess-ducks in #403, five-squares and ropes-10 in #404, on the
+`runMatch`-based pattern (`coins-in-3-piles`, `remove-row-or-column`). Two
+things the work taught, both worth keeping:
+
+- The winners had to be established empirically before anything could be
+  asserted: chess-ducks 4×6 and 4×7 are second-player wins, five-squares is a
+  second-player win from every start square, ropes-10 is a mover win via
+  axis-opening plus mirroring.
+- **chess-ducks' opening books stay unverified**, and the spec says so. One
+  `isWinningState` search from a 3-duck board costs ~4.3 s, so checking the
+  tables against a fresh search is unaffordable — which is exactly why those
+  variants are in `SLOW_VARIANTS` to begin with. The spec asserts the book is
+  self-consistent and that its moves are legal and win real matches; it cannot
+  catch a book that is optimal-looking but wrong.
 
 ### 4b. Other bots with real search but no spec
 
@@ -89,15 +101,20 @@ Until then, at least correct the sweep's comment.
 ~22 spec-less bots are ≤30-line closed forms — acceptable to leave, the sweep
 covers their conformance.
 
-### 4c. Untested shared modules
+### 4c. Untested shared modules — mostly ✅ (#405)
 
-| Module | Why it matters |
-|---|---|
-| `src/test-utils.ts` | 98 specs depend on it; a bug here silently weakens all of them. `botNextMoveArgs` returns `any[]` — worth typing while at it |
-| `src/language/translate.ts` | `t()` used site-wide; the `?? texts.hu` fallback and null guard are a 10-line spec |
-| `strategy-game-factory/hooks/use-game-stats.ts` | corrupt-localStorage fallback and `resetStats` are untested branches |
-| `strategy-game-factory/engine/bot-turn.ts`, `engine/build-ctx.ts` | the only engine modules without a direct spec; `build-ctx` is the single source of `ctx` for every validator |
-| `game-parts/common/game-controls.tsx` | the `notAlwaysOptimal` ⓘ marker logic |
+| Module | Why it matters | Status |
+|---|---|---|
+| `src/language/translate.ts` | `t()` used site-wide; the `?? texts.hu` fallback and null guard are a 10-line spec | ✅ #405 |
+| `strategy-game-factory/hooks/use-game-stats.ts` | corrupt-localStorage fallback and `resetStats` are untested branches | ✅ #405 |
+| `strategy-game-factory/engine/bot-turn.ts`, `engine/build-ctx.ts` | the only engine modules without a direct spec; `build-ctx` is the single source of `ctx` for every validator | ✅ #405 |
+| `src/test-utils.ts` | 98 specs depend on it | declined — a helper this thin is exercised by its 98 callers |
+| `game-parts/common/game-controls.tsx` | the `notAlwaysOptimal` ⓘ marker logic | open |
+
+Writing the `build-ctx` spec turned up a real gap rather than just documenting
+the module: `isClientMoveAllowed` compared `currentPlayer === chosenRoleIndex`
+with both unset, so `null === null` made a move allowed before either seat was
+taken. #405 added the `currentPlayer !== null` guard.
 
 ### 4d. Thin specs
 
@@ -107,16 +124,27 @@ rules specs relative to module size.
 
 ## 5. Engine duplication and readability
 
-- **The bot turn loop exists twice**: `strategy-game-factory.tsx`
-  (`runBotTurn`, with `BOT_STEP_DELAY` pacing) and `engine/run-match.ts`
-  (immediate), with divergent error strings; auto-`endOfTurnMove` scheduling
-  is likewise duplicated. Only three helpers are shared via `engine/bot-turn.ts`.
-  Extracting one shared turn-runner parameterised by a scheduler would make the
-  headless path *provably* the browser path — which is the property the
-  competition effort (issue #313) relies on.
-- `engine/run-match.ts` rewrites `ctx.chosenRoleIndex` every turn; in the
-  browser it is fixed for the whole game. A bot consulting it behaves
-  differently headless. Decide the semantics and align.
+- ~~**The bot turn loop exists twice**~~ — **the review was wrong here**, and
+  the correction is the useful part. `strategy-game-factory.tsx`
+  (`runBotTurn`, paced) and `engine/run-match.ts` (immediate) read differently
+  but had **not** drifted: the "named moves after the turn ended" rule decides
+  the same thing in both. The only observable duplication was one bug producing
+  two different error strings. What differs between them is deliberate —
+  pacing, state access, illegal-move policy (prod warns, headless throws),
+  `endOfTurnMove` scheduling, cancellation, one bot vs two, `maxMoves` — and a
+  turn-runner parameterised over all of it needs a callback bag costing more
+  than it saves. A first attempt at the extraction removed ~6 duplicated lines
+  per host and added 27, and was dropped for that reason.
+
+  What *was* missing is a check that the two stay agreed, which is the property
+  issue #313 actually relies on. #408 adds
+  `engine/bot-turn-agreement.spec.tsx`: the same turn played through both
+  hosts, moves compared — named whole, named one at a time, and won partway
+  with moves left over.
+- ~~`engine/run-match.ts` rewrites `ctx.chosenRoleIndex` every turn~~ — also a
+  false alarm, settled while writing #404. The rewrite is *correct*: it is what
+  lets a bot infer which seat it is holding, and ropes-10's bot (the one that
+  consults it) gets the right answer in both seats. No change needed.
 - `strategy-game-factory.tsx` (378 L) mixes store wiring, illegal-move
   reporting, analytics, player names, timeout management, variant/mode reset,
   bot pacing and layout. Notable hazards: `let wrappedGameMoves = {} as …`
@@ -147,16 +175,20 @@ rules specs relative to module size.
 - **7 copies of `asTurn`**, **7 declarations of `type Field = { row, col }`**
   (4 with a byte-identical validator idiom) — obvious `games/shared/`
   extractions.
-- **6 BoardClients hand-derive legality** instead of `moves.X.isAllowed`
-  (`remove-row-or-column`, `two-of-three-takeaway`, `chocolate-breaking`,
-  `number-pyramid`, `pile-union`, `pairs-of-numbers`) — splits the single
-  source of truth the validate layer just established.
+- ~~**6 BoardClients hand-derive legality**~~ — **3**, not 6 ✅ (#407). The
+  count was overstated: of the six named, `remove-row-or-column`,
+  `two-of-three-takeaway` and `chocolate-breaking` restate their validator, and
+  those now call `moves.X.isAllowed`. The other three gate on something the
+  validator does not cover, so they stay as they are.
 - **4 BoardClients pace a two-move human turn with a raw
-  `setTimeout(…, 750)`** (`three-piles-rebuild`, `pile-splitter`,
-  `pile-splitter-3`, `pile-splitter-4`); none clears the timer, so a restart
-  inside the window dispatches against a dead board. One shared hook (or
-  engine support mirroring `BOT_STEP_DELAY`) fixes the leak and the
-  duplication.
+  `setTimeout(…, 750)`** ✅ (#406) — `three-piles-rebuild`, `pile-splitter`,
+  `pile-splitter-3`, `pile-splitter-4`; none cleared the timer. The leak was
+  real and reproduced in a browser: undoing 150 ms after a click threw
+  `stale board passed to move splitPile`. Restart was quieter only by luck.
+  All four now use `useDeferredMove(ctx.moveCount)`, which cancels on restart,
+  variant switch, undo and unmount. The same PR replaced the `BOT_STEP_DELAY`
+  constant with `stepDelay()`, so a human's second move and a bot's next move
+  share one beat.
 - **Precomputed tables stored two ways**: JSON (`modified-mill`,
   `shark-5-by-5`) vs inline TS (`remove-divisor-multiple/bot-strategy.ts`,
   16,028 lines; `bank-robbers`, 999). Converge on JSON.
@@ -185,27 +217,41 @@ rules specs relative to module size.
 - `package.json`: `postcss` sits in `dependencies` (build-only); `playwright`
   is a devDependency no code uses — it exists to bake Chromium into the
   devcontainer, worth a comment where it's declared.
-- CI: `pr_test.yml` has no `concurrency` group (stacked runs on busy PRs) and
-  no npm cache; the two workflows duplicate their build block verbatim.
+- CI: ~~`pr_test.yml` has no `concurrency` group (stacked runs on busy PRs) and
+  no npm cache~~ ✅ (#401); the two workflows still duplicate their build block
+  verbatim.
 - No path alias for `test-utils` — 97 specs import `../../../test-utils`.
 - 7 `console.*` calls in shipped game code (`triangular-grid-ropes-10`,
   `stones-remove-one-not-twice-from-left`, `cube-coloring`) as "unexpected
   state" fallbacks — arguably should throw in dev like the engine does.
-- No SessionStart hook for web/agent sessions: a fresh clone cannot run
-  tests until `npm ci`; a hook would remove that friction.
+- ~~No SessionStart hook for web/agent sessions~~ ✅ (#399): `npm ci` now runs
+  at session start, guarded by `CLAUDE_CODE_REMOTE` so local sessions are
+  unaffected.
 
 ---
 
 ## Suggested order
 
-| # | Item | Size |
+| # | Item | Status |
 |---|---|---|
-| 1 | ✅ Docs sync (§1) + toolchain leftovers (§2) | done on this branch |
-| 2 | Annotate untyped move args (§3); CI concurrency + cache and a SessionStart hook (§7) | mechanical PRs, in flight |
-| 3 | Bot specs for the four zero-coverage variants (§4a) | 3 small PRs |
-| 4 | Specs for `test-utils`, `translate`, `use-game-stats`, `bot-turn`, `build-ctx` (§4c) | 1–2 small PRs |
-| 5 | Unify the bot turn loop; settle `chosenRoleIndex` semantics (§5) | 1 design PR |
-| 6 | `games/shared/`: win/loss solver, mex, `Field`, `asTurn`; migrate by family (§6) | design PR + sweeps |
-| 7 | Route the 6 hand-gated BoardClients through `isAllowed`; fix the 4 `setTimeout` pacers (§6) | 2 small PRs |
-| 8 | react-hooks lint, quotes rule (§7) | small PRs |
-| 9 | Factory component/spec split, `turnState` generic, table-storage convergence, naming sweeps | opportunistic |
+| 1 | Docs sync (§1) + toolchain leftovers (§2) | ✅ #398 |
+| 2 | Annotate untyped move args (§3) | ✅ #402 |
+| 3 | SessionStart hook, CI concurrency + cache (§7) | ✅ #399, #401 |
+| 4 | Bot specs for the four zero-coverage variants (§4a) | ✅ #403, #404 |
+| 5 | Specs for `translate`, `use-game-stats`, `bot-turn`, `build-ctx` (§4c) | ✅ #405 |
+| 6 | Hand-gated BoardClients through `isAllowed`; the `setTimeout` pacers (§6) | ✅ #407, #406 |
+| 7 | Bot turn loop and `chosenRoleIndex` (§5) | ✅ #408 — both premises were false; landed as an agreement test |
+| 8 | `games/shared/`: win/loss solver, mex, `Field`, `asTurn`; migrate by family (§6) | deferred — worth more evidence before committing to an abstraction |
+| 9 | react-hooks lint, quotes rule (§7) | open, small PRs |
+| 10 | Factory component/spec split, `turnState` generic, table-storage convergence, naming sweeps | opportunistic |
+
+Remaining open items worth a line: `game-controls.tsx`'s ⓘ marker (§4c), the
+bots with real search but no spec (§4b), thin rules specs (§4d), and everything
+in §5 below the first two bullets — the 378-line factory component, the
+`turnState` generic, the 1050-line factory spec.
+
+**On the review's own accuracy**: of the items acted on, three claims did not
+survive contact — the bot turn loops had not drifted (§5), `chosenRoleIndex`
+was not divergent (§5), and the hand-gated BoardClient count was 3 rather than
+6 (§6). Worth weighing when reading the items nobody has picked up yet,
+particularly §6's duplication counts, which were gathered the same way.

--- a/src/components/strategy-game-factory/engine/bot-turn-agreement.spec.tsx
+++ b/src/components/strategy-game-factory/engine/bot-turn-agreement.spec.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { render, fireEvent, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { strategyGameFactory, type StrategyGameConfig } from '../strategy-game-factory';
+import { runMatch } from './run-match';
+import type { BotMove, BotStrategy, Ctx, Gameplay, MoveOutcome } from '../types';
+
+// The React shell and the headless runner play a named turn out separately —
+// one paced by a timer, one straight through. What they must never disagree on
+// is *which* moves get played. This plays the same turn through both and
+// compares; it is the standing check behind engine/bot-turn.ts, where the
+// sequencing decisions live precisely so that these two cannot drift apart.
+
+type Board = number
+
+// A turn is three takes long: the move keeps the turn open until the third, and
+// the sixth take ends the game so a headless match terminates.
+const makeGameplay = (log: string[], winsOnSecond = false): Gameplay<Board> => ({
+  moves: {
+    take: {
+      apply: (board: Board, { ctx }: { ctx: Ctx }, mark: string): MoveOutcome<Board> => {
+        log.push(mark);
+        const nextBoard = board + 1;
+        if (winsOnSecond && nextBoard === 2) {
+          return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
+        }
+        if (nextBoard === 6) return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
+        if (nextBoard % 3 === 0) return { nextBoard, isTurnEnd: true };
+        return { nextBoard };
+      }
+    }
+  }
+});
+
+const wholeTurn: BotMove[] = [
+  { move: 'take', args: ['a'] }, { move: 'take', args: ['b'] }, { move: 'take', args: ['c'] }
+];
+
+// Two shapes the bot contract allows: name the whole turn, or name one move and
+// be asked again while the turn is still yours.
+const namesWholeTurn: BotStrategy<Board> = () => wholeTurn;
+const namesOneAtATime: BotStrategy<Board> = ({ board }) => wholeTurn[board % 3]!;
+
+const BoardClient = () => <div data-testid="board" />;
+
+const shellConfig = (
+  gameplay: Gameplay<Board>, botStrategy: BotStrategy<Board>
+): StrategyGameConfig<Board> => ({
+  presentation: { rule: <></>, getPlayerStepDescription: () => '' },
+  BoardClient,
+  gameplay,
+  variants: [{ botStrategy, generateStartBoard: (): Board => 0 }]
+});
+
+// The bot's opening turn as the browser plays it: the human takes seat 1, so
+// the bot holds seat 0 and moves first. The human never answers, so what the
+// log holds afterwards is exactly that one turn.
+const playOpeningTurnInShell = (gameplay: Gameplay<Board>, strategy: BotStrategy<Board>) => {
+  const Game = strategyGameFactory(shellConfig(gameplay, strategy));
+  const { getByTestId } = render(<MemoryRouter><Game /></MemoryRouter>);
+  fireEvent.click(getByTestId('role-btn-1'));
+  // a beat per move, plus room for the ask-again round trips
+  act(() => { vi.advanceTimersByTime(6000); });
+};
+
+const playHeadless = (gameplay: Gameplay<Board>, strategy: BotStrategy<Board>) => {
+  runMatch({ gameplay, strategies: [strategy, strategy], startBoard: 0 });
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  // stepDelay() spreads the beat; pinning it keeps the timer advance exact
+  vi.spyOn(Math, 'random').mockReturnValue(0);
+});
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
+
+describe.each([
+  ['a turn named whole', namesWholeTurn],
+  ['a turn named one move at a time', namesOneAtATime]
+])('%s', (_name, strategy) => {
+  it('plays the same moves in the shell as headless', () => {
+    const headlessLog: string[] = [];
+    playHeadless(makeGameplay(headlessLog), strategy);
+
+    const shellLog: string[] = [];
+    playOpeningTurnInShell(makeGameplay(shellLog), strategy);
+
+    expect(shellLog).toEqual(['a', 'b', 'c']);
+    // the headless match plays on past the opening turn; its first three are it
+    expect(headlessLog.slice(0, 3)).toEqual(shellLog);
+  });
+});
+
+// The interesting divergence risk: a planned turn that wins partway leaves
+// moves behind, and both callers have to drop them rather than call it a bug.
+describe('a turn that wins partway through', () => {
+  it('drops the moves the win made moot, in both', () => {
+    const headlessLog: string[] = [];
+    playHeadless(makeGameplay(headlessLog, true), namesWholeTurn);
+
+    const shellLog: string[] = [];
+    playOpeningTurnInShell(makeGameplay(shellLog, true), namesWholeTurn);
+
+    expect(shellLog).toEqual(['a', 'b']);
+    expect(headlessLog).toEqual(shellLog);
+  });
+});

--- a/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
@@ -690,6 +690,7 @@ describe('move validate enforcement', () => {
   const playTwoPhaseBotTurn = (extraMs = 0) => {
     vi.useFakeTimers();
     try {
+      vi.spyOn(Math, 'random').mockReturnValue(0); // pin the spread beat to 750ms
       const { getByTestId } = renderGame(twoPhaseBotConfig());
       fireEvent.click(getByTestId('role-btn-1')); // human is 2nd player → bot moves first
       act(() => { vi.advanceTimersByTime(1500); }); // bot "thinking" delay → phase1
@@ -949,6 +950,7 @@ describe('outcome-returning moves (apply)', () => {
     it('validates the second move of a bot turn against current ctx.moveCount', () => {
       vi.useFakeTimers();
       try {
+        vi.spyOn(Math, 'random').mockReturnValue(0); // pin the spread beat to 750ms
         const config = makeConfig({
           BoardClient: ({ board }: BoardClientProps<Board>) => (
             <span data-testid="board">{board.join(',')}</span>


### PR DESCRIPTION
§5 of `docs/project-review-2026-08.md`, scoped down to what it turned out to be worth — plus a pass over the review doc itself, and a flake fix CI turned up along the way.

## What §5 got wrong

It assumed the two bot-turn loops had drifted. They hadn't. The browser shell and `run-match`'s headless loop read differently, but the "named moves after the turn ended" rule decides the same thing in both, and #404 already confirmed `runMatch`'s per-turn `chosenRoleIndex` rewrite is correct rather than divergent. The only observable duplication was one bug producing two different error strings.

What genuinely differs between the hosts is deliberate: pacing, state access, illegal/unknown-move policy, `endOfTurnMove` scheduling, cancellation, one bot vs two, history, `maxMoves`. A unified `runBotTurn` over all of that needs a callback bag to keep prod-warn and headless-throw apart, and costs more than it saves.

So there was no dedup worth doing. What was missing is a check that they *stay* agreed.

## Commit 1 — the agreement test

Adds `engine/bot-turn-agreement.spec.tsx`, **no production change**. It plays the same turn through both hosts and compares the moves that land:

- a turn named whole
- a turn named one move at a time (the ask-again round trip)
- a turn that wins partway and leaves moves behind

Mutation-checked against both hosts, so it isn't decorative:

| mutation | host | result |
|---|---|---|
| drop the rest of a named turn | shell | all 3 fail |
| remove only the ask-again round trip | shell | 1 fails (named-one-at-a-time) |
| treat moves made moot by a win as a bug | shell | 1 fails (wins-partway) |
| same, on the headless side | `run-match` | 1 fails (wins-partway) |

An earlier version of this PR also factored the shared continuation decision into `continueAfterMove` in `engine/bot-turn.ts`. It removed ~6 duplicated lines per host and added 27, so production code grew 28 lines net — czeildi called that out, correctly, and it is gone. The helper's only real argument was that one decision gets one name; the drift protection comes from the test, which is black-box and passes against the un-refactored hosts unchanged.

`AGENTS.md` now names the two hosts, says which differences are deliberate, and points at the spec. It also picks up a stale `STEP_DELAY` → `stepDelay()` reference in the same paragraph.

## Commit 2 — the review doc

No code. Every item acted on since #398 is marked with the PR that did it, and the three claims that did not survive contact are corrected in place rather than quietly deleted:

- the bot turn loops had not drifted (§5)
- `run-match`'s `chosenRoleIndex` rewrite is correct, not divergent (§5)
- **3** BoardClients hand-derived legality, not 6 (§6)

It also records two things the work taught that outlived their items: chess-ducks' opening books cannot be affordably verified (~4.3 s per `isWinningState` search, which is why those variants are in `SLOW_VARIANTS`), and the `build-ctx` spec found a real gap rather than just documenting the module (`null === null` allowed a move before either seat was taken).

`games/shared/` (§6) is marked deferred per your call. Since the review's counts there were gathered the same way as the ones that turned out wrong, the doc says so — worth re-verifying before anyone builds on them.

## Commit 3 — a flake on `main`, not from this PR

CI went red on the docs-only commit, which was the tell. `strategy-game-factory.spec.tsx` has two tests that advance timers by `1500` then `750` for a two-move bot turn. That was exact while the pause was the `BOT_STEP_DELAY` constant; **#406 replaced it with `stepDelay()`'s 750–1250 ms spread**, so the second move only lands when the two beats sum under 2250 — roughly 7 runs in 8.

Confirmed rather than assumed: `git diff origin/main HEAD -- src/` on this branch is *only* the new spec file, so both the production code and that spec are byte-identical to main; and the test failed 2 times in 8 runs on the unmodified branch, matching the predicted ~12.5%.

Fixed by pinning `Math.random`, which is what the same file already does at its other two fixed-beat assertions. Audited every timer-advancing spec in the repo — exactly two were exposed; the rest advance 1500+ (above the 1250 ceiling), pin already, or assert a negative where the delay cannot matter.

## Verification

Lint, typecheck, and full suite green — 163 files, 1510 tests (+3). Factory spec run 12× and the full suite 5× to confirm the flake is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Lg8UokewKvCAACeyKGChz

---
_Generated by [Claude Code](https://claude.ai/code/session_012Lg8UokewKvCAACeyKGChz)_