### PR TITLE
Fix radio button groups when selectors render multiple times

### DIFF
--- a/src/components/strategy-game-factory/game-parts/common/game-controls.spec.tsx
+++ b/src/components/strategy-game-factory/game-parts/common/game-controls.spec.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { render, fireEvent } from '@testing-library/react';
+import { ModeSelector, DifficultySelector } from './game-controls';
+import type { Variant } from '../../types';
+
+// The sidebar and the game-end dialog render these selectors into the same
+// document at the same time. Radios sharing a `name` are one native group with
+// one checked member between them, so two instances have to get separate
+// groups — otherwise interacting with one silently unchecks the other, and the
+// radios are what assistive technology reads the selection from. (The visible
+// highlight comes from the label's own class, so this is invisible on screen.)
+
+const variants: Variant[] = [
+  { originalIndex: 0, label: { hu: 'Könnyű', en: 'Easy' }, disabled: false } as Variant,
+  { originalIndex: 1, label: { hu: 'Nehéz', en: 'Hard' }, disabled: false } as Variant
+];
+
+describe('ModeSelector', () => {
+  it('keeps two instances in separate radio groups', () => {
+    const { getAllByTestId } = render(
+      <>
+        <ModeSelector isHumanVsHumanGame={false} onSwitchMode={() => {}} disabled={false} />
+        <ModeSelector isHumanVsHumanGame={false} onSwitchMode={() => {}} disabled={false} />
+      </>
+    );
+
+    const [firstComputer, secondComputer] = getAllByTestId('mode-vsComputer') as HTMLInputElement[];
+
+    expect(firstComputer!.name).not.toBe(secondComputer!.name);
+    expect(firstComputer!.name).toBeTruthy();
+  });
+
+  // The failure this prevents: the browser moves "checked" within a shared
+  // group, so picking a mode in the dialog left the sidebar's radio — and, as
+  // it happened, both of the dialog's own — reporting nothing selected.
+  it('does not uncheck another instance when one is picked', () => {
+    const { getAllByTestId } = render(
+      <>
+        <ModeSelector isHumanVsHumanGame={false} onSwitchMode={() => {}} disabled={false} />
+        <ModeSelector isHumanVsHumanGame onSwitchMode={() => {}} disabled={false} />
+      </>
+    );
+
+    const [firstComputer] = getAllByTestId('mode-vsComputer') as HTMLInputElement[];
+    const [, secondHuman] = getAllByTestId('mode-vsHuman') as HTMLInputElement[];
+
+    expect(firstComputer!.checked).toBe(true);
+    expect(secondHuman!.checked).toBe(true);
+
+    fireEvent.click(secondHuman!);
+
+    expect(firstComputer!.checked).toBe(true);
+  });
+});
+
+describe('DifficultySelector', () => {
+  it('keeps two instances in separate radio groups', () => {
+    const { container } = render(
+      <>
+        <DifficultySelector variants={variants} selectedIndex={0} onSelect={() => {}} disabled={false} />
+        <DifficultySelector variants={variants} selectedIndex={0} onSelect={() => {}} disabled={false} />
+      </>
+    );
+
+    const names = [...container.querySelectorAll('input[type="radio"]')]
+      .map(el => (el as HTMLInputElement).name);
+
+    expect(new Set(names).size).toBe(2); // two groups of two, not one group of four
+  });
+
+  it('marks a variant whose bot is not always optimal', () => {
+    const withMarker: Variant[] = [
+      variants[0]!,
+      { ...variants[1]!, notAlwaysOptimal: true } as Variant
+    ];
+    const { getAllByTitle } = render(
+      <DifficultySelector variants={withMarker} selectedIndex={0} onSelect={() => {}} disabled={false} />
+    );
+
+    expect(getAllByTitle(/nem minden esetben|not always find/i)).toHaveLength(1);
+  });
+});

--- a/src/components/strategy-game-factory/game-parts/common/game-controls.tsx
+++ b/src/components/strategy-game-factory/game-parts/common/game-controls.tsx
@@ -1,5 +1,13 @@
+import { useId } from 'react';
 import { useTranslation } from '../../../../language';
 import type { Variant, Mode } from '../../types';
