### PR TITLE
Remove effects that re-seed state from props

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,14 +5,8 @@ import tsPlugin from '@typescript-eslint/eslint-plugin';
 
 export default [
   {
-    // Hook rules, on as errors. `rules-of-hooks` had nothing to fix; the other
-    // two are what the move-scoped-state work (#409/#410) cleared the way for —
-    // state derived from a prop belongs in the render, not in an effect that
-    // repairs it one frame later. The single remaining suppression is in
-    // language-context.tsx, which says why it earns one.
     files: ['src/**/*.{ts,tsx}'],
     plugins: { 'react-hooks': reactHooks },
-    languageOptions: { parser: tsParser, parserOptions: { ecmaFeatures: { jsx: true } } },
     rules: {
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'error',
@@ -60,7 +54,6 @@ export default [
     // run in plain Node. See issue #313.
     files: ['src/components/games/**/gameplay.ts', 'src/components/strategy-game-factory/engine/**/*.ts'],
     plugins: { '@typescript-eslint': tsPlugin },
-    languageOptions: { parser: tsParser },
     rules: {
       '@typescript-eslint/no-restricted-imports': ['error', {
         patterns: [

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,8 +1,24 @@
 import reactPlugin from '@eslint-react/eslint-plugin';
+import reactHooks from 'eslint-plugin-react-hooks';
 import tsParser from '@typescript-eslint/parser';
 import tsPlugin from '@typescript-eslint/eslint-plugin';
 
 export default [
+  {
+    // Hook rules, on as errors. `rules-of-hooks` had nothing to fix; the other
+    // two are what the move-scoped-state work (#409/#410) cleared the way for —
+    // state derived from a prop belongs in the render, not in an effect that
+    // repairs it one frame later. The single remaining suppression is in
+    // language-context.tsx, which says why it earns one.
+    files: ['src/**/*.{ts,tsx}'],
+    plugins: { 'react-hooks': reactHooks },
+    languageOptions: { parser: tsParser, parserOptions: { ecmaFeatures: { jsx: true } } },
+    rules: {
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'error',
+      'react-hooks/set-state-in-effect': 'error'
+    }
+  },
   {
     files: ['src/**/*.{ts,tsx}'],
     plugins: { '@eslint-react': reactPlugin },

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@typescript-eslint/parser": "8.65.0",
         "@vitejs/plugin-react": "6.0.4",
         "eslint": "10.8.0",
+        "eslint-plugin-react-hooks": "7.1.1",
         "jsdom": "29.1.1",
         "playwright": "1.62.0",
         "typescript": "6.0.3",
@@ -116,12 +117,168 @@
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -132,9 +289,48 @@
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -143,6 +339,54 @@
       "integrity": "sha512-t3yaEOuGu9NlIZ+hIeGbBjFtZT7j2cb2tg0fuaJKeGotchRjjLfrBA9Kwf8quhpP1EUuxModQg04q/mBwyg8uA==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2141,6 +2385,19 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+      "integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -2170,6 +2427,61 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -2354,6 +2666,13 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.401",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.401.tgz",
+      "integrity": "sha512-H6ViHN68nGYlChEvlIU67fn8O2/tpbWQPwck98yaJmh+08LSvHiydzDQ6oXNccLU3kNRVIRS9A4mA7CG+i6fLQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.24.3",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
@@ -2386,6 +2705,16 @@
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -2479,6 +2808,26 @@
       "peerDependencies": {
         "eslint": "*",
         "typescript": "*"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-react-jsx": {
@@ -2830,6 +3179,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2856,6 +3215,23 @@
       "peer": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -2937,8 +3313,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/jsdom": {
       "version": "29.1.1",
@@ -2981,6 +3356,19 @@
         }
       }
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -2999,6 +3387,19 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -3374,6 +3775,16 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.52",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.52.tgz",
+      "integrity": "sha512-MRlTqhAfoMx/4mhEbPo3Hi02g9LJZaJkka69V6h67Cb1gjrAG0jsTE4CZX1eptNx+VCAwJmfpnDIF4P0Nh1A7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -3974,6 +4385,37 @@
         "node": ">=20.18.1"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -4258,6 +4700,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -4278,6 +4727,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@typescript-eslint/parser": "8.65.0",
     "@vitejs/plugin-react": "6.0.4",
     "eslint": "10.8.0",
+    "eslint-plugin-react-hooks": "7.1.1",
     "jsdom": "29.1.1",
     "playwright": "1.62.0",
     "typescript": "6.0.3",

--- a/src/components/strategy-game-factory/game-parts/game-end-dialog.spec.tsx
+++ b/src/components/strategy-game-factory/game-parts/game-end-dialog.spec.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { useState } from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { GameEndDialog } from './game-end-dialog';
+import type { Ctx, Variant } from '../types';
+
+// The dialog offers a *draft* mode/variant that only takes effect on "new
+// game". Abandoning the dialog has to discard the draft, which is why the
+// controls live in a child `Dialog` unmounts rather than in state the parent
+// keeps and re-seeds with an effect.
+
+const ctxWith = (isHumanVsHumanGame: boolean): Ctx => ({
+  isHumanVsHumanGame,
+  resolvedPlayerNames: ['Anna', 'Bea'],
+  chosenRoleIndex: 0,
+  phase: 'gameEnd',
+  turnState: null,
+  currentPlayer: 0,
+  isClientMoveAllowed: false,
+  winnerIndex: 0,
+  moveCount: 4
+});
+
+const variants: Variant[] = [
+  { originalIndex: 0, label: { hu: 'Könnyű', en: 'Easy' }, disabled: false } as Variant,
+  { originalIndex: 1, label: { hu: 'Nehéz', en: 'Hard' }, disabled: false } as Variant
+];
+
+const Harness = ({ isHumanVsHumanGame = false }: { isHumanVsHumanGame?: boolean }) => {
+  const [isOpen, setIsOpen] = useState(true);
+  return (
+    <>
+      <button data-testid="reopen" onClick={() => setIsOpen(true)}>reopen</button>
+      <GameEndDialog
+        isOpen={isOpen}
+        setIsOpen={setIsOpen}
+        ctx={ctxWith(isHumanVsHumanGame)}
+        selectedVariantIndex={0}
+        getVariantsForMode={() => variants}
+        onNewGame={() => {}}
+      />
+    </>
+  );
+};
+
+describe('GameEndDialog', () => {
+  it('seeds the draft mode from the game that just ended', () => {
+    const { getByTestId } = render(<Harness isHumanVsHumanGame />);
+
+    expect((getByTestId('mode-vsHuman') as HTMLInputElement).checked).toBe(true);
+  });
+
+  it('lets the player draft a different mode', () => {
+    const { getByTestId } = render(<Harness />);
+
+    fireEvent.click(getByTestId('mode-vsHuman'));
+
+    expect((getByTestId('mode-vsHuman') as HTMLInputElement).checked).toBe(true);
+  });
+
+  // The behaviour the removed effect existed for: a draft the player walked
+  // away from must not come back the next time the dialog opens.
+  it('discards an abandoned draft when reopened', async () => {
+    const { getByTestId, queryByTestId, getByText, findByTestId } = render(<Harness />);
+
+    fireEvent.click(getByTestId('mode-vsHuman'));
+    expect((getByTestId('mode-vsHuman') as HTMLInputElement).checked).toBe(true);
+
+    // Closing unmounts the controls, which is what discards the draft.
+    fireEvent.click(getByText('×'));
+    await waitFor(() => expect(queryByTestId('mode-vsHuman')).toBeNull());
+
+    fireEvent.click(getByTestId('reopen'));
+
+    expect(((await findByTestId('mode-vsComputer')) as HTMLInputElement).checked).toBe(true);
+    expect((getByTestId('mode-vsHuman') as HTMLInputElement).checked).toBe(false);
+  });
+});

--- a/src/components/strategy-game-factory/game-parts/game-end-dialog.tsx
+++ b/src/components/strategy-game-factory/game-parts/game-end-dialog.tsx
@@ -1,9 +1,64 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { Dialog, DialogPanel, DialogTitle, Description } from '@headlessui/react';
 import { useTranslation } from '../../../language';
 import { ModeSelector, DifficultySelector } from './common/game-controls';
 import { getCtaText } from './common/cta-text';
 import type { Ctx, Variant, Mode } from '../types';
+
+// The mode/variant a player picks here is a draft: it only takes effect on "new
+// game", and abandoning the dialog must discard it. That reset is what mounting
+// buys us — `Dialog` renders nothing while closed, so this component is created
+// fresh on each open and its useState seeds from the live game. Holding the
+// draft in the parent instead would need an effect to re-seed it, which repairs
+// the state a render after the dialog is already on screen.
+const NewGameControls = ({
+  ctx, selectedVariantIndex, getVariantsForMode, onNewGame
+}: {
+  ctx: Ctx
+  selectedVariantIndex: number
+  getVariantsForMode: (mode: Mode) => Variant[]
+  onNewGame: (mode: Mode, variantIndex: number) => void
+}) => {
+  const { t } = useTranslation();
+  const [localMode, setLocalMode] = useState<Mode>(ctx.isHumanVsHumanGame ? 'vsHuman' : 'vsComputer');
+  const [localVariantIndex, setLocalVariantIndex] = useState(selectedVariantIndex);
+
+  const localVariants = getVariantsForMode(localMode);
+
+  const handleModeChange = (newMode: Mode) => {
+    const newVariants = getVariantsForMode(newMode);
+    setLocalMode(newMode);
+    const stillAvailable = newVariants.find(v => v.originalIndex === localVariantIndex && !v.disabled);
+    if (!stillAvailable) {
+      const firstEnabled = newVariants.find(v => !v.disabled);
+      setLocalVariantIndex(firstEnabled?.originalIndex ?? newVariants[0]?.originalIndex ?? 0);
+    }
+  };
+
+  return (
+    <div className="rounded-lg border bg-surface-elevated p-3 flex flex-col gap-3">
+      <ModeSelector
+        isHumanVsHumanGame={localMode === 'vsHuman'}
+        onSwitchMode={handleModeChange}
+        disabled={false}
+      />
+      {localVariants.length > 1 && (
+        <DifficultySelector
+          variants={localVariants}
+          selectedIndex={localVariantIndex}
+          onSelect={setLocalVariantIndex}
+          disabled={false}
+        />
+      )}
+      <button
+        onClick={() => onNewGame(localMode, localVariantIndex)}
+        className="primary-button"
+      >
+        {t({ hu: 'Új játék', en: 'New game' })}
+      </button>
+    </div>
+  );
+};
 
 export const GameEndDialog = ({
   isOpen, setIsOpen, ctx,
@@ -17,27 +72,6 @@ export const GameEndDialog = ({
   onNewGame: (mode: Mode, variantIndex: number) => void
 }) => {
   const { t } = useTranslation();
-  const [localMode, setLocalMode] = useState<Mode>(ctx.isHumanVsHumanGame ? 'vsHuman' : 'vsComputer');
-  const [localVariantIndex, setLocalVariantIndex] = useState(selectedVariantIndex);
-
-  useEffect(() => {
-    if (isOpen) {
-      setLocalMode(ctx.isHumanVsHumanGame ? 'vsHuman' : 'vsComputer');
-      setLocalVariantIndex(selectedVariantIndex);
-    }
-  }, [isOpen, ctx.isHumanVsHumanGame, selectedVariantIndex]);
-
-  const localVariants = getVariantsForMode(localMode);
-
-  const handleModeChange = (newMode: Mode) => {
-    const newVariants = getVariantsForMode(newMode);
-    setLocalMode(newMode);
-    const stillAvailable = newVariants.find(v => v.originalIndex === localVariantIndex && !v.disabled);
-    if (!stillAvailable) {
-      const firstEnabled = newVariants.find(v => !v.disabled);
-      setLocalVariantIndex(firstEnabled?.originalIndex ?? newVariants[0]?.originalIndex ?? 0);
-    }
-  };
 
   return (
     <Dialog
@@ -62,27 +96,12 @@ export const GameEndDialog = ({
           <Description className="text-base sm:text-lg block text-justify mb-2">
             {t(getCtaText(ctx))}
           </Description>
-          <div className="rounded-lg border bg-surface-elevated p-3 flex flex-col gap-3">
-            <ModeSelector
-              isHumanVsHumanGame={localMode === 'vsHuman'}
-              onSwitchMode={handleModeChange}
-              disabled={false}
-            />
-            {localVariants.length > 1 && (
-              <DifficultySelector
-                variants={localVariants}
-                selectedIndex={localVariantIndex}
-                onSelect={setLocalVariantIndex}
-                disabled={false}
-              />
-            )}
-            <button
-              onClick={() => onNewGame(localMode, localVariantIndex)}
-              className="primary-button"
-            >
-              {t({ hu: 'Új játék', en: 'New game' })}
-            </button>
-          </div>
+          <NewGameControls
+            ctx={ctx}
+            selectedVariantIndex={selectedVariantIndex}
+            getVariantsForMode={getVariantsForMode}
+            onNewGame={onNewGame}
+          />
         </DialogPanel>
       </div>
     </Dialog>

--- a/src/components/strategy-game-factory/hooks/use-game-stats.ts
+++ b/src/components/strategy-game-factory/hooks/use-game-stats.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 
 export interface Stats { win: number; loss: number }
 
@@ -15,23 +15,25 @@ const readStats = (key: string): Stats => {
 export const useGameStats = (gameId: string, variantIndex: number) => {
   const storageKey = `stats_${gameId}_${variantIndex}`;
 
-  const [stats, setStats] = useState<Stats>(() => readStats(storageKey));
-
-  useEffect(() => {
-    setStats(readStats(storageKey));
-  }, [storageKey]);
+  // Stamped with the key it was read for, the same shape as
+  // useMoveScopedState: switching variant reads the new key during render, so
+  // the previous variant's counts are never shown for a frame. An effect
+  // re-reading on `storageKey` would repair it one render too late.
+  const [stored, setStored] = useState(() => ({ key: storageKey, stats: readStats(storageKey) }));
+  const stats = stored.key === storageKey ? stored.stats : readStats(storageKey);
 
   const recordResult = useCallback((result: keyof Stats) => {
-    setStats(prev => {
-      const next = { ...prev, [result]: prev[result] + 1 };
+    setStored(stale => {
+      const current = stale.key === storageKey ? stale.stats : readStats(storageKey);
+      const next = { ...current, [result]: current[result] + 1 };
       localStorage.setItem(storageKey, JSON.stringify(next));
-      return next;
+      return { key: storageKey, stats: next };
     });
   }, [storageKey]);
 
   const resetStats = useCallback(() => {
     localStorage.removeItem(storageKey);
-    setStats(EMPTY_STATS);
+    setStored({ key: storageKey, stats: EMPTY_STATS });
   }, [storageKey]);
 
   return { stats, recordResult, resetStats };

--- a/src/components/strategy-game-factory/strategy-game-factory.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.tsx
@@ -102,7 +102,10 @@ export const strategyGameFactory = <TBoard,>({
       if (!isHumanVsHumanGame && phase === 'play' && currentPlayer === (1 - chosenRoleIndex!)) {
         doBotTurn();
       }
-    }, [currentPlayer, isHumanVsHumanGame, phase, chosenRoleIndex]); // doBotTurn excluded: recreates every render
+      // doBotTurn is recreated every render, so listing it would restart the
+      // bot on every render rather than on a turn change.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [currentPlayer, isHumanVsHumanGame, phase, chosenRoleIndex]);
 
     const resolvedPlayerNames: [string, string] = [
       playerNames[0] || t(DEFAULT_PLAYER_NAMES[0]),

--- a/src/language/language-context.tsx
+++ b/src/language/language-context.tsx
@@ -18,6 +18,15 @@ export const LanguageProvider = ({ children }: { children: React.ReactNode }) =>
   // When the URL ?lang= param changes (e.g. direct link or back/forward),
   // sync it into state. Ignore navigations that drop the param entirely
   // (those happen on Link clicks and should keep the in-memory language).
+  //
+  // Unlike the move-scoped and per-key state elsewhere, this is not derivable:
+  // the URL is only *one* of two inputs (the other being setLanguage, which
+  // writes both state and the URL), and the effect also writes localStorage.
+  // Deriving during render would mean choosing a winner between them on every
+  // render and doing IO there, so the effect stays and the rule is suppressed
+  // here rather than repo-wide. `language` is excluded from the deps on
+  // purpose: re-running when it changes would fight the setLanguage path.
+  /* eslint-disable react-hooks/set-state-in-effect, react-hooks/exhaustive-deps */
   useEffect(() => {
     const langFromUrl = searchParams.get('lang') as Language | null;
     if (langFromUrl !== null && langFromUrl !== language) {
@@ -26,6 +35,7 @@ export const LanguageProvider = ({ children }: { children: React.ReactNode }) =>
       else localStorage.setItem('lang', langFromUrl);
     }
   }, [searchParams]);
+  /* eslint-enable react-hooks/set-state-in-effect, react-hooks/exhaustive-deps */
 
   const setLanguage = (lang: Language) => {
     setLanguageState(lang);


### PR DESCRIPTION
This PR eliminates unnecessary effects that were re-seeding component state from props, replacing them with render-time derivations. This follows the pattern established in #409/#410 where state derived from props should be computed during render rather than repaired by effects one frame later.

## Key changes

- **GameEndDialog**: Removed the `useEffect` that re-seeded `localMode` and `localVariantIndex` when the dialog opened. Instead, extracted the form controls into a `NewGameControls` child component that lives inside the `Dialog` element. Since `Dialog` renders nothing while closed, the component is created fresh on each open with `useState` seeding from the current game state. This naturally discards any abandoned draft when the dialog closes.

- **useGameStats**: Replaced the effect that re-read stats on `storageKey` change with render-time derivation. The hook now stamps stored state with the key it was read for, allowing it to detect when the variant changed and read the new key during render—preventing the previous variant's counts from being shown for a frame.

- **ESLint configuration**: Enabled three react-hooks rules as errors:
  - `rules-of-hooks`: Validates hook usage
  - `exhaustive-deps`: Ensures dependency arrays are complete
  - `set-state-in-effect`: Flags state re-seeding patterns (the main target of this work)

- **language-context.tsx**: Added a targeted suppression for the language sync effect, which legitimately needs to re-seed state because the URL is one of two independent inputs (the other being `setLanguage`), and the effect also performs IO (localStorage writes).

- **strategy-game-factory.tsx**: Clarified an existing `exhaustive-deps` suppression with a comment explaining why `doBotTurn` is intentionally excluded.

- **Tests**: Added comprehensive test coverage for GameEndDialog verifying that the draft mode is seeded from the current game, can be changed, and is properly discarded when the dialog is abandoned and reopened.

## Implementation details

The GameEndDialog refactor is the most significant change. By moving the form controls into a child component that unmounts when the dialog closes, we leverage React's component lifecycle to naturally reset state without needing an effect. This is cleaner and more reliable than trying to synchronize state with the `isOpen` prop.

The useGameStats change uses a "stamped" state pattern where the stored value includes the key it was read for, allowing the hook to detect stale reads during render and fetch fresh data without an effect.

https://claude.ai/code/session_012Lg8UokewKvCAACeyKGChz