### PR TITLE
Replace useState+useEffect with useMoveScopedState for UI state

### DIFF
--- a/src/components/games/matches-on-edges/board-client.tsx
+++ b/src/components/games/matches-on-edges/board-client.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react';
 import { range } from 'lodash';
 import { useTranslation } from '../../../language';
-import { GameBoard, type BoardClientProps, useHoverPreview } from '../../strategy-game-factory';
+import {
+  GameBoard, type BoardClientProps, useHoverPreview, useMoveScopedState
+} from '../../strategy-game-factory';
 import { type Board, boundaryEdgesToPlace, currentWindowSize } from './gameplay';
 
 const Matchstick = ({ ghost = false }: { ghost?: boolean }) => (
@@ -35,14 +36,10 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const isValidStart = (a: number) =>
     k !== null && moves.placeWindow.isAllowed(board, a, a + k - 1);
 
-  const [selectedStart, setSelectedStart] = useState<number | null>(null);
+  // Both are move-scoped: the selection and the hover preview expire together
+  // when the board advances (own or bot move).
+  const [selectedStart, setSelectedStart] = useMoveScopedState<number | null>(ctx.moveCount, null);
   const { value: hoverStart, hoverProps } = useHoverPreview<number>(ctx.moveCount);
-
-  // Drop the in-progress selection whenever the board advances (own or bot
-  // move). The hover preview needs no reset: its moveCount stamp expires.
-  useEffect(() => {
-    setSelectedStart(null);
-  }, [ctx.moveCount]);
 
   const canInteract = ctx.isClientMoveAllowed;
   const previewStart = canInteract ? (hoverStart ?? selectedStart) : null;

--- a/src/components/games/recolouring-discs/board-client.tsx
+++ b/src/components/games/recolouring-discs/board-client.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { range } from 'lodash';
 import { useTranslation } from '../../../language';
-import { GameBoard, type BoardClientProps } from '../../strategy-game-factory';
+import { GameBoard, type BoardClientProps, useMoveScopedState } from '../../strategy-game-factory';
 import { type Board, type Cell, colorOf } from './gameplay';
 
 // Translucent version of each disc colour, used for the recolour pulse ring.
@@ -37,10 +37,8 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const myColor = ctx.currentPlayer === null ? null : colorOf(ctx.currentPlayer);
   const canInteract = ctx.isClientMoveAllowed && myColor !== null;
 
-  const [selectedFrom, setSelectedFrom] = useState<number | null>(null);
-
-  // Drop any in-progress selection whenever the board advances.
-  useEffect(() => setSelectedFrom(null), [ctx.moveCount]);
+  // Move-scoped: any in-progress selection expires when the board advances.
+  const [selectedFrom, setSelectedFrom] = useMoveScopedState<number | null>(ctx.moveCount, null);
 
   // Pulse discs that were just recoloured (a cell that held a disc and now holds
   // the opposite colour) so the flip is easy to spot. We diff against the

--- a/src/components/games/take-and-point/board-client.tsx
+++ b/src/components/games/take-and-point/board-client.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useState } from 'react';
 import { range } from 'lodash';
 import { useTranslation } from '../../../language';
