### PR TITLE
Extract move-scoped state logic into useMoveScopedState hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,6 +283,29 @@ state without going through a move, deliberately: a selection is not a move, so
 it must not bump `moveCount` or take an undo snapshot. Moves never get it; they
 return `nextTurnState` instead.
 
+**`useMoveScopedState(ctx.moveCount, initial)`** — for a `BoardClient`'s own
+mid-turn UI state: a half-made selection, a pending set of removals. The value
+is stamped with the `moveCount` at which it was set and exposed only while that
+stamp holds, so any move discards it during the next render.
+
+Do not clear such state with `useEffect(() => setX(initial), [ctx.moveCount])`.
+That repairs it one render too late — the browser paints a frame with the old
+selection over the advanced board — and it is a reset every component has to
+remember rather than a property of the state itself.
+
+```tsx
+const [selectedCell, setSelectedCell] = useMoveScopedState<number | null>(ctx.moveCount, null);
+```
+
+Two things to get right: `initial` is handed back on every stale render, so a
+non-primitive must be one stable reference (hoist it to module scope, never
+`[]` inline); and mid-turn state the *engine* has to see — anything
+`getPlayerStepDescription` reads — belongs in `ctx.turnState` instead, since
+this hook is local to the component.
+
+`useHoverPreview(ctx.moveCount)` is this hook plus pointer/focus plumbing, so
+board previews get the same invalidation for free.
+
 **`useDeferredMove(ctx.moveCount)`** — for a `BoardClient` whose single click
 submits a whole turn made of two moves (`pile-splitter`, `three-piles-rebuild`).
 Dispatch the first move, then hand the second to the returned function: it plays

--- a/src/components/games/four-piles-two-grabs/four-piles-two-grabs.tsx
+++ b/src/components/games/four-piles-two-grabs/four-piles-two-grabs.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react';
 import { range } from 'lodash';
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import {
+  strategyGameFactory, useMoveScopedState, type BoardClientProps, GameBoard
+} from '../../strategy-game-factory';
 import { useTranslation } from '../../../language';
 import { generateStartBoard, moves, type Board, type Move } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
@@ -74,16 +75,14 @@ const Pile = ({ count, index, removeCount, canAdd, disabled, onInc, onDec }: {
   );
 };
 
+// module scope: useMoveScopedState hands this back on every render where the
+// stamp is stale, so it has to be one stable reference
 const emptyRemovals: Move = [0, 0, 0, 0];
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
-  const [removals, setRemovals] = useState<Move>(emptyRemovals);
-
-  // Reset the in-progress selection whenever the board advances (own or bot move).
-  useEffect(() => {
-    setRemovals(emptyRemovals);
-  }, [ctx.moveCount]);
+  // Move-scoped: the in-progress removals are gone once the board advances.
+  const [removals, setRemovals] = useMoveScopedState<Move>(ctx.moveCount, emptyRemovals);
 
   const activeCount = removals.filter(r => r > 0).length;
   const readyToMove = moves.takeStones.isAllowed(board, removals);

