### PR TITLE
Move five games' bot strategy out of gameplay.ts

### DIFF
--- a/src/components/games/chocolate-breaking/chocolate-breaking.tsx
+++ b/src/components/games/chocolate-breaking/chocolate-breaking.tsx
@@ -153,7 +153,7 @@ export const ChocolateBreaking = strategyGameFactory({
       label: { hu: 'Teszt', en: 'Test' }
     },
     {
-      // smart bot: optimal via Sprague–Grundy values (see helpers.ts / bot-strategy.ts)
+      // smart bot: optimal via Sprague–Grundy values (see bot-strategy.ts)
       botStrategy: smartBotStrategy,
       generateStartBoard,
       label: { hu: 'Teljes', en: 'Full' },

--- a/src/components/games/four-piles-two-grabs/bot-strategy.spec.ts
+++ b/src/components/games/four-piles-two-grabs/bot-strategy.spec.ts
@@ -1,0 +1,91 @@
+import { getRandomBotMove, getSmartBotMove } from './bot-strategy';
+import {
+  applyMove,
+  getLegalMoves,
+  isTerminal,
+  isWinningBoard,
+  isWinningInOneMove,
+  type Board
+} from './gameplay';
+
+// Exhaustive game-theoretic value: the player to move wins iff some move leads
+// to a position from which the opponent loses. Positions are symmetric in the
+// four piles, so we memoise on the sorted quadruple.
+const minimaxWin = (() => {
+  const memo = new Map<string, boolean>();
+  const solve = (board: Board): boolean => {
+    const key = [...board].sort((a, b) => a - b).join(',');
+    if (memo.has(key)) return memo.get(key)!;
+    const win = getLegalMoves(board).some(m => !solve(applyMove(board, m)));
+    memo.set(key, win);
+    return win;
+  };
+  return solve;
+})();
+
+// All boards with each pile in 0..MAX (up to symmetry: sorted, non-decreasing).
+const MAX = 7;
+const allBoards = (): Board[] => {
+  const boards: Board[] = [];
+  for (let a = 0; a <= MAX; a++) {
+    for (let b = a; b <= MAX; b++) {
+      for (let c = b; c <= MAX; c++) {
+        for (let d = c; d <= MAX; d++) {
+          boards.push([a, b, c, d]);
+        }
+      }
+    }
+  }
+  return boards;
+};
+
+describe('four-piles-two-grabs bot', () => {
+  describe('winning-position characterisation', () => {
+    it('matches exhaustive minimax on every board', () => {
+      for (const board of allBoards()) {
+        expect(isWinningBoard(board)).toBe(minimaxWin(board));
+      }
+    });
+
+    it('is a loss exactly when the three smallest piles are equal', () => {
+      expect(isWinningBoard([6, 7, 8, 9])).toBe(true);
+      expect(isWinningBoard([6, 6, 6, 9])).toBe(false);
+      expect(isWinningBoard([2, 2, 2, 2])).toBe(false);
+      expect(isWinningBoard([5, 0, 0, 0])).toBe(false); // terminal position
+    });
+  });
+
+  describe('smart bot', () => {
+    it('from a winning position leaves the opponent a losing position', () => {
+      for (const board of allBoards()) {
+        if (!isWinningBoard(board)) continue;
+        const next = applyMove(board, getSmartBotMove(board));
+        expect(minimaxWin(next)).toBe(false);
+      }
+    });
+
+    it('always makes a legal move', () => {
+      for (const board of allBoards()) {
+        if (isTerminal(board)) continue;
+        const move = getSmartBotMove(board);
+        expect(getLegalMoves(board)).toContainEqual(move);
+      }
+    });
+
+    it('grabs an immediate win when it has one', () => {
+      expect(isWinningInOneMove([2, 3, 4, 0], getSmartBotMove([2, 3, 4, 0]))).toBe(true);
+    });
+  });
+
+  describe('random (test) bot', () => {
+    it('grabs an immediate one-move win when available', () => {
+      expect(isWinningInOneMove([1, 3, 0, 0], getRandomBotMove([1, 3, 0, 0]))).toBe(true);
+      expect(isWinningInOneMove([1, 1, 4, 0], getRandomBotMove([1, 1, 4, 0]))).toBe(true);
+    });
+
+    it('makes a legal move otherwise', () => {
+      const board = [4, 2, 6, 3];
+      expect(getLegalMoves(board)).toContainEqual(getRandomBotMove(board));
+    });
+  });
+});

--- a/src/components/games/four-piles-two-grabs/bot-strategy.ts
+++ b/src/components/games/four-piles-two-grabs/bot-strategy.ts
@@ -1,7 +1,45 @@
+import { sample } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
-import { getRandomBotMove, getSmartBotMove, type Board, type Moves } from './gameplay';
+import {
+  applyMove,
+  getLegalMoves,
+  isWinningBoard,
+  isWinningInOneMove,
+  type Board,
+  type Move,
+  type Moves
+} from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>
+
+// A position is losing for the player to move exactly when the three smallest
+// piles are equal, so a winning move is one that hands the opponent such a
+// position. `isWinningBoard` (in gameplay.ts, where generateStartBoard needs it)
+// is the same predicate the other way round.
+const handsOverALoss = (board: Board, move: Move): boolean =>
+  !isWinningBoard(applyMove(board, move));
+
+export const getSmartBotMove = (board: Board): Move => {
+  // Winning moves leave the opponent with three equal smallest piles (a losing
+  // position). Immediate wins (leaving the opponent unable to move) are a
+  // special case, so prefer them to end the game promptly.
+  const winning = getLegalMoves(board).filter(m => handsOverALoss(board, m));
+  const immediate = winning.filter(m => isWinningInOneMove(board, m));
+  if (immediate.length > 0) return sample(immediate)!;
+  if (winning.length > 0) return sample(winning)!;
+  // Losing position (three smallest already equal): every move hands the
+  // opponent a winning position, so we cannot win against optimal play. Play
+  // any legal move and hope the opponent slips up.
+  return sample(getLegalMoves(board))!;
+};
+
+// Test bot: play a random legal move, but grab an immediate one-move win when
+// one is available.
+export const getRandomBotMove = (board: Board): Move => {
+  const moves = getLegalMoves(board);
+  const winningNow = moves.filter(m => isWinningInOneMove(board, m));
+  return sample(winningNow.length > 0 ? winningNow : moves)!;
+};
 
 export const smartBotStrategy: Bot = ({ board }) =>
   ({ move: 'takeStones', args: [getSmartBotMove(board)] });

--- a/src/components/games/four-piles-two-grabs/four-piles-two-grabs.tsx
+++ b/src/components/games/four-piles-two-grabs/four-piles-two-grabs.tsx
@@ -154,7 +154,7 @@ export const FourPilesTwoGrabs = strategyGameFactory({
       generateStartBoard,
       label: { hu: 'Teszt', en: 'Test' }
     },
-    // smart bot: verified as optimal (see helpers.spec.ts exhaustive minimax check)
+    // smart bot: verified as optimal (see bot-strategy.spec.ts exhaustive minimax check)
     {
       botStrategy: smartBotStrategy,
       generateStartBoard,

--- a/src/components/games/four-piles-two-grabs/gameplay.spec.ts
+++ b/src/components/games/four-piles-two-grabs/gameplay.spec.ts
@@ -3,8 +3,6 @@ import {
   canMove,
   generateStartBoard,
   getLegalMoves,
-  getRandomBotMove,
-  getSmartBotMove,
   isMoveLegal,
   isTerminal,
   isWinningBoard,
@@ -14,38 +12,7 @@ import {
 } from './gameplay';
 import { makeCtx } from '../../../test-utils';
 
-// Exhaustive game-theoretic value: the player to move wins iff some move leads
-// to a position from which the opponent loses. Positions are symmetric in the
-// four piles, so we memoise on the sorted quadruple.
-const minimaxWin = (() => {
-  const memo = new Map<string, boolean>();
-  const solve = (board: Board): boolean => {
-    const key = [...board].sort((a, b) => a - b).join(',');
-    if (memo.has(key)) return memo.get(key)!;
-    const win = getLegalMoves(board).some(m => !solve(applyMove(board, m)));
-    memo.set(key, win);
-    return win;
-  };
-  return solve;
-})();
-
-// All boards with each pile in 0..MAX (up to symmetry: sorted, non-decreasing).
-const MAX = 7;
-const allBoards = (): Board[] => {
-  const boards: Board[] = [];
-  for (let a = 0; a <= MAX; a++) {
-    for (let b = a; b <= MAX; b++) {
-      for (let c = b; c <= MAX; c++) {
-        for (let d = c; d <= MAX; d++) {
-          boards.push([a, b, c, d]);
-        }
-      }
-    }
-  }
-  return boards;
-};
-
-describe('four-piles-two-grabs helpers', () => {
+describe('four-piles-two-grabs gameplay', () => {
   describe('move mechanics', () => {
     it('removes the chosen amount from each chosen pile', () => {
       expect(applyMove([6, 7, 8, 9], [0, 1, 2, 0])).toEqual([6, 6, 6, 9]);
@@ -70,55 +37,6 @@ describe('four-piles-two-grabs helpers', () => {
       expect(isWinningInOneMove([1, 1, 0, 0], [1, 1, 0, 0])).toBe(true); // -> all empty
       expect(isWinningInOneMove([2, 3, 4, 0], [2, 3, 0, 0])).toBe(true); // -> only pile 2 left
       expect(isWinningInOneMove([2, 2, 2, 2], [1, 1, 0, 0])).toBe(false);
-    });
-  });
-
-  describe('winning-position characterisation', () => {
-    it('matches exhaustive minimax on every board', () => {
-      for (const board of allBoards()) {
-        expect(isWinningBoard(board)).toBe(minimaxWin(board));
-      }
-    });
-
-    it('is a loss exactly when the three smallest piles are equal', () => {
-      expect(isWinningBoard([6, 7, 8, 9])).toBe(true);
-      expect(isWinningBoard([6, 6, 6, 9])).toBe(false);
-      expect(isWinningBoard([2, 2, 2, 2])).toBe(false);
-      expect(isWinningBoard([5, 0, 0, 0])).toBe(false); // terminal position
-    });
-  });
-
-  describe('smart bot', () => {
-    it('from a winning position leaves the opponent a losing position', () => {
-      for (const board of allBoards()) {
-        if (!isWinningBoard(board)) continue;
-        const next = applyMove(board, getSmartBotMove(board));
-        expect(minimaxWin(next)).toBe(false);
-      }
-    });
-
-    it('always makes a legal move', () => {
-      for (const board of allBoards()) {
-        if (isTerminal(board)) continue;
-        const move = getSmartBotMove(board);
-        expect(getLegalMoves(board)).toContainEqual(move);
-      }
-    });
-
-    it('grabs an immediate win when it has one', () => {
-      expect(isWinningInOneMove([2, 3, 4, 0], getSmartBotMove([2, 3, 4, 0]))).toBe(true);
-    });
-  });
-
-  describe('random (test) bot', () => {
-    it('grabs an immediate one-move win when available', () => {
-      expect(isWinningInOneMove([1, 3, 0, 0], getRandomBotMove([1, 3, 0, 0]))).toBe(true);
-      expect(isWinningInOneMove([1, 1, 4, 0], getRandomBotMove([1, 1, 4, 0]))).toBe(true);
-    });
-
-    it('makes a legal move otherwise', () => {
-      const board = [4, 2, 6, 3];
-      expect(getLegalMoves(board)).toContainEqual(getRandomBotMove(board));
     });
   });
 

--- a/src/components/games/four-piles-two-grabs/gameplay.ts
+++ b/src/components/games/four-piles-two-grabs/gameplay.ts
@@ -1,5 +1,5 @@
 import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
-import { random, sample, sortBy } from 'lodash';
+import { random, sortBy } from 'lodash';
 
 // Stones in each of the four piles.
 export type Board = number[]; // length 4
@@ -55,7 +55,7 @@ export const isWinningInOneMove = (board: Board, move: Move): boolean =>
   isTerminal(applyMove(board, move));
 
 // The player to move LOSES exactly when the three smallest piles are equal.
-// (Verified against exhaustive minimax in helpers.spec.) Terminal positions –
+// (Verified against exhaustive minimax in bot-strategy.spec.ts.) Terminal positions –
 // at most one non-empty pile – have three zero piles, so they satisfy this too.
 const threeSmallestEqual = (board: Board): boolean => {
   const s = sortBy(board);
@@ -63,28 +63,6 @@ const threeSmallestEqual = (board: Board): boolean => {
 };
 
 export const isWinningBoard = (board: Board): boolean => !threeSmallestEqual(board);
-
-export const getSmartBotMove = (board: Board): Move => {
-  // Winning moves leave the opponent with three equal smallest piles (a losing
-  // position). Immediate wins (leaving the opponent unable to move) are a
-  // special case, so prefer them to end the game promptly.
-  const winning = getLegalMoves(board).filter(m => threeSmallestEqual(applyMove(board, m)));
-  const immediate = winning.filter(m => isWinningInOneMove(board, m));
-  if (immediate.length > 0) return sample(immediate)!;
-  if (winning.length > 0) return sample(winning)!;
-  // Losing position (three smallest already equal): every move hands the
-  // opponent a winning position, so we cannot win against optimal play. Play
-  // any legal move and hope the opponent slips up.
-  return sample(getLegalMoves(board))!;
-};
-
-// Test bot: play a random legal move, but grab an immediate one-move win when
-// one is available.
-export const getRandomBotMove = (board: Board): Move => {
-  const moves = getLegalMoves(board);
-  const winningNow = moves.filter(m => isWinningInOneMove(board, m));
-  return sample(winningNow.length > 0 ? winningNow : moves)!;
-};
 
 // --- Starting positions -----------------------------------------------------
 

--- a/src/components/games/latin-square-filling/bot-strategy.spec.ts
+++ b/src/components/games/latin-square-filling/bot-strategy.spec.ts
@@ -1,0 +1,117 @@
+import {
+  getRandomBotStep,
+  getSmartBotStep,
+  optimalWinner
+} from './bot-strategy';
+import {
+  applyMove,
+  generateStartBoard,
+  isFull,
+  isLegalPlacement,
+  isTerminal,
+  legalMoves,
+  playerToMove,
+  type Board,
+  type Move
+} from './gameplay';
+
+describe('latin-square-filling bot', () => {
+// Play a full game between two step functions, returning the winner index.
+const playGame = (
+  step0: (b: Board) => Move,
+  step1: (b: Board) => Move,
+  start: Board = generateStartBoard()
+): number => {
+  let board = start;
+  // safety bound: at most 9 placements
+  for (let i = 0; i < 20; i++) {
+    if (isFull(board)) return 0; // grid filled -> first player won
+    const moves = legalMoves(board);
+    if (moves.length === 0) return 1; // player to move stuck -> second player won
+    const step = playerToMove(board) === 0 ? step0 : step1;
+    board = applyMove(board, step(board));
+  }
+  throw new Error('game did not terminate');
+};
+
+  describe('optimal winner (minimax)', () => {
+    it('is a forced first-player win from the empty board', () => {
+      expect(optimalWinner(generateStartBoard())).toBe(0);
+    });
+
+    it('credits a completed Latin square to the first player', () => {
+      expect(optimalWinner([1, 2, 3, 2, 3, 1, 3, 1, 2])).toBe(0);
+    });
+
+    it('every legal first move preserves the first player win', () => {
+      const start = generateStartBoard();
+      for (const move of legalMoves(start)) {
+        expect(optimalWinner(applyMove(start, move))).toBe(0);
+      }
+    });
+
+    it('declares the second player the winner whenever the game jams', () => {
+      // two empty cells (5, 7) remain but neither accepts any digit: the game is
+      // jammed, so the second player wins no matter whose turn it is. (A single
+      // empty cell can always be filled, so jamming needs at least two gaps.)
+      const board: Board = [1, 2, 3, 2, 1, 0, 3, 0, 1];
+      expect(isFull(board)).toBe(false);
+      expect(legalMoves(board)).toEqual([]);
+      expect(optimalWinner(board)).toBe(1);
+    });
+  });
+
+  describe('getSmartBotStep', () => {
+    it('always returns a legal move', () => {
+      const board: Board = [1, 0, 0, 0, 0, 0, 0, 0, 0];
+      const { cell, digit } = getSmartBotStep(board);
+      expect(isLegalPlacement(board, cell, digit)).toBe(true);
+    });
+
+    it('as first player, forces a win against any opponent', () => {
+      // smart bot is player 0 (starts from empty), so it must win every game
+      const alwaysFirstLegal = (b: Board): Move => legalMoves(b)[0];
+      const randomOpponent = (b: Board): Move => getRandomBotStep(b);
+      for (let i = 0; i < 40; i++) {
+        expect(playGame(getSmartBotStep, alwaysFirstLegal)).toBe(0);
+        expect(playGame(getSmartBotStep, randomOpponent)).toBe(0);
+      }
+    });
+
+    it('realises the theoretical value from any reachable position (smart vs smart)', () => {
+      // Collect reachable mid-game positions via random playouts, then play them
+      // out smart-vs-smart. Two optimal players must always reach the outcome
+      // predicted by the minimax value — for both winning and losing sides.
+      const positions: Board[] = [];
+      for (let i = 0; i < 60; i++) {
+        let board = generateStartBoard();
+        while (!isTerminal(board)) {
+          positions.push([...board]);
+          board = applyMove(board, getRandomBotStep(board));
+        }
+      }
+      for (const position of positions) {
+        expect(playGame(getSmartBotStep, getSmartBotStep, position)).toBe(optimalWinner(position));
+      }
+    });
+  });
+
+  describe('getRandomBotStep', () => {
+    it('always returns a legal move', () => {
+      const board: Board = [1, 2, 0, 0, 0, 0, 0, 0, 0];
+      for (let i = 0; i < 20; i++) {
+        const { cell, digit } = getRandomBotStep(board);
+        expect(isLegalPlacement(board, cell, digit)).toBe(true);
+      }
+    });
+
+    it('takes an immediate first-player win (filling the last cell) when available', () => {
+      // one empty cell (8); player to move is player 0 (8 filled); digit 2 fits
+      const board: Board = [1, 2, 3, 2, 3, 1, 3, 1, 0];
+      expect(playerToMove(board)).toBe(0);
+      const { cell, digit } = getRandomBotStep(board);
+      expect(cell).toBe(8);
+      expect(digit).toBe(2);
+    });
+  });
+});

--- a/src/components/games/latin-square-filling/bot-strategy.ts
+++ b/src/components/games/latin-square-filling/bot-strategy.ts
@@ -1,7 +1,86 @@
+import { sample } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
-import { getRandomBotStep, getSmartBotStep, type Board, type Moves } from './gameplay';
+import {
+  applyMove,
+  isFull,
+  isTerminal,
+  legalMoves,
+  playerToMove,
+  type Board,
+  type Move,
+  type Moves
+} from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>
+
+// Winner index (0 or 1) under optimal play from `board`, with `playerToMove`
+// to move. The reachable state space is tiny (~1400 positions), so a memoised
+// exhaustive minimax is both fast and provably optimal. Player 0 has a forced
+// win from the empty board (see bot-strategy.spec.ts / the written solution: reach a
+// "mixed rook arrangement" — a transversal holding all three digits).
+const winnerCache = new Map<string, number>();
+
+export const optimalWinner = (board: Board): number => {
+  const key = board.join('');
+  const cached = winnerCache.get(key);
+  if (cached !== undefined) return cached;
+
+  let winner: number;
+  if (isFull(board)) {
+    winner = 0;
+  } else {
+    const moves = legalMoves(board);
+    if (moves.length === 0) {
+      winner = 1;
+    } else {
+      const player = playerToMove(board);
+      winner = moves.some(m => optimalWinner(applyMove(board, m)) === player)
+        ? player
+        : 1 - player;
+    }
+  }
+  winnerCache.set(key, winner);
+  return winner;
+};
+
+// Smart bot: keep a forced win when one exists. From a losing position every
+// move hands the opponent a forced win, so play the reply that leaves the
+// opponent the most losing continuations — the most rope for a non-optimal
+// human to hang themselves with. Random tie-break.
+export const getSmartBotStep = (board: Board): Move => {
+  const me = playerToMove(board);
+  const moves = legalMoves(board);
+
+  const winningMoves = moves.filter(m => optimalWinner(applyMove(board, m)) === me);
+  if (winningMoves.length > 0) return sample(winningMoves)!;
+
+  const trapCount = (m: Move): number => {
+    const next = applyMove(board, m);
+    if (isTerminal(next)) return 0;
+    // opponent replies that (mistakenly) hand the game back to the bot
+    return legalMoves(next).filter(om => optimalWinner(applyMove(next, om)) === me).length;
+  };
+  const scored = moves.map(m => ({ m, traps: trapCount(m) }));
+  const maxTraps = Math.max(...scored.map(s => s.traps));
+  return sample(scored.filter(s => s.traps === maxTraps))!.m;
+};
+
+// Test bot: play a random legal move, but grab an immediate win (a move that
+// ends the game in the bot's favour right now) whenever one is available.
+export const getRandomBotStep = (board: Board): Move => {
+  const me = playerToMove(board);
+  const moves = legalMoves(board);
+
+  const immediateWins = moves.filter(m => {
+    const next = applyMove(board, m);
+    if (isFull(next)) return me === 0; // filled the grid -> player 0 wins
+    if (legalMoves(next).length === 0) return me === 1; // opponent stuck -> player 1 wins
+    return false;
+  });
+  if (immediateWins.length > 0) return sample(immediateWins)!;
+
+  return sample(moves)!;
+};
 
 export const smartBotStrategy: Bot = ({ board }) => {
   const { cell, digit } = getSmartBotStep(board);

--- a/src/components/games/latin-square-filling/gameplay.spec.ts
+++ b/src/components/games/latin-square-filling/gameplay.spec.ts
@@ -1,40 +1,18 @@
 import {
   applyMove,
   generateStartBoard,
-  getRandomBotStep,
-  getSmartBotStep,
   isFull,
   isLegalPlacement,
   isTerminal,
   legalDigits,
   legalMoves,
   moves,
-  optimalWinner,
   playerToMove,
-  type Board,
-  type Move
+  type Board
 } from './gameplay';
 import { makeCtx } from '../../../test-utils';
 
-// Play a full game between two step functions, returning the winner index.
-const playGame = (
-  step0: (b: Board) => Move,
-  step1: (b: Board) => Move,
-  start: Board = generateStartBoard()
-): number => {
-  let board = start;
-  // safety bound: at most 9 placements
-  for (let i = 0; i < 20; i++) {
-    if (isFull(board)) return 0; // grid filled -> first player won
-    const moves = legalMoves(board);
-    if (moves.length === 0) return 1; // player to move stuck -> second player won
-    const step = playerToMove(board) === 0 ? step0 : step1;
-    board = applyMove(board, step(board));
-  }
-  throw new Error('game did not terminate');
-};
-
-describe('latin-square-filling helpers', () => {
+describe('latin-square-filling gameplay', () => {
   describe('legality', () => {
     it('rejects a digit already present in the same row', () => {
       const board: Board = [1, 0, 0, 0, 0, 0, 0, 0, 0];
@@ -81,84 +59,6 @@ describe('latin-square-filling helpers', () => {
       const solved: Board = [1, 2, 3, 2, 3, 1, 3, 1, 2];
       expect(isFull(solved)).toBe(true);
       expect(isTerminal(solved)).toBe(true);
-      expect(optimalWinner(solved)).toBe(0);
-    });
-  });
-
-  describe('optimal winner (minimax)', () => {
-    it('is a forced first-player win from the empty board', () => {
-      expect(optimalWinner(generateStartBoard())).toBe(0);
-    });
-
-    it('every legal first move preserves the first player win', () => {
-      const start = generateStartBoard();
-      for (const move of legalMoves(start)) {
-        expect(optimalWinner(applyMove(start, move))).toBe(0);
-      }
-    });
-
-    it('declares the second player the winner whenever the game jams', () => {
-      // two empty cells (5, 7) remain but neither accepts any digit: the game is
-      // jammed, so the second player wins no matter whose turn it is. (A single
-      // empty cell can always be filled, so jamming needs at least two gaps.)
-      const board: Board = [1, 2, 3, 2, 1, 0, 3, 0, 1];
-      expect(isFull(board)).toBe(false);
-      expect(legalMoves(board)).toEqual([]);
-      expect(optimalWinner(board)).toBe(1);
-    });
-  });
-
-  describe('getSmartBotStep', () => {
-    it('always returns a legal move', () => {
-      const board: Board = [1, 0, 0, 0, 0, 0, 0, 0, 0];
-      const { cell, digit } = getSmartBotStep(board);
-      expect(isLegalPlacement(board, cell, digit)).toBe(true);
-    });
-
-    it('as first player, forces a win against any opponent', () => {
-      // smart bot is player 0 (starts from empty), so it must win every game
-      const alwaysFirstLegal = (b: Board): Move => legalMoves(b)[0];
-      const randomOpponent = (b: Board): Move => getRandomBotStep(b);
-      for (let i = 0; i < 40; i++) {
-        expect(playGame(getSmartBotStep, alwaysFirstLegal)).toBe(0);
-        expect(playGame(getSmartBotStep, randomOpponent)).toBe(0);
-      }
-    });
-
-    it('realises the theoretical value from any reachable position (smart vs smart)', () => {
-      // Collect reachable mid-game positions via random playouts, then play them
-      // out smart-vs-smart. Two optimal players must always reach the outcome
-      // predicted by the minimax value — for both winning and losing sides.
-      const positions: Board[] = [];
-      for (let i = 0; i < 60; i++) {
-        let board = generateStartBoard();
-        while (!isTerminal(board)) {
-          positions.push([...board]);
-          board = applyMove(board, getRandomBotStep(board));
-        }
-      }
-      for (const position of positions) {
-        expect(playGame(getSmartBotStep, getSmartBotStep, position)).toBe(optimalWinner(position));
-      }
-    });
-  });
-
-  describe('getRandomBotStep', () => {
-    it('always returns a legal move', () => {
-      const board: Board = [1, 2, 0, 0, 0, 0, 0, 0, 0];
-      for (let i = 0; i < 20; i++) {
-        const { cell, digit } = getRandomBotStep(board);
-        expect(isLegalPlacement(board, cell, digit)).toBe(true);
-      }
-    });
-
-    it('takes an immediate first-player win (filling the last cell) when available', () => {
-      // one empty cell (8); player to move is player 0 (8 filled); digit 2 fits
-      const board: Board = [1, 2, 3, 2, 3, 1, 3, 1, 0];
-      expect(playerToMove(board)).toBe(0);
-      const { cell, digit } = getRandomBotStep(board);
-      expect(cell).toBe(8);
-      expect(digit).toBe(2);
     });
   });
 });

--- a/src/components/games/latin-square-filling/gameplay.ts
+++ b/src/components/games/latin-square-filling/gameplay.ts
@@ -1,5 +1,4 @@
 import type { MoveOutcome } from '../../strategy-game-factory';
-import { sample } from 'lodash';
 
 // A 3x3 grid, row-major. 0 = empty, 1 | 2 | 3 = a written digit.
 export type Board = number[]; // always length 9
@@ -51,75 +50,6 @@ export const playerToMove = (board: Board): number =>
 // (they are stuck, so player 1 wins).
 export const isTerminal = (board: Board): boolean =>
   isFull(board) || legalMoves(board).length === 0;
-
-// Winner index (0 or 1) under optimal play from `board`, with `playerToMove`
-// to move. The reachable state space is tiny (~1400 positions), so a memoised
-// exhaustive minimax is both fast and provably optimal. Player 0 has a forced
-// win from the empty board (see helpers.spec.ts / the written solution: reach a
-// "mixed rook arrangement" — a transversal holding all three digits).
-const winnerCache = new Map<string, number>();
-
-export const optimalWinner = (board: Board): number => {
-  const key = board.join('');
-  const cached = winnerCache.get(key);
-  if (cached !== undefined) return cached;
-
-  let winner: number;
-  if (isFull(board)) {
-    winner = 0;
-  } else {
-    const moves = legalMoves(board);
-    if (moves.length === 0) {
-      winner = 1;
-    } else {
-      const player = playerToMove(board);
-      winner = moves.some(m => optimalWinner(applyMove(board, m)) === player)
-        ? player
-        : 1 - player;
-    }
-  }
-  winnerCache.set(key, winner);
-  return winner;
-};
-
-// Smart bot: keep a forced win when one exists. From a losing position every
-// move hands the opponent a forced win, so play the reply that leaves the
-// opponent the most losing continuations — the most rope for a non-optimal
-// human to hang themselves with. Random tie-break.
-export const getSmartBotStep = (board: Board): Move => {
-  const me = playerToMove(board);
-  const moves = legalMoves(board);
-
-  const winningMoves = moves.filter(m => optimalWinner(applyMove(board, m)) === me);
-  if (winningMoves.length > 0) return sample(winningMoves)!;
-
-  const trapCount = (m: Move): number => {
-    const next = applyMove(board, m);
-    if (isTerminal(next)) return 0;
-    // opponent replies that (mistakenly) hand the game back to the bot
-    return legalMoves(next).filter(om => optimalWinner(applyMove(next, om)) === me).length;
-  };
-  const scored = moves.map(m => ({ m, traps: trapCount(m) }));
-  const maxTraps = Math.max(...scored.map(s => s.traps));
-  return sample(scored.filter(s => s.traps === maxTraps))!.m;
-};
-
-// Test bot: play a random legal move, but grab an immediate win (a move that
-// ends the game in the bot's favour right now) whenever one is available.
-export const getRandomBotStep = (board: Board): Move => {
-  const me = playerToMove(board);
-  const moves = legalMoves(board);
-
-  const immediateWins = moves.filter(m => {
-    const next = applyMove(board, m);
-    if (isFull(next)) return me === 0; // filled the grid -> player 0 wins
-    if (legalMoves(next).length === 0) return me === 1; // opponent stuck -> player 1 wins
-    return false;
-  });
-  if (immediateWins.length > 0) return sample(immediateWins)!;
-
-  return sample(moves)!;
-};
 
 export const moves = {
   placeDigit: {

--- a/src/components/games/latin-square-filling/latin-square-filling.tsx
+++ b/src/components/games/latin-square-filling/latin-square-filling.tsx
@@ -136,7 +136,7 @@ export const LatinSquareFilling = strategyGameFactory({
       generateStartBoard,
       label: { hu: 'Teszt', en: 'Test' }
     },
-    // smart bot: exhaustive minimax, verified optimal (see helpers.spec.ts)
+    // smart bot: exhaustive minimax, verified optimal (see bot-strategy.spec.ts)
     {
       botStrategy: smartBotStrategy,
       generateStartBoard,

--- a/src/components/games/sum-fifteen/bot-strategy.spec.ts
+++ b/src/components/games/sum-fifteen/bot-strategy.spec.ts
@@ -1,0 +1,84 @@
+import { range } from 'lodash';
+import { chooseSmartMove, chooseTestMove, winnerOptimal } from './bot-strategy';
+import {
+  currentPlayerFromOwner,
+  freeNumbers,
+  generateStartBoard,
+  hasSum15,
+  numbersOwnedBy,
+  type Owner
+} from './gameplay';
+
+describe('winnerOptimal', () => {
+  it('declares the second player the winner from the empty board (optimal play is a draw)', () => {
+    expect(winnerOptimal(generateStartBoard().owner)).toBe(1);
+  });
+
+  it('lets the current player win when a triple summing to 15 is one move away', () => {
+    // First player owns 6 and 8; claiming 1 makes 6 + 8 + 1 = 15.
+    const owner: Owner = [null, null, null, null, null, 0, 1, 0, 1];
+    // numbers owned: player0 -> {6, 8}, player1 -> {7, 9}; player0 to move (4 claimed).
+    expect(currentPlayerFromOwner(owner)).toBe(0);
+    expect(winnerOptimal(owner)).toBe(0);
+  });
+});
+
+// Play out full games; assert the smart bot never loses as the second player,
+// which — since the game has no draws in the players' favour — means it wins.
+const playSmartBotVsRandom = (botPlayer: 0 | 1, rng: () => number): 0 | 1 => {
+  let owner: Owner = generateStartBoard().owner;
+  while (true) {
+    const cp = currentPlayerFromOwner(owner);
+    const move = cp === botPlayer
+      ? chooseSmartMove(owner, cp)
+      : freeNumbers(owner)[Math.floor(rng() * freeNumbers(owner).length)];
+    owner = owner.slice() as Owner;
+    owner[move - 1] = cp;
+    if (hasSum15(numbersOwnedBy(owner, cp))) return cp;
+    if (owner.every(o => o !== null)) return 1;
+  }
+};
+
+describe('chooseSmartMove', () => {
+  it('never loses as the second player against random play', () => {
+    let seed = 1;
+    const rng = () => {
+      // deterministic LCG so the test is reproducible
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+      return seed / 0x7fffffff;
+    };
+    for (const i of range(300)) {
+      expect(playSmartBotVsRandom(1, rng), `game ${i}`).toBe(1);
+    }
+  });
+
+  it('takes an immediate winning number when available', () => {
+    // Player 0 holds 4 and 5; 6 completes 4 + 5 + 6 = 15.
+    const owner: Owner = [null, null, 1, 0, 0, null, 1, null, null];
+    expect(currentPlayerFromOwner(owner)).toBe(0);
+    expect(chooseSmartMove(owner, 0)).toBe(6);
+  });
+
+  it('blocks the opponent immediate threat', () => {
+    // Player 0 holds {1, 3}, player 1 holds {2, 6} (threatening 2 + 6 + 7 = 15);
+    // player 0 to move must take 7 or lose immediately.
+    const owner: Owner = [0, 1, 0, null, null, 1, null, null, null];
+    expect(currentPlayerFromOwner(owner)).toBe(0);
+    expect(chooseSmartMove(owner, 0)).toBe(7);
+  });
+});
+
+describe('chooseTestMove', () => {
+  it('takes a number that completes a triple summing to 15', () => {
+    // Player 0 holds 4 and 5, so 6 wins on the spot.
+    const owner: Owner = [null, null, 1, 0, 0, null, 1, null, null];
+    expect(chooseTestMove(owner, 0)).toBe(6);
+  });
+
+  it('otherwise picks some number nobody has claimed', () => {
+    const owner: Owner = [0, 1, null, null, null, null, null, null, null];
+    for (let i = 0; i < 20; i++) {
+      expect(freeNumbers(owner)).toContain(chooseTestMove(owner, 0));
+    }
+  });
+});

--- a/src/components/games/sum-fifteen/bot-strategy.ts
+++ b/src/components/games/sum-fifteen/bot-strategy.ts
@@ -1,7 +1,95 @@
+import { sample } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
-import { chooseSmartMove, chooseTestMove, currentPlayerFromOwner, type Board, type Moves } from './gameplay';
+import {
+  currentPlayerFromOwner,
+  freeNumbers,
+  hasSum15,
+  numbersOwnedBy,
+  type Board,
+  type Moves,
+  type Owner
+} from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>
+
+// Winner (0 or 1) with optimal play from the given position. There are no draws:
+// if the board fills with no triple summing to 15, the second player (1) wins.
+//
+// This game is tic-tac-toe in disguise — via the magic square, three numbers sum
+// to 15 iff they form a line — so optimal play is a draw and the second player
+// always wins. The state space is tiny (< 3^9), so we just memoise a full search.
+const memo = new Map<string, 0 | 1>();
+
+const key = (owner: Owner) => owner.map(o => (o === null ? '.' : o)).join('');
+
+// Winner if `player` claims `n` from this position, then play continues optimally.
+const outcomeAfterMove = (owner: Owner, n: number, player: 0 | 1): 0 | 1 => {
+  const next = owner.slice();
+  next[n - 1] = player;
+  if (hasSum15(numbersOwnedBy(next, player))) return player;
+  if (next.every(o => o !== null)) return 1;
+  return winnerOptimal(next);
+};
+
+export const winnerOptimal = (owner: Owner): 0 | 1 => {
+  const cached = memo.get(key(owner));
+  if (cached !== undefined) return cached;
+
+  const cp = currentPlayerFromOwner(owner);
+  // If the current player cannot force their own win, the opponent wins.
+  let result: 0 | 1 = (1 - cp) as 0 | 1;
+  for (const n of freeNumbers(owner)) {
+    if (outcomeAfterMove(owner, n, cp) === cp) {
+      result = cp;
+      break;
+    }
+  }
+  memo.set(key(owner), result);
+  return result;
+};
+
+// Optimal move for the bot. Wins immediately when possible; otherwise keeps a
+// forced win if it has one; otherwise (a losing position) plays the move that
+// leaves the opponent the fewest winning replies, maximising the chance a human
+// slips up. This naturally blocks the opponent's immediate threats.
+export const chooseSmartMove = (owner: Owner, currentPlayer: 0 | 1): number => {
+  const free = freeNumbers(owner);
+  const mine = numbersOwnedBy(owner, currentPlayer);
+
+  const immediateWins = free.filter(n => hasSum15([...mine, n]));
+  if (immediateWins.length > 0) return sample(immediateWins)!;
+
+  const winningMoves = free.filter(n => outcomeAfterMove(owner, n, currentPlayer) === currentPlayer);
+  if (winningMoves.length > 0) return sample(winningMoves)!;
+
+  // Losing position: play the toughest defence. Rank moves lexicographically —
+  // (1) don't lose outright by filling the board, (2) don't hand the opponent an
+  // immediate winning reply (i.e. block their threats), (3) among the safe moves,
+  // leave the opponent the fewest winning continuations.
+  const opponent = (1 - currentPlayer) as 0 | 1;
+  const rankOf = (n: number): number => {
+    const next = owner.slice();
+    next[n - 1] = currentPlayer;
+    const freeAfter = freeNumbers(next);
+    const fillLoss = freeAfter.length === 0 ? 1 : 0;
+    const opponentNums = numbersOwnedBy(next, opponent);
+    const givesImmediateWin = freeAfter.some(m => hasSum15([...opponentNums, m])) ? 1 : 0;
+    const winningReplies = freeAfter.filter(m => outcomeAfterMove(next, m, opponent) === opponent).length;
+    return fillLoss * 1000 + givesImmediateWin * 100 + winningReplies;
+  };
+  const ranks = free.map(rankOf);
+  const min = Math.min(...ranks);
+  const leastBad = free.filter((_, i) => ranks[i] === min);
+  return sample(leastBad)!;
+};
+
+// Test bot: plays randomly, but grabs an immediate win when one is available.
+export const chooseTestMove = (owner: Owner, currentPlayer: 0 | 1): number => {
+  const free = freeNumbers(owner);
+  const mine = numbersOwnedBy(owner, currentPlayer);
+  const immediateWins = free.filter(n => hasSum15([...mine, n]));
+  return sample(immediateWins.length > 0 ? immediateWins : free)!;
+};
 
 export const smartBotStrategy: Bot = ({ board, ctx }) => {
   const player = (ctx.currentPlayer ?? currentPlayerFromOwner(board.owner)) as 0 | 1;

--- a/src/components/games/sum-fifteen/gameplay.spec.ts
+++ b/src/components/games/sum-fifteen/gameplay.spec.ts
@@ -1,15 +1,10 @@
-import { range } from 'lodash';
 import {
-  chooseSmartMove,
-  currentPlayerFromOwner,
   findWinningTriple,
   freeNumbers,
-  generateStartBoard,
   hasSum15,
   isChoiceAllowed,
   moves,
   numbersOwnedBy,
-  winnerOptimal,
   type Board,
   type Owner
 } from './gameplay';
@@ -37,65 +32,6 @@ describe('findWinningTriple', () => {
 
   it('returns null when no triple sums to 15', () => {
     expect(findWinningTriple([1, 2, 4])).toBeNull();
-  });
-});
-
-describe('winnerOptimal', () => {
-  it('declares the second player the winner from the empty board (optimal play is a draw)', () => {
-    expect(winnerOptimal(generateStartBoard().owner)).toBe(1);
-  });
-
-  it('lets the current player win when a triple summing to 15 is one move away', () => {
-    // First player owns 6 and 8; claiming 1 makes 6 + 8 + 1 = 15.
-    const owner: Owner = [null, null, null, null, null, 0, 1, 0, 1];
-    // numbers owned: player0 -> {6, 8}, player1 -> {7, 9}; player0 to move (4 claimed).
-    expect(currentPlayerFromOwner(owner)).toBe(0);
-    expect(winnerOptimal(owner)).toBe(0);
-  });
-});
-
-// Play out full games; assert the smart bot never loses as the second player,
-// which — since the game has no draws in the players' favour — means it wins.
-const playSmartBotVsRandom = (botPlayer: 0 | 1, rng: () => number): 0 | 1 => {
-  let owner: Owner = generateStartBoard().owner;
-  while (true) {
-    const cp = currentPlayerFromOwner(owner);
-    const move = cp === botPlayer
-      ? chooseSmartMove(owner, cp)
-      : freeNumbers(owner)[Math.floor(rng() * freeNumbers(owner).length)];
-    owner = owner.slice() as Owner;
-    owner[move - 1] = cp;
-    if (hasSum15(numbersOwnedBy(owner, cp))) return cp;
-    if (owner.every(o => o !== null)) return 1;
-  }
-};
-
-describe('chooseSmartMove', () => {
-  it('never loses as the second player against random play', () => {
-    let seed = 1;
-    const rng = () => {
-      // deterministic LCG so the test is reproducible
-      seed = (seed * 1103515245 + 12345) & 0x7fffffff;
-      return seed / 0x7fffffff;
-    };
-    for (const i of range(300)) {
-      expect(playSmartBotVsRandom(1, rng), `game ${i}`).toBe(1);
-    }
-  });
-
-  it('takes an immediate winning number when available', () => {
-    // Player 0 holds 4 and 5; 6 completes 4 + 5 + 6 = 15.
-    const owner: Owner = [null, null, 1, 0, 0, null, 1, null, null];
-    expect(currentPlayerFromOwner(owner)).toBe(0);
-    expect(chooseSmartMove(owner, 0)).toBe(6);
-  });
-
-  it('blocks the opponent immediate threat', () => {
-    // Player 0 holds {1, 3}, player 1 holds {2, 6} (threatening 2 + 6 + 7 = 15);
-    // player 0 to move must take 7 or lose immediately.
-    const owner: Owner = [0, 1, 0, null, null, 1, null, null, null];
-    expect(currentPlayerFromOwner(owner)).toBe(0);
-    expect(chooseSmartMove(owner, 0)).toBe(7);
   });
 });
 

--- a/src/components/games/sum-fifteen/gameplay.ts
+++ b/src/components/games/sum-fifteen/gameplay.ts
@@ -1,5 +1,4 @@
 import type { MoveOutcome, Ctx } from '../../strategy-game-factory';
-import { sample } from 'lodash';
 
 // owner[i] holds who owns the number (i + 1): 0 = first player, 1 = second
 // player, null = still available.
@@ -50,85 +49,6 @@ export const findWinningTriple = (nums: number[]): number[] | null => {
     }
   }
   return null;
-};
-
-// Winner (0 or 1) with optimal play from the given position. There are no draws:
-// if the board fills with no triple summing to 15, the second player (1) wins.
-//
-// This game is tic-tac-toe in disguise — via the magic square, three numbers sum
-// to 15 iff they form a line — so optimal play is a draw and the second player
-// always wins. The state space is tiny (< 3^9), so we just memoise a full search.
-const memo = new Map<string, 0 | 1>();
-
-const key = (owner: Owner) => owner.map(o => (o === null ? '.' : o)).join('');
-
-// Winner if `player` claims `n` from this position, then play continues optimally.
-const outcomeAfterMove = (owner: Owner, n: number, player: 0 | 1): 0 | 1 => {
-  const next = owner.slice();
-  next[n - 1] = player;
-  if (hasSum15(numbersOwnedBy(next, player))) return player;
-  if (next.every(o => o !== null)) return 1;
-  return winnerOptimal(next);
-};
-
-export const winnerOptimal = (owner: Owner): 0 | 1 => {
-  const cached = memo.get(key(owner));
-  if (cached !== undefined) return cached;
-
-  const cp = currentPlayerFromOwner(owner);
-  // If the current player cannot force their own win, the opponent wins.
-  let result: 0 | 1 = (1 - cp) as 0 | 1;
-  for (const n of freeNumbers(owner)) {
-    if (outcomeAfterMove(owner, n, cp) === cp) {
-      result = cp;
-      break;
-    }
-  }
-  memo.set(key(owner), result);
-  return result;
-};
-
-// Optimal move for the bot. Wins immediately when possible; otherwise keeps a
-// forced win if it has one; otherwise (a losing position) plays the move that
-// leaves the opponent the fewest winning replies, maximising the chance a human
-// slips up. This naturally blocks the opponent's immediate threats.
-export const chooseSmartMove = (owner: Owner, currentPlayer: 0 | 1): number => {
-  const free = freeNumbers(owner);
-  const mine = numbersOwnedBy(owner, currentPlayer);
-
-  const immediateWins = free.filter(n => hasSum15([...mine, n]));
-  if (immediateWins.length > 0) return sample(immediateWins)!;
-
-  const winningMoves = free.filter(n => outcomeAfterMove(owner, n, currentPlayer) === currentPlayer);
-  if (winningMoves.length > 0) return sample(winningMoves)!;
-
-  // Losing position: play the toughest defence. Rank moves lexicographically —
-  // (1) don't lose outright by filling the board, (2) don't hand the opponent an
-  // immediate winning reply (i.e. block their threats), (3) among the safe moves,
-  // leave the opponent the fewest winning continuations.
-  const opponent = (1 - currentPlayer) as 0 | 1;
-  const rankOf = (n: number): number => {
-    const next = owner.slice();
-    next[n - 1] = currentPlayer;
-    const freeAfter = freeNumbers(next);
-    const fillLoss = freeAfter.length === 0 ? 1 : 0;
-    const opponentNums = numbersOwnedBy(next, opponent);
-    const givesImmediateWin = freeAfter.some(m => hasSum15([...opponentNums, m])) ? 1 : 0;
-    const winningReplies = freeAfter.filter(m => outcomeAfterMove(next, m, opponent) === opponent).length;
-    return fillLoss * 1000 + givesImmediateWin * 100 + winningReplies;
-  };
-  const ranks = free.map(rankOf);
-  const min = Math.min(...ranks);
-  const leastBad = free.filter((_, i) => ranks[i] === min);
-  return sample(leastBad)!;
-};
-
-// Test bot: plays randomly, but grabs an immediate win when one is available.
-export const chooseTestMove = (owner: Owner, currentPlayer: 0 | 1): number => {
-  const free = freeNumbers(owner);
-  const mine = numbersOwnedBy(owner, currentPlayer);
-  const immediateWins = free.filter(n => hasSum15([...mine, n]));
-  return sample(immediateWins.length > 0 ? immediateWins : free)!;
 };
 
 export const moves = {

--- a/src/components/games/sum-fifteen/sum-fifteen.tsx
+++ b/src/components/games/sum-fifteen/sum-fifteen.tsx
@@ -102,7 +102,7 @@ export const SumFifteen = strategyGameFactory({
       label: { hu: 'Teszt', en: 'Test' }
     },
     {
-      // smart bot: full optimal search (see winnerOptimal in helpers.ts)
+      // smart bot: full optimal search (see winnerOptimal in bot-strategy.ts)
       botStrategy: smartBotStrategy,
       generateStartBoard,
       label: { hu: 'Teljes', en: 'Full' },

--- a/src/components/games/three-piles-rebuild/bot-strategy.spec.ts
+++ b/src/components/games/three-piles-rebuild/bot-strategy.spec.ts
@@ -1,0 +1,77 @@
+import { range } from 'lodash';
+import {
+  getLosingBotStep,
+  getRandomBotStep,
+  getSmartBotStep,
+  splitWinningNumber
+} from './bot-strategy';
+import { isLosingNumber, isWinningBoard, isWinningNumber, type Board } from './gameplay';
+
+describe('three-piles-rebuild bot', () => {
+  describe('splitWinningNumber', () => {
+    it('splits a winning number into three losing numbers summing to n', () => {
+      range(3, 200).filter(isWinningNumber).forEach(n => {
+        const parts = splitWinningNumber(n);
+        expect(parts).toHaveLength(3);
+        expect(parts.reduce((a, b) => a + b, 0)).toBe(n);
+        parts.forEach(p => {
+          expect(p).toBeGreaterThanOrEqual(1);
+          expect(isLosingNumber(p)).toBe(true);
+        });
+      });
+    });
+
+    it('handles the competition start pile 2010', () => {
+      expect(splitWinningNumber(2010)).toEqual([2, 2, 2006]);
+    });
+  });
+
+  describe('getSmartBotStep', () => {
+    it('from a winning board hands the opponent an all-losing (terminal-or-losing) triple', () => {
+      const boards: Board[] = [[7, 8, 9], [3, 7, 8], [6, 13, 14], [2010, 2011, 2012], [12, 1, 2]];
+      boards.forEach(board => {
+        const { keepId, parts } = getSmartBotStep(board);
+        expect(isWinningNumber(board[keepId])).toBe(true);
+        expect(parts.reduce((a, b) => a + b, 0)).toBe(board[keepId]);
+        // opponent receives a board with no winning pile → losing for them
+        expect(isWinningBoard(parts)).toBe(false);
+      });
+    });
+
+    it('from a losing board still returns a legal split', () => {
+      const { keepId, parts } = getSmartBotStep([7, 8, 13]);
+      expect([7, 8, 13][keepId]).toBeGreaterThanOrEqual(3);
+      expect(parts.reduce((a, b) => a + b, 0)).toBe([7, 8, 13][keepId]);
+      parts.forEach(p => expect(p).toBeGreaterThanOrEqual(1));
+    });
+  });
+
+  describe('getLosingBotStep', () => {
+    it('minimizes the number of winning piles handed to the opponent', () => {
+      // every split of a losing pile leaves >= 1 winning pile; best is exactly 1
+      const { parts } = getLosingBotStep([7, 8, 13]);
+      expect(parts.filter(isWinningNumber).length).toBe(1);
+    });
+  });
+
+  describe('getRandomBotStep', () => {
+    it('grabs an immediate one-move win when a pile is 3..6', () => {
+      [3, 4, 5, 6].forEach(n => {
+        const { keepId, parts } = getRandomBotStep([1, n, 2]);
+        expect([1, n, 2][keepId]).toBe(n);
+        expect(Math.max(...parts)).toBeLessThan(3); // opponent gets a terminal triple
+        expect(parts.reduce((a, b) => a + b, 0)).toBe(n);
+      });
+    });
+
+    it('otherwise returns a legal split of a splittable pile', () => {
+      for (let i = 0; i < 50; i++) {
+        const board: Board = [7, 8, 13];
+        const { keepId, parts } = getRandomBotStep(board);
+        expect(board[keepId]).toBeGreaterThanOrEqual(3);
+        expect(parts.reduce((a, b) => a + b, 0)).toBe(board[keepId]);
+        parts.forEach(p => expect(p).toBeGreaterThanOrEqual(1));
+      }
+    });
+  });
+});

--- a/src/components/games/three-piles-rebuild/bot-strategy.ts
+++ b/src/components/games/three-piles-rebuild/bot-strategy.ts
@@ -1,9 +1,79 @@
+import { random, sample } from 'lodash';
 import type { BotMove, BotStrategy } from '../../strategy-game-factory';
-import { getRandomBotStep, getSmartBotStep, type Board, type Moves } from './gameplay';
+import {
+  canSplit,
+  isWinningNumber,
+  type Board,
+  type BotStep,
+  type Moves
+} from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>
 
-const asTurn = ({ keepId, parts }: { keepId: number; parts: number[] }): BotMove<Moves>[] => [
+// Split a winning number into three losing numbers (the optimal winning move).
+// r in {3,4}: [1,1,n-2]; r in {5,0}: [2,2,n-4]. Every part is ≡1 or 2 (mod 6).
+export const splitWinningNumber = (n: number): number[] => {
+  const r = n % 6;
+  return r === 3 || r === 4 ? [1, 1, n - 2] : [2, 2, n - 4];
+};
+
+// All ordered splits of n into three parts each >= 1.
+const allSplits = (n: number): number[][] => {
+  const splits: number[][] = [];
+  for (let x = 1; x <= n - 2; x++) {
+    for (let y = 1; y <= n - 1 - x; y++) {
+      splits.push([x, y, n - x - y]);
+    }
+  }
+  return splits;
+};
+
+// From a losing position every move hands the opponent a winning triple (see
+// proof). We can't win against optimal play, so play the move that is hardest to
+// answer: minimize the number of winning piles in the result (ideally exactly
+// one), forcing the opponent to find the unique winning pile. Random tie-break.
+export const getLosingBotStep = (board: Board): BotStep => {
+  const candidates: { step: BotStep; winningCount: number }[] = [];
+  board.forEach((n, keepId) => {
+    if (!canSplit(n)) return;
+    for (const parts of allSplits(n)) {
+      candidates.push({ step: { keepId, parts }, winningCount: parts.filter(isWinningNumber).length });
+    }
+  });
+  const minWinning = Math.min(...candidates.map(c => c.winningCount));
+  return sample(candidates.filter(c => c.winningCount === minWinning))!.step;
+};
+
+export const getSmartBotStep = (board: Board): BotStep => {
+  const keepId = board.findIndex(isWinningNumber);
+  if (keepId !== -1) {
+    return { keepId, parts: splitWinningNumber(board[keepId]) };
+  }
+  return getLosingBotStep(board);
+};
+
+// Split n (3..6) so every part is <= 2 — an immediate win (opponent gets a
+// terminal triple). Starts from [1,1,1] and hands out the n-3 spare pebbles.
+const splitForImmediateWin = (n: number): number[] => {
+  const parts = [1, 1, 1];
+  for (let i = 0; i < n - 3; i++) parts[i] += 1;
+  return parts;
+};
+
+// Test bot: plays randomly, but grabs an immediate one-move win when available.
+export const getRandomBotStep = (board: Board): BotStep => {
+  const winNowId = board.findIndex(n => n >= 3 && n <= 6);
+  if (winNowId !== -1) {
+    return { keepId: winNowId, parts: splitForImmediateWin(board[winNowId]) };
+  }
+  const keepId = sample([0, 1, 2].filter(i => canSplit(board[i])))!;
+  const n = board[keepId];
+  const x = random(1, n - 2);
+  const y = random(1, n - 1 - x);
+  return { keepId, parts: [x, y, n - x - y] };
+};
+
+const asTurn = ({ keepId, parts }: BotStep): BotMove<Moves>[] => [
   { move: 'keepPile', args: [keepId] },
   { move: 'splitPile', args: [parts] }
 ];

--- a/src/components/games/three-piles-rebuild/gameplay.spec.ts
+++ b/src/components/games/three-piles-rebuild/gameplay.spec.ts
@@ -1,10 +1,6 @@
-import { range } from 'lodash';
 import {
   generateStartBoard,
   generateTestStartBoard,
-  getLosingBotStep,
-  getRandomBotStep,
-  getSmartBotStep,
   isKeepAllowed,
   isLosingNumber,
   isSplitAllowed,
@@ -12,13 +8,11 @@ import {
   isWinningBoard,
   isWinningNumber,
   keptPileId,
-  moves,
-  splitWinningNumber,
-  type Board
+  moves
 } from './gameplay';
 import { makeCtx } from '../../../test-utils';
 
-describe('three-piles-rebuild helpers', () => {
+describe('three-piles-rebuild gameplay', () => {
   describe('isWinningNumber / isLosingNumber', () => {
     it('classifies losing numbers as n % 6 in {1,2}', () => {
       [1, 2, 7, 8, 13, 14, 19, 20, 2011, 2012].forEach(n => {
@@ -68,73 +62,6 @@ describe('three-piles-rebuild helpers', () => {
       expect(isWinningBoard([7, 8, 13])).toBe(false);
       expect(isWinningBoard([7, 8, 9])).toBe(true);
       expect(isWinningBoard([2010, 2011, 2012])).toBe(true);
-    });
-  });
-
-  describe('splitWinningNumber', () => {
-    it('splits a winning number into three losing numbers summing to n', () => {
-      range(3, 200).filter(isWinningNumber).forEach(n => {
-        const parts = splitWinningNumber(n);
-        expect(parts).toHaveLength(3);
-        expect(parts.reduce((a, b) => a + b, 0)).toBe(n);
-        parts.forEach(p => {
-          expect(p).toBeGreaterThanOrEqual(1);
-          expect(isLosingNumber(p)).toBe(true);
-        });
-      });
-    });
-
-    it('handles the competition start pile 2010', () => {
-      expect(splitWinningNumber(2010)).toEqual([2, 2, 2006]);
-    });
-  });
-
-  describe('getSmartBotStep', () => {
-    it('from a winning board hands the opponent an all-losing (terminal-or-losing) triple', () => {
-      const boards: Board[] = [[7, 8, 9], [3, 7, 8], [6, 13, 14], [2010, 2011, 2012], [12, 1, 2]];
-      boards.forEach(board => {
-        const { keepId, parts } = getSmartBotStep(board);
-        expect(isWinningNumber(board[keepId])).toBe(true);
-        expect(parts.reduce((a, b) => a + b, 0)).toBe(board[keepId]);
-        // opponent receives a board with no winning pile → losing for them
-        expect(isWinningBoard(parts)).toBe(false);
-      });
-    });
-
-    it('from a losing board still returns a legal split', () => {
-      const { keepId, parts } = getSmartBotStep([7, 8, 13]);
-      expect([7, 8, 13][keepId]).toBeGreaterThanOrEqual(3);
-      expect(parts.reduce((a, b) => a + b, 0)).toBe([7, 8, 13][keepId]);
-      parts.forEach(p => expect(p).toBeGreaterThanOrEqual(1));
-    });
-  });
-
-  describe('getLosingBotStep', () => {
-    it('minimizes the number of winning piles handed to the opponent', () => {
-      // every split of a losing pile leaves >= 1 winning pile; best is exactly 1
-      const { parts } = getLosingBotStep([7, 8, 13]);
-      expect(parts.filter(isWinningNumber).length).toBe(1);
-    });
-  });
-
-  describe('getRandomBotStep', () => {
-    it('grabs an immediate one-move win when a pile is 3..6', () => {
-      [3, 4, 5, 6].forEach(n => {
-        const { keepId, parts } = getRandomBotStep([1, n, 2]);
-        expect([1, n, 2][keepId]).toBe(n);
-        expect(Math.max(...parts)).toBeLessThan(3); // opponent gets a terminal triple
-        expect(parts.reduce((a, b) => a + b, 0)).toBe(n);
-      });
-    });
-
-    it('otherwise returns a legal split of a splittable pile', () => {
-      for (let i = 0; i < 50; i++) {
-        const board: Board = [7, 8, 13];
-        const { keepId, parts } = getRandomBotStep(board);
-        expect(board[keepId]).toBeGreaterThanOrEqual(3);
-        expect(parts.reduce((a, b) => a + b, 0)).toBe(board[keepId]);
-        parts.forEach(p => expect(p).toBeGreaterThanOrEqual(1));
-      }
     });
   });
 

--- a/src/components/games/three-piles-rebuild/gameplay.ts
+++ b/src/components/games/three-piles-rebuild/gameplay.ts
@@ -39,7 +39,7 @@ export const isSplitAllowed = (board: Board, parts: number[]): boolean => {
 };
 
 // Winning ("N") numbers are n >= 3 with n % 6 in {0,3,4,5}; the losing ("P")
-// numbers are exactly n % 6 in {1,2} (1,2,7,8,13,14,...). See helpers.spec.ts /
+// numbers are exactly n % 6 in {1,2} (1,2,7,8,13,14,...). See bot-strategy.spec.ts /
 // the written proof: a number is winning iff it can be split into three losing
 // numbers, and only n % 6 in {1,2} cannot.
 export const isWinningNumber = (n: number): boolean =>
@@ -50,69 +50,6 @@ export const isLosingNumber = (n: number): boolean =>
 
 // A triple is winning for the player to move iff it contains a winning pile.
 export const isWinningBoard = (board: Board): boolean => board.some(isWinningNumber);
-
-// Split a winning number into three losing numbers (the optimal winning move).
-// r in {3,4}: [1,1,n-2]; r in {5,0}: [2,2,n-4]. Every part is ≡1 or 2 (mod 6).
-export const splitWinningNumber = (n: number): number[] => {
-  const r = n % 6;
-  return r === 3 || r === 4 ? [1, 1, n - 2] : [2, 2, n - 4];
-};
-
-// All ordered splits of n into three parts each >= 1.
-const allSplits = (n: number): number[][] => {
-  const splits: number[][] = [];
-  for (let x = 1; x <= n - 2; x++) {
-    for (let y = 1; y <= n - 1 - x; y++) {
-      splits.push([x, y, n - x - y]);
-    }
-  }
-  return splits;
-};
-
-// From a losing position every move hands the opponent a winning triple (see
-// proof). We can't win against optimal play, so play the move that is hardest to
-// answer: minimize the number of winning piles in the result (ideally exactly
-// one), forcing the opponent to find the unique winning pile. Random tie-break.
-export const getLosingBotStep = (board: Board): BotStep => {
-  const candidates: { step: BotStep; winningCount: number }[] = [];
-  board.forEach((n, keepId) => {
-    if (!canSplit(n)) return;
-    for (const parts of allSplits(n)) {
-      candidates.push({ step: { keepId, parts }, winningCount: parts.filter(isWinningNumber).length });
-    }
-  });
-  const minWinning = Math.min(...candidates.map(c => c.winningCount));
-  return sample(candidates.filter(c => c.winningCount === minWinning))!.step;
-};
-
-export const getSmartBotStep = (board: Board): BotStep => {
-  const keepId = board.findIndex(isWinningNumber);
-  if (keepId !== -1) {
-    return { keepId, parts: splitWinningNumber(board[keepId]) };
-  }
-  return getLosingBotStep(board);
-};
-
-// Split n (3..6) so every part is <= 2 — an immediate win (opponent gets a
-// terminal triple). Starts from [1,1,1] and hands out the n-3 spare pebbles.
-const splitForImmediateWin = (n: number): number[] => {
-  const parts = [1, 1, 1];
-  for (let i = 0; i < n - 3; i++) parts[i] += 1;
-  return parts;
-};
-
-// Test bot: plays randomly, but grabs an immediate one-move win when available.
-export const getRandomBotStep = (board: Board): BotStep => {
-  const winNowId = board.findIndex(n => n >= 3 && n <= 6);
-  if (winNowId !== -1) {
-    return { keepId: winNowId, parts: splitForImmediateWin(board[winNowId]) };
-  }
-  const keepId = sample([0, 1, 2].filter(i => canSplit(board[i])))!;
-  const n = board[keepId];
-  const x = random(1, n - 2);
-  const y = random(1, n - 1 - x);
-  return { keepId, parts: [x, y, n - x - y] };
-};
 
 // Starting-position ranges. Floors avoid trivial 1-move wins from tiny piles;
 // maxes are tuned so optimal games last ~2-6 moves — change a max to retune.

--- a/src/components/games/two-of-three-takeaway/bot-strategy.spec.ts
+++ b/src/components/games/two-of-three-takeaway/bot-strategy.spec.ts
@@ -1,0 +1,106 @@
+import {
+  getRandomBotMove,
+  getSmartBotMove,
+  isWinningBoard,
+  isWinningInOneMove
+} from './bot-strategy';
+import { applyMove, generateStartBoard, getLegalMoves, isTerminal, type Board } from './gameplay';
+
+// Exhaustive game-theoretic value: the player to move wins iff some move leads
+// to a position from which the opponent loses. Positions are symmetric in the
+// three fields, so we memoise on the sorted triple.
+const minimaxWin = (() => {
+  const memo = new Map<string, boolean>();
+  const solve = (board: Board): boolean => {
+    const key = [...board].sort((a, b) => a - b).join(',');
+    if (memo.has(key)) return memo.get(key)!;
+    const moves = getLegalMoves(board);
+    // Set before recursing to guard against re-entry; positions are acyclic
+    // (the total strictly decreases) so this is only a micro-optimisation.
+    const win = moves.some(m => !solve(applyMove(board, m)));
+    memo.set(key, win);
+    return win;
+  };
+  return solve;
+})();
+
+// All boards with an even total (the only positions reachable during play) and
+// each field in 0..10.
+const evenTotalBoards = (): Board[] => {
+  const boards: Board[] = [];
+  for (let a = 0; a <= 10; a++) {
+    for (let b = 0; b <= 10; b++) {
+      for (let c = 0; c <= 10; c++) {
+        if ((a + b + c) % 2 === 0) boards.push([a, b, c]);
+      }
+    }
+  }
+  return boards;
+};
+
+describe('two-of-three-takeaway bot', () => {
+  it('detects a move that wins immediately', () => {
+    expect(isWinningInOneMove([1, 1, 0], [0, 1])).toBe(true); // -> [0,0,0]
+    expect(isWinningInOneMove([1, 3, 0], [0, 1])).toBe(true); // -> [0,2,0]
+    expect(isWinningInOneMove([2, 2, 0], [0, 1])).toBe(false); // -> [1,1,0]
+  });
+
+  describe('winning-position characterisation', () => {
+    it('matches exhaustive minimax on every even-total board', () => {
+      for (const board of evenTotalBoards()) {
+        expect(isWinningBoard(board)).toBe(minimaxWin(board));
+      }
+    });
+
+    it('is a type (b) position (two odd fields) that wins', () => {
+      expect(isWinningBoard([3, 2, 5])).toBe(true);
+      expect(isWinningBoard([1, 0, 0])).toBe(false); // odd total is unreachable, still not two odds
+      expect(isWinningBoard([2, 2, 2])).toBe(false);
+    });
+  });
+
+  describe('smart bot', () => {
+    it('from a winning position leaves the opponent a losing position', () => {
+      for (const board of evenTotalBoards()) {
+        if (!isWinningBoard(board)) continue;
+        const next = applyMove(board, getSmartBotMove(board));
+        expect(minimaxWin(next)).toBe(false);
+      }
+    });
+
+    it('always makes a legal move', () => {
+      for (const board of evenTotalBoards()) {
+        if (isTerminal(board)) continue;
+        const move = getSmartBotMove(board);
+        expect(getLegalMoves(board)).toContainEqual(move);
+      }
+    });
+
+    it('takes from the two odd fields in a type (b) position', () => {
+      expect(getSmartBotMove([4, 1, 3])).toEqual([1, 2]);
+      expect(getSmartBotMove([5, 1, 0])).toEqual([0, 1]);
+    });
+  });
+
+  // generateStartBoard aims for a ~50/50 split between the two roles, which is a
+  // claim about the characterisation rather than about the board shape.
+  describe('generateStartBoard balance', () => {
+    it('produces both winning and losing starting positions', () => {
+      const results = new Set<boolean>();
+      for (let i = 0; i < 500; i++) results.add(isWinningBoard(generateStartBoard()));
+      expect(results).toEqual(new Set([true, false]));
+    });
+  });
+
+  describe('random (test) bot', () => {
+    it('grabs an immediate one-move win when available', () => {
+      expect(isWinningInOneMove([1, 3, 0], getRandomBotMove([1, 3, 0]))).toBe(true);
+      expect(isWinningInOneMove([1, 1, 4], getRandomBotMove([1, 1, 4]))).toBe(true);
+    });
+
+    it('makes a legal move otherwise', () => {
+      const move = getRandomBotMove([4, 2, 6]);
+      expect(getLegalMoves([4, 2, 6])).toContainEqual(move);
+    });
+  });
+});

--- a/src/components/games/two-of-three-takeaway/bot-strategy.ts
+++ b/src/components/games/two-of-three-takeaway/bot-strategy.ts
@@ -1,7 +1,41 @@
+import { sample } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
-import { getRandomBotMove, getSmartBotMove, type Board, type Moves } from './gameplay';
+import { applyMove, getLegalMoves, isTerminal, type Board, type Move, type Moves } from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>
+
+// A move wins immediately when it leaves the opponent unable to move (at most
+// one non-empty pile remains).
+export const isWinningInOneMove = (board: Board, move: Move): boolean =>
+  isTerminal(applyMove(board, move));
+
+const oddPiles = (board: Board): number[] =>
+  board.map((v, i) => i).filter(i => board[i] % 2 === 1);
+
+// Because the total is even, the number of odd piles is even: either 0 (all
+// piles even — type (a)) or 2 (two odd, one even — type (b)). The player to
+// move wins exactly from type (b): taking a chip from each of the two odd
+// piles leaves three even piles (type (a)) for the opponent, who is then
+// forced back into a type (b) position (or has already lost). See the spec
+// for an exhaustive minimax check of this characterisation.
+export const isWinningBoard = (board: Board): boolean => oddPiles(board).length === 2;
+
+export const getSmartBotMove = (board: Board): Move => {
+  const odds = oddPiles(board);
+  if (odds.length === 2) return [odds[0], odds[1]];
+  // Losing position (all even): every move hands the opponent a winning type
+  // (b) position, so we cannot win against optimal play. Play any legal move
+  // and hope the opponent slips up.
+  return sample(getLegalMoves(board))!;
+};
+
+// Test bot: play a random legal move, but grab an immediate one-move win when
+// one is available.
+export const getRandomBotMove = (board: Board): Move => {
+  const moves = getLegalMoves(board);
+  const winningNow = moves.filter(m => isWinningInOneMove(board, m));
+  return sample(winningNow.length > 0 ? winningNow : moves)!;
+};
 
 export const smartBotStrategy: Bot = ({ board }) => {
   const [i, j] = getSmartBotMove(board);

--- a/src/components/games/two-of-three-takeaway/gameplay.spec.ts
+++ b/src/components/games/two-of-three-takeaway/gameplay.spec.ts
@@ -3,50 +3,14 @@ import {
   canMove,
   generateStartBoard,
   getLegalMoves,
-  getRandomBotMove,
-  getSmartBotMove,
   isTakeAllowed,
   isTerminal,
-  isWinningBoard,
-  isWinningInOneMove,
   moves,
   type Board
 } from './gameplay';
 import { makeCtx } from '../../../test-utils';
 
-// Exhaustive game-theoretic value: the player to move wins iff some move leads
-// to a position from which the opponent loses. Positions are symmetric in the
-// three fields, so we memoise on the sorted triple.
-const minimaxWin = (() => {
-  const memo = new Map<string, boolean>();
-  const solve = (board: Board): boolean => {
-    const key = [...board].sort((a, b) => a - b).join(',');
-    if (memo.has(key)) return memo.get(key)!;
-    const moves = getLegalMoves(board);
-    // Set before recursing to guard against re-entry; positions are acyclic
-    // (the total strictly decreases) so this is only a micro-optimisation.
-    const win = moves.some(m => !solve(applyMove(board, m)));
-    memo.set(key, win);
-    return win;
-  };
-  return solve;
-})();
-
-// All boards with an even total (the only positions reachable during play) and
-// each field in 0..10.
-const evenTotalBoards = (): Board[] => {
-  const boards: Board[] = [];
-  for (let a = 0; a <= 10; a++) {
-    for (let b = 0; b <= 10; b++) {
-      for (let c = 0; c <= 10; c++) {
-        if ((a + b + c) % 2 === 0) boards.push([a, b, c]);
-      }
-    }
-  }
-  return boards;
-};
-
-describe('two-of-three-takeaway helpers', () => {
+describe('two-of-three-takeaway gameplay', () => {
   describe('move mechanics', () => {
     it('takes one chip from each chosen field', () => {
       expect(applyMove([3, 2, 5], [0, 2])).toEqual([2, 2, 4]);
@@ -64,61 +28,6 @@ describe('two-of-three-takeaway helpers', () => {
       expect(getLegalMoves([2, 3, 1])).toEqual([[0, 1], [0, 2], [1, 2]]);
       expect(getLegalMoves([5, 0, 0])).toEqual([]);
     });
-
-    it('detects a move that wins immediately', () => {
-      expect(isWinningInOneMove([1, 1, 0], [0, 1])).toBe(true); // -> [0,0,0]
-      expect(isWinningInOneMove([1, 3, 0], [0, 1])).toBe(true); // -> [0,2,0]
-      expect(isWinningInOneMove([2, 2, 0], [0, 1])).toBe(false); // -> [1,1,0]
-    });
-  });
-
-  describe('winning-position characterisation', () => {
-    it('matches exhaustive minimax on every even-total board', () => {
-      for (const board of evenTotalBoards()) {
-        expect(isWinningBoard(board)).toBe(minimaxWin(board));
-      }
-    });
-
-    it('is a type (b) position (two odd fields) that wins', () => {
-      expect(isWinningBoard([3, 2, 5])).toBe(true);
-      expect(isWinningBoard([1, 0, 0])).toBe(false); // odd total is unreachable, still not two odds
-      expect(isWinningBoard([2, 2, 2])).toBe(false);
-    });
-  });
-
-  describe('smart bot', () => {
-    it('from a winning position leaves the opponent a losing position', () => {
-      for (const board of evenTotalBoards()) {
-        if (!isWinningBoard(board)) continue;
-        const next = applyMove(board, getSmartBotMove(board));
-        expect(minimaxWin(next)).toBe(false);
-      }
-    });
-
-    it('always makes a legal move', () => {
-      for (const board of evenTotalBoards()) {
-        if (isTerminal(board)) continue;
-        const move = getSmartBotMove(board);
-        expect(getLegalMoves(board)).toContainEqual(move);
-      }
-    });
-
-    it('takes from the two odd fields in a type (b) position', () => {
-      expect(getSmartBotMove([4, 1, 3])).toEqual([1, 2]);
-      expect(getSmartBotMove([5, 1, 0])).toEqual([0, 1]);
-    });
-  });
-
-  describe('random (test) bot', () => {
-    it('grabs an immediate one-move win when available', () => {
-      expect(isWinningInOneMove([1, 3, 0], getRandomBotMove([1, 3, 0]))).toBe(true);
-      expect(isWinningInOneMove([1, 1, 4], getRandomBotMove([1, 1, 4]))).toBe(true);
-    });
-
-    it('makes a legal move otherwise', () => {
-      const move = getRandomBotMove([4, 2, 6]);
-      expect(getLegalMoves([4, 2, 6])).toContainEqual(move);
-    });
   });
 
   describe('generateStartBoard', () => {
@@ -133,12 +42,6 @@ describe('two-of-three-takeaway helpers', () => {
         expect(board.every(v => v > 0)).toBe(true);
         expect(canMove(board)).toBe(true);
       }
-    });
-
-    it('produces both winning and losing starting positions', () => {
-      const results = new Set<boolean>();
-      for (let i = 0; i < 500; i++) results.add(isWinningBoard(generateStartBoard()));
-      expect(results).toEqual(new Set([true, false]));
     });
   });
 });

--- a/src/components/games/two-of-three-takeaway/gameplay.ts
+++ b/src/components/games/two-of-three-takeaway/gameplay.ts
@@ -1,5 +1,5 @@
 import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
-import { random, sample } from 'lodash';
+import { random } from 'lodash';
 
 // Chips in each of the three piles. The total is always even (it starts even
 // and every move removes exactly two chips).
@@ -33,39 +33,6 @@ export const getLegalMoves = (board: Board): Move[] => {
     }
   }
   return moves;
-};
-
-// A move wins immediately when it leaves the opponent unable to move (at most
-// one non-empty pile remains).
-export const isWinningInOneMove = (board: Board, move: Move): boolean =>
-  isTerminal(applyMove(board, move));
-
-const oddPiles = (board: Board): number[] =>
-  board.map((v, i) => i).filter(i => board[i] % 2 === 1);
-
-// Because the total is even, the number of odd piles is even: either 0 (all
-// piles even — type (a)) or 2 (two odd, one even — type (b)). The player to
-// move wins exactly from type (b): taking a chip from each of the two odd
-// piles leaves three even piles (type (a)) for the opponent, who is then
-// forced back into a type (b) position (or has already lost). See helpers.spec
-// for an exhaustive minimax check of this characterisation.
-export const isWinningBoard = (board: Board): boolean => oddPiles(board).length === 2;
-
-export const getSmartBotMove = (board: Board): Move => {
-  const odds = oddPiles(board);
-  if (odds.length === 2) return [odds[0], odds[1]];
-  // Losing position (all even): every move hands the opponent a winning type
-  // (b) position, so we cannot win against optimal play. Play any legal move
-  // and hope the opponent slips up.
-  return sample(getLegalMoves(board))!;
-};
-
-// Test bot: play a random legal move, but grab an immediate one-move win when
-// one is available.
-export const getRandomBotMove = (board: Board): Move => {
-  const moves = getLegalMoves(board);
-  const winningNow = moves.filter(m => isWinningInOneMove(board, m));
-  return sample(winningNow.length > 0 ? winningNow : moves)!;
 };
 
 // --- Starting positions -----------------------------------------------------

--- a/src/components/games/two-of-three-takeaway/two-of-three-takeaway.tsx
+++ b/src/components/games/two-of-three-takeaway/two-of-three-takeaway.tsx
@@ -121,7 +121,7 @@ export const TwoOfThreeTakeaway = strategyGameFactory({
       generateStartBoard,
       label: { hu: 'Teszt', en: 'Test' }
     },
-    // smart bot: verified as optimal (see helpers.spec.ts exhaustive minimax check)
+    // smart bot: verified as optimal (see bot-strategy.spec.ts exhaustive minimax check)
     {
       botStrategy: smartBotStrategy,
       generateStartBoard,


### PR DESCRIPTION
Follow-up from the rule-text cross-check. AGENTS.md draws the line twice — *"a predicate that exists only to characterise the winning strategy belongs with the bot, not in `gameplay.ts`"*, and a spec is *"named after the module whose behaviour it asserts"* — and five games sat on the wrong side of both.

In each, the whole search and both move-choosers lived in `gameplay.ts` behind a two-line `bot-strategy.ts` wrapper, and the bot tests sat in `gameplay.spec.ts` with no `bot-strategy.spec.ts` at all:

| game | moved to `bot-strategy.ts` |
|---|---|
| `four-piles-two-grabs` | `getSmartBotMove`, `getRandomBotMove` |
| `latin-square-filling` | `optimalWinner`, `getSmartBotStep`, `getRandomBotStep` |
| `two-of-three-takeaway` | `isWinningBoard`, `getSmartBotMove`, `getRandomBotMove` |
| `three-piles-rebuild` | `splitWinningNumber`, `getLosingBotStep`, `get*BotStep` |
| `sum-fifteen` | `winnerOptimal`, `chooseSmartMove`, `chooseTestMove` |

All five are ex-`helpers.ts` files, so this is the move that rename should have made. Every other game in the repo is already shaped this way.

### What stays behind

The win/loss predicate a `generateStartBoard` reads to balance its start boards — the exemption AGENTS.md grants explicitly (as with `coins-in-3-piles`' `isLostForMover`). That's why `four-piles-two-grabs` keeps `isWinningBoard` and `three-piles-rebuild` keeps `isWinningNumber`/`isLosingNumber`. `two-of-three-takeaway` and `sum-fifteen` build their start boards without consulting the characterisation, so theirs move wholesale.

### Tests

Each game gains a `bot-strategy.spec.ts` holding its exhaustive-minimax oracle and bot assertions. A few assertions moved with the module they were really about:

- `latin-square-filling`: "a completed Latin square is a first-player win" (a search claim inside a `isFull`/`isTerminal` test)
- `two-of-three-takeaway`: immediate-win detection, and the `generateStartBoard` 50/50 balance check — that one asserts the characterisation, not the board shape

The move also exposed that `sum-fifteen`'s **test bot had no coverage at all** — the opponent in its playout harness is a seeded RNG, not `chooseTestMove` — so it gets the two cases the other games' test bots have.

### Housekeeping

Drops the last ten references to a `helpers` module that no longer exists, including two in game files pointing at a `helpers.ts` (`sum-fifteen`, `chocolate-breaking`) that were never part of this group.

### Verification

No behaviour changes — same functions, same call sites. `npm test` green: 1588 tests across 176 files, plus lint and `tsc --noEmit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01832SpPq9YC5AGcYZn5NYkZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01832SpPq9YC5AGcYZn5NYkZ)_