+
+// Radios sharing a `name` form one native group, and the browser keeps exactly
+// one of them checked. The sidebar and the game-end dialog each render these
+// selectors into the same document, so a fixed name made the two instances one
+// group: clicking the dialog's choice unchecked the sidebar's, and React —
+// whose own state had not changed there — left it that way. useId gives each
+// instance its own group.
 
 export const ModeSelector = ({ isHumanVsHumanGame, onSwitchMode, disabled }: {
   isHumanVsHumanGame: boolean
@@ -7,6 +15,7 @@ export const ModeSelector = ({ isHumanVsHumanGame, onSwitchMode, disabled }: {
   disabled: boolean
 }) => {
   const { t } = useTranslation();
+  const groupName = useId();
 
   return (
     <fieldset>
@@ -18,7 +27,7 @@ export const ModeSelector = ({ isHumanVsHumanGame, onSwitchMode, disabled }: {
         <label className={labelClass(!isHumanVsHumanGame, disabled)}>
           <input
             type="radio"
-            name="mode"
+            name={groupName}
             className="sr-only"
             data-testid="mode-vsComputer"
             checked={!isHumanVsHumanGame}
@@ -30,7 +39,7 @@ export const ModeSelector = ({ isHumanVsHumanGame, onSwitchMode, disabled }: {
         <label className={labelClass(isHumanVsHumanGame, disabled)}>
           <input
             type="radio"
-            name="mode"
+            name={groupName}
             className="sr-only"
             data-testid="mode-vsHuman"
             checked={isHumanVsHumanGame}
@@ -51,6 +60,7 @@ export const DifficultySelector = ({ variants, selectedIndex, onSelect, disabled
   disabled: boolean
 }) => {
   const { t } = useTranslation();
+  const groupName = useId();
 
   return (
     <fieldset>
@@ -67,7 +77,7 @@ export const DifficultySelector = ({ variants, selectedIndex, onSelect, disabled
           >
             <input
               type="radio"
-              name="difficulty"
+              name={groupName}
               className="sr-only"
               checked={v.originalIndex === selectedIndex}
               onChange={() => onSelect(v.originalIndex)}

--- a/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
@@ -482,8 +482,11 @@ describe('per-variant rule', () => {
     expect(getByText('RULE_ONE')).toBeTruthy();
     expect(queryByText('RULE_TWO')).toBeNull();
 
-    const radios = container.querySelectorAll('input[name="difficulty"]');
-    fireEvent.click(radios[1]);
+    // the variant radios' group name is a useId, so select them by the
+    // fieldset they live in rather than by a fixed name
+    const variantFieldset = container.querySelectorAll('fieldset')[1]!;
+    const radios = variantFieldset.querySelectorAll('input[type="radio"]');
+    fireEvent.click(radios[1]!);
 
     expect(getByText('RULE_TWO')).toBeTruthy();
     expect(queryByText('RULE_ONE')).toBeNull();


### PR DESCRIPTION
## Summary
Fixed an issue where multiple instances of `ModeSelector` and `DifficultySelector` components (e.g., in sidebar and game-end dialog) were sharing the same radio button group name, causing browser-level radio group behavior to interfere between instances.

## Key Changes
- Updated `ModeSelector` and `DifficultySelector` to use `useId()` hook for generating unique radio group names instead of hardcoded names ("mode" and "difficulty")
- Added comprehensive test coverage for the multi-instance scenario in `game-controls.spec.tsx`
- Updated existing test in `strategy-game-factory.spec.tsx` to select radio buttons by fieldset instead of relying on the now-dynamic group name

## Implementation Details
When multiple radio inputs share the same `name` attribute, they form a single native radio group where only one can be checked at a time. Since the sidebar and game-end dialog both render these selectors into the same DOM, the hardcoded names caused them to be treated as one group. Clicking a radio in the dialog would uncheck the corresponding radio in the sidebar, even though React's state hadn't changed.

Using `useId()` ensures each component instance gets its own unique group name, allowing independent radio groups while maintaining proper accessibility semantics. The tests verify that:
1. Two instances maintain separate radio groups
2. Selecting an option in one instance doesn't affect the other
3. Variants marked as "not always optimal" are properly labeled

https://claude.ai/code/session_012Lg8UokewKvCAACeyKGChz