--- a/src/components/games/latin-square-filling/latin-square-filling.tsx
+++ b/src/components/games/latin-square-filling/latin-square-filling.tsx
@@ -1,17 +1,14 @@
-import { useEffect, useState } from 'react';
-import { strategyGameFactory, type BoardClientProps, type Ctx, GameBoard } from '../../strategy-game-factory';
+import {
+  strategyGameFactory, useMoveScopedState, type BoardClientProps, type Ctx, GameBoard
+} from '../../strategy-game-factory';
 import { useTranslation } from '../../../language';
 import { generateStartBoard, moves, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
-  const [selectedCell, setSelectedCell] = useState<number | null>(null);
-
-  // Clear the pending selection whenever the board advances (own or bot move).
-  useEffect(() => {
-    setSelectedCell(null);
-  }, [ctx.moveCount]);
+  // Move-scoped: the pending selection is gone once the board advances.
+  const [selectedCell, setSelectedCell] = useMoveScopedState<number | null>(ctx.moveCount, null);
 
   const clickCell = (cell: number) => {
     if (!ctx.isClientMoveAllowed || board[cell] !== 0) return;

--- a/src/components/strategy-game-factory/hooks/use-hover-preview.ts
+++ b/src/components/strategy-game-factory/hooks/use-hover-preview.ts
@@ -1,14 +1,13 @@
-import { useState } from 'react';
+import { useMoveScopedState } from './use-move-scoped-state';
 
 /**
  * Move-scoped hover state for board previews.
  *
- * A hover is stamped with the `moveCount` at which it was set, and the derived
- * `value` is exposed only while that stamp still matches the current
- * `moveCount`. Any move bumps `moveCount`, so a stale hover is invalidated on
- * the very next render — no effect and no explicit reset call. This is what
- * stops a preview from "sticking" after a move on touch devices, where no
- * `pointerleave` fires (the original reason the `moveCount` guard was added).
+ * The hover is `useMoveScopedState` (which owns the moveCount stamping) plus
+ * the pointer/focus plumbing: any move invalidates the preview on the very
+ * next render, which is what stops one from "sticking" after a move on touch
+ * devices, where no `pointerleave` fires (the original reason the `moveCount`
+ * guard was added).
  *
  * Pass `ctx.moveCount` from a BoardClient, or a `moveCount` prop when the hover
  * lives inside a repeated child component.
@@ -24,12 +23,9 @@ import { useState } from 'react';
  * the same moveCount stamp, so they are invalidated by the next move too.
  */
 export function useHoverPreview<T>(moveCount: number) {
-  const [hovered, setHovered] = useState<{ value: T; moveCount: number } | null>(null);
+  const [value, setHovered, clear] = useMoveScopedState<T | null>(moveCount, null);
 
-  const value = hovered?.moveCount === moveCount ? hovered.value : null;
-
-  const set = (v: T) => setHovered({ value: v, moveCount });
-  const clear = () => setHovered(null);
+  const set = (v: T) => setHovered(v);
 
   const hoverProps = (v: T) => ({
     onPointerEnter: () => set(v),

--- a/src/components/strategy-game-factory/hooks/use-move-scoped-state.spec.ts
+++ b/src/components/strategy-game-factory/hooks/use-move-scoped-state.spec.ts
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { renderHook, act } from '@testing-library/react';
+import { useMoveScopedState } from './use-move-scoped-state';
+
+const render = <T,>(initial: T, moveCount = 0) =>
+  renderHook(
+    ({ count }) => useMoveScopedState<T>(count, initial),
+    { initialProps: { count: moveCount } }
+  );
+
+describe('useMoveScopedState', () => {
+  it('starts at the initial value', () => {
+    const { result } = render<number | null>(null);
+    expect(result.current[0]).toBeNull();
+  });
+
+  it('holds a value set during the same move', () => {
+    const { result } = render<number | null>(null, 3);
+
+    act(() => result.current[1](7));
+
+    expect(result.current[0]).toBe(7);
+  });
+
+  // The whole point: no effect runs, so there is no render in which the old
+  // value is visible against the new board.
+  it('drops the value as soon as the move count advances', () => {
+    const { result, rerender } = render<number | null>(null, 3);
+
+    act(() => result.current[1](7));
+    rerender({ count: 4 });
+
+    expect(result.current[0]).toBeNull();
+  });
+
+  it('can be set again under the new move count', () => {
+    const { result, rerender } = render<number | null>(null, 3);
+
+    act(() => result.current[1](7));
+    rerender({ count: 4 });
+    act(() => result.current[1](9));
+
+    expect(result.current[0]).toBe(9);
+  });
+
+  it('resets on demand, for a deselect that is not a move', () => {
+    const { result } = render<number | null>(null, 2);
+
+    act(() => result.current[1](5));
+    act(() => result.current[2]());
+
+    expect(result.current[0]).toBeNull();
+  });
+
+  describe('the updater form', () => {
+    it('sees the current value, so a toggle works', () => {
+      const { result } = render<number | null>(null, 1);
+
+      act(() => result.current[1](5));
+      act(() => result.current[1](prev => (prev === 5 ? null : 5)));
+
+      expect(result.current[0]).toBeNull();
+    });
+
+    // Reading the raw state instead of reading it through the stamp would hand
+    // the updater the value the move just invalidated — a toggle on the same
+    // cell would then deselect instead of selecting.
+    it('sees the initial value after a move, not the invalidated one', () => {
+      const { result, rerender } = render<number | null>(null, 1);
+
+      act(() => result.current[1](5));
+      rerender({ count: 2 }); // the move that invalidates it
+      act(() => result.current[1](prev => (prev === 5 ? null : 5)));
+
+      expect(result.current[0]).toBe(5);
+    });
+
+    it('composes two updates dispatched in one handler', () => {
+      const { result } = render(0, 1);
+
+      act(() => {
+        result.current[1](prev => prev + 1);
+        result.current[1](prev => prev + 1);
+      });
+
+      expect(result.current[0]).toBe(2);
+    });
+  });
+
+  // A stale render returns `initial` itself rather than a copy, so a caller
+  // that hoists it to module scope keeps a stable reference across moves.
+  it('returns the same initial reference on every stale render', () => {
+    const initial = [0, 0, 0, 0];
+    const { result, rerender } = renderHook(
+      ({ count }) => useMoveScopedState(count, initial),
+      { initialProps: { count: 1 } }
+    );
+
+    act(() => result.current[1]([1, 0, 0, 0]));
+    rerender({ count: 2 });
+    const afterOneMove = result.current[0];
+    rerender({ count: 3 });
+
+    expect(afterOneMove).toBe(initial);
+    expect(result.current[0]).toBe(initial);
+  });
+});

--- a/src/components/strategy-game-factory/hooks/use-move-scoped-state.ts
+++ b/src/components/strategy-game-factory/hooks/use-move-scoped-state.ts
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+
+/**
+ * State that lives for exactly one move.
+ *
+ * The value is stamped with the `moveCount` at which it was set, and is
+ * exposed only while that stamp still matches. Any move bumps `moveCount`, so
+ * a value set under the previous one is gone on the very next render — no
+ * effect, no reset call, and no frame in which a stale selection is painted
+ * over an advanced board.
+ *
+ * This is the alternative to `useEffect(() => setX(initial), [ctx.moveCount])`,
+ * which repairs the state one render too late and has to be remembered on
+ * every component that keeps mid-turn UI state.
+ *
+ * Pass `ctx.moveCount` from a BoardClient, or a `moveCount` prop when the
+ * state lives inside a repeated child component.
+ *
+ * `initial` is returned whenever the stamp is stale, so it must be a stable
+ * reference — hoist a non-primitive to module scope rather than writing `[]`
+ * or `{}` inline, which would hand out a fresh object on every such render.
+ *
+ * For mid-turn state the *engine* has to see — anything
+ * `getPlayerStepDescription` reads — use `ctx.turnState` and `setTurnState`
+ * instead. This hook is local to the component.
+ */
+export function useMoveScopedState<T>(moveCount: number, initial: T) {
+  const [stamped, setStamped] = useState<{ value: T; moveCount: number } | null>(null);
+
+  const value = stamped?.moveCount === moveCount ? stamped.value : initial;
+
+  // The updater form reads through the stamp rather than the raw state, so a
+  // toggle written as `set(prev => ...)` sees `initial` after a move rather
+  // than the value that move invalidated. Deriving it inside setStamped (not
+  // from `value` above) also keeps two set calls in one handler correct.
+  const set = (next: T | ((prev: T) => T)) =>
+    setStamped(stale => {
+      const current = stale?.moveCount === moveCount ? stale.value : initial;
+      const resolved = typeof next === 'function' ? (next as (prev: T) => T)(current) : next;
+      return { value: resolved, moveCount };
+    });
+
+  const reset = () => setStamped(null);
+
+  return [value, set, reset] as const;
+}

--- a/src/components/strategy-game-factory/index.ts
+++ b/src/components/strategy-game-factory/index.ts
@@ -10,4 +10,5 @@ export { runMatch } from './engine/run-match';
 export type { MatchMove, MatchResult } from './engine/run-match';
 export { GameBoard } from './game-parts/game-board';
 export { useHoverPreview } from './hooks/use-hover-preview';
+export { useMoveScopedState } from './hooks/use-move-scoped-state';
 export { useDeferredMove } from './hooks/use-deferred-move';


### PR DESCRIPTION
## Summary
Extracts the move-scoped state pattern into a reusable `useMoveScopedState` hook, eliminating the need for manual `useEffect` cleanup in components that maintain mid-turn UI state. This ensures state is invalidated immediately on the next render when a move advances, preventing stale selections from being painted over an advanced board.

## Key Changes
- **New hook: `useMoveScopedState`** — A custom hook that stamps state with the current `moveCount` and automatically invalidates it when the move count changes, without requiring `useEffect` or explicit reset calls
  - Includes comprehensive test suite covering value persistence, invalidation, updater functions, and reference stability
  - Properly handles updater functions by reading through the stamp to see the correct previous value after a move

- **Refactored `useHoverPreview`** — Now built on top of `useMoveScopedState`, removing duplicate moveCount stamping logic while maintaining the same behavior for board preview invalidation

- **Updated game components** — Replaced manual `useState` + `useEffect` patterns with `useMoveScopedState`:
  - `four-piles-two-grabs`: Removed `useEffect` that reset removals on moveCount change
  - `latin-square-filling`: Removed `useEffect` that cleared selectedCell on moveCount change

- **Documentation** — Added comprehensive AGENTS.md entry explaining the hook's purpose, usage patterns, and common pitfalls (stable reference requirement, distinction from `ctx.turnState`)

## Notable Implementation Details
- The hook returns the `initial` reference itself on stale renders, allowing callers to hoist non-primitives to module scope for stable references across moves
- Updater functions read through the stamp rather than raw state, ensuring correct behavior for toggles and composed updates after a move
- No effects or explicit resets needed — invalidation happens automatically during the next render when moveCount changes

https://claude.ai/code/session_012Lg8UokewKvCAACeyKGChz