-import { GameBoard, type BoardClientProps } from '../../strategy-game-factory';
+import { GameBoard, type BoardClientProps, useMoveScopedState } from '../../strategy-game-factory';
 import { type Board, requiredPointCount } from './gameplay';
 
 const Chips = ({ count, removeCount = 0 }: { count: number; removeCount?: number }) => (
@@ -50,19 +49,21 @@ const pileClass = (highlighted: boolean, pointed: boolean, empty: boolean) => `
   ${empty ? 'opacity-40' : ''}
 `;
 
+type Removal = { index: number; amount: number } | null
+
+// module scope: useMoveScopedState hands this back on every render where the
+// stamp is stale, so it has to be one stable reference
+const nonePointed: number[] = [];
+
 export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
   const { piles, pointed } = board;
   const stage: 'point' | 'remove' = pointed === null ? 'point' : 'remove';
 
-  const [selectedForPoint, setSelectedForPoint] = useState<number[]>([]);
-  const [removal, setRemoval] = useState<{ index: number; amount: number } | null>(null);
-
-  // Reset the in-progress selection whenever the board advances (own or bot move).
-  useEffect(() => {
-    setSelectedForPoint([]);
-    setRemoval(null);
-  }, [ctx.moveCount]);
+  // Move-scoped: both halves of the in-progress selection expire when the board
+  // advances (own or bot move).
+  const [selectedForPoint, setSelectedForPoint] = useMoveScopedState<number[]>(ctx.moveCount, nonePointed);
+  const [removal, setRemoval] = useMoveScopedState<Removal>(ctx.moveCount, null);
 
   const canInteract = ctx.isClientMoveAllowed;
   const pointCount = requiredPointCount(piles);

--- a/src/components/games/three-piles-rebuild/three-piles-rebuild.tsx
+++ b/src/components/games/three-piles-rebuild/three-piles-rebuild.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useState } from 'react';
 import {
-  strategyGameFactory, type BoardClientProps, GameBoard, useDeferredMove
+  strategyGameFactory, type BoardClientProps, GameBoard, useDeferredMove, useMoveScopedState
 } from '../../strategy-game-factory';
 import { useTranslation } from '../../../language';
 import {
@@ -21,17 +20,19 @@ const parsePart = (raw: string): number | null => {
   return value >= 1 ? value : null;
 };
 
+type Inputs = { p1: string; p2: string }
+
+// module scope: useMoveScopedState hands this back on every render where the
+// stamp is stale, so it has to be one stable reference
+const emptyInputs: Inputs = { p1: '', p2: '' };
+
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
   const deferMove = useDeferredMove(ctx.moveCount);
-  const [keepId, setKeepId] = useState<number | null>(null);
-  const [inputs, setInputs] = useState<{ p1: string; p2: string }>({ p1: '', p2: '' });
-
-  // Reset the in-progress selection whenever the board advances (own or bot move).
-  useEffect(() => {
-    setKeepId(null);
-    setInputs({ p1: '', p2: '' });
-  }, [ctx.moveCount]);
+  // Move-scoped: the kept pile and the typed parts expire when the board
+  // advances (own or bot move).
+  const [keepId, setKeepId] = useMoveScopedState<number | null>(ctx.moveCount, null);
+  const [inputs, setInputs] = useMoveScopedState<Inputs>(ctx.moveCount, emptyInputs);
 
   // Between keepPile and splitPile the two discarded piles are 0 — the board is
   // frozen mid-move (own animation beat or the bot's first step).
@@ -42,7 +43,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   // rather than relying on the engine silently ignoring the dispatch.
   const clickPile = (pileId: number) => {
     if (!moves.keepPile.isAllowed(board, pileId)) return;
-    setInputs({ p1: '', p2: '' });
+    setInputs(emptyInputs);
     setKeepId(prev => (prev === pileId ? null : pileId));
   };
 
@@ -62,7 +63,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     // split it into the three new piles.
     const { nextBoard } = moves.keepPile(board, keepId);
     setKeepId(null);
-    setInputs({ p1: '', p2: '' });
+    setInputs(emptyInputs);
     deferMove(() => moves.splitPile(nextBoard, parts));
   };
 

--- a/src/components/games/triangle-circle-game/board-client.tsx
+++ b/src/components/games/triangle-circle-game/board-client.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useState } from 'react';
 import { useTranslation } from '../../../language';
-import { GameBoard, type BoardClientProps } from '../../strategy-game-factory';
+import { GameBoard, type BoardClientProps, useHoverPreview } from '../../strategy-game-factory';
 import { BOARD_OUTLINE, EDGES, TRIANGLES, type Edge } from './geometry';
 import { type Board } from './gameplay';
 
@@ -20,11 +19,8 @@ const insetEdge = (edge: Edge) => ({
 
 export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
-  const [hoveredEdge, setHoveredEdge] = useState<number | null>(null);
-
-  useEffect(() => {
-    setHoveredEdge(null);
-  }, [ctx.moveCount]);
+  // The preview is move-scoped, so shading an edge clears it without a reset.
+  const { value: hoveredEdge, hoverProps } = useHoverPreview<number>(ctx.moveCount);
 
   const triangleClickable = (t: number) => moves.placeCircle.isAllowed(board, t);
 
@@ -133,10 +129,7 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
               strokeLinecap="round"
               className="cursor-pointer outline-none"
               onClick={() => moves.shadeEdge(board, edge.id)}
-              onMouseEnter={() => setHoveredEdge(edge.id)}
-              onMouseLeave={() => setHoveredEdge(null)}
-              onFocus={() => setHoveredEdge(edge.id)}
-              onBlur={() => setHoveredEdge(null)}
+              {...hoverProps(edge.id)}
               onKeyUp={event => { if (event.key === 'Enter') moves.shadeEdge(board, edge.id); }}
               tabIndex={0}
               role="button"

--- a/src/components/games/two-of-three-takeaway/two-of-three-takeaway.tsx
+++ b/src/components/games/two-of-three-takeaway/two-of-three-takeaway.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react';
 import { range } from 'lodash';
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import {
+  strategyGameFactory, useMoveScopedState, type BoardClientProps, GameBoard
+} from '../../strategy-game-factory';
 import { useTranslation } from '../../../language';
 import { generateStartBoard, moves, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
@@ -46,12 +47,8 @@ const Pile = ({ count, index, selected, selectable, onClick }: {
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
-  const [firstSelected, setFirstSelected] = useState<number | null>(null);
-
-  // Reset the in-progress selection whenever the board advances (own or bot move).
-  useEffect(() => {
-    setFirstSelected(null);
-  }, [ctx.moveCount]);
+  // Move-scoped: the in-progress selection expires when the board advances.
+  const [firstSelected, setFirstSelected] = useMoveScopedState<number | null>(ctx.moveCount, null);
 
   // A pile can start a move when some other pile can partner it — the pair is
   // what the validator judges, so ask it rather than restate "not empty".


### PR DESCRIPTION
## Summary
Refactored multiple game board components to use the `useMoveScopedState` hook instead of manually managing state resets with `useState` and `useEffect`. This eliminates boilerplate code and provides a cleaner, more declarative way to handle UI state that should reset when the game board advances.

## Key Changes
- **three-piles-rebuild**: Replaced `useState` + `useEffect` for `keepId` and `inputs` with `useMoveScopedState`
- **take-and-point**: Replaced `useState` + `useEffect` for `selectedForPoint` and `removal` with `useMoveScopedState`
- **matches-on-edges**: Replaced `useState` + `useEffect` for `selectedStart` with `useMoveScopedState`
- **triangle-circle-game**: Replaced `useState` + `useEffect` for `hoveredEdge` with `useHoverPreview` hook
- **two-of-three-takeaway**: Replaced `useState` + `useEffect` for `firstSelected` with `useMoveScopedState`
- **recolouring-discs**: Replaced `useState` + `useEffect` for `selectedFrom` with `useMoveScopedState`

## Implementation Details
- Removed direct imports of `useEffect` and `useState` from React where they're no longer needed
- Added imports of `useMoveScopedState` and `useHoverPreview` from the strategy-game-factory
- Created module-scoped constant references (e.g., `emptyInputs`, `nonePointed`) for default values to ensure stable object references across renders
- Added clarifying comments explaining the move-scoped behavior and why these constants must be stable references
- The `useHoverPreview` hook in triangle-circle-game provides both the state value and event handler props, further reducing boilerplate

https://claude.ai/code/session_012Lg8UokewKvCAACeyKGChz