### PR TITLE
Pin four rule clauses that no test reached

### DIFF
--- a/src/components/games/architect-and-bandits/architect-and-bandits-a/gameplay.spec.ts
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-a/gameplay.spec.ts
@@ -1,5 +1,5 @@
-import { moves } from './gameplay';
-import { ARCHITECT, BANDITS, type Board } from '../gameplay';
+import { generateStartBoard, moves } from './gameplay';
+import { ARCHITECT, BANDITS, KM_PER_EDGE, type Board } from '../gameplay';
 import { makeCtx } from '../../../../test-utils';
 
 // After the fourth day the architect wins exactly when every vertex carries a
@@ -40,5 +40,46 @@ describe('architect-and-bandits-a end of game', () => {
     expect(outcome.autoEndOfTurn).toBe(true);
     // the scheduled `startNextDay` is what ends the turn, not this move
     expect(outcome.isTurnEnd).toBeUndefined();
+  });
+});
+
+// The rule builds a tower wherever the architect's journey touches a bare
+// vertex, "including at the very start or end of the day". That happens in three
+// places, none of which the end-of-game tests above reach.
+describe('architect-and-bandits-a tower building', () => {
+  const noTowers = () => Array(VERTEX_COUNT).fill(false);
+
+  it('raises a tower on every vertex the architect steps onto', () => {
+    const board = { architectPosition: 0, towers: noTowers(), day: 1, kmUsedToday: 0 };
+    const outcome = moves.moveArchitect.apply(board, meta, 1);
+    expect(outcome.nextBoard.towers[1]).toBe(true);
+    expect(outcome.nextBoard.architectPosition).toBe(1);
+    // walking uses up the day's allowance one edge at a time
+    expect(outcome.nextBoard.kmUsedToday).toBe(KM_PER_EDGE);
+    // the architect may keep walking, so the turn stays open
+    expect(outcome.isTurnEnd).toBeUndefined();
+    expect(outcome.gameEnd).toBeUndefined();
+  });
+
+  it('leaves a tower the bandits knocked down standing again at dawn', () => {
+    // the architect spent the night on vertex 3 and the bandits razed it
+    const towers = Array(VERTEX_COUNT).fill(true);
+    towers[3] = false;
+    const outcome = moves.startNextDay.apply({
+      architectPosition: 3, towers, day: 2, kmUsedToday: 40
+    });
+    expect(outcome.nextBoard.towers[3]).toBe(true);
+    expect(outcome.nextBoard.day).toBe(3);
+    expect(outcome.nextBoard.kmUsedToday).toBe(0);
+    expect(outcome.isTurnEnd).toBe(true);
+  });
+
+  it('starts day 1 with a tower already on the architect\'s vertex', () => {
+    const board = generateStartBoard();
+    expect(board.towers).toHaveLength(VERTEX_COUNT);
+    expect(board.architectPosition).toBe(0);
+    expect(board.towers[0]).toBe(true);
+    expect(board.towers.filter(Boolean)).toHaveLength(1);
+    expect(board.day).toBe(1);
   });
 });

--- a/src/components/games/architect-and-bandits/architect-and-bandits-b/gameplay.spec.ts
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-b/gameplay.spec.ts
@@ -1,5 +1,5 @@
-import { moves } from './gameplay';
-import { ARCHITECT, BANDITS, type Board } from '../gameplay';
+import { generateStartBoard, moves } from './gameplay';
+import { ARCHITECT, BANDITS, KM_PER_EDGE, type Board } from '../gameplay';
 import { makeCtx } from '../../../../test-utils';
 
 // After the fourth day the architect wins exactly when every vertex carries a
@@ -40,5 +40,46 @@ describe('architect-and-bandits-b end of game', () => {
     expect(outcome.autoEndOfTurn).toBe(true);
     // the scheduled `startNextDay` is what ends the turn, not this move
     expect(outcome.isTurnEnd).toBeUndefined();
+  });
+});
+
+// The rule builds a tower wherever the architect's journey touches a bare
+// vertex, "including at the very start or end of the day". That happens in three
+// places, none of which the end-of-game tests above reach.
+describe('architect-and-bandits-b tower building', () => {
+  const noTowers = () => Array(VERTEX_COUNT).fill(false);
+
+  it('raises a tower on every vertex the architect steps onto', () => {
+    const board = { architectPosition: 0, towers: noTowers(), day: 1, kmUsedToday: 0 };
+    const outcome = moves.moveArchitect.apply(board, meta, 1);
+    expect(outcome.nextBoard.towers[1]).toBe(true);
+    expect(outcome.nextBoard.architectPosition).toBe(1);
+    // walking uses up the day's allowance one edge at a time
+    expect(outcome.nextBoard.kmUsedToday).toBe(KM_PER_EDGE);
+    // the architect may keep walking, so the turn stays open
+    expect(outcome.isTurnEnd).toBeUndefined();
+    expect(outcome.gameEnd).toBeUndefined();
+  });
+
+  it('leaves a tower the bandits knocked down standing again at dawn', () => {
+    // the architect spent the night on vertex 3 and the bandits razed it
+    const towers = Array(VERTEX_COUNT).fill(true);
+    towers[3] = false;
+    const outcome = moves.startNextDay.apply({
+      architectPosition: 3, towers, day: 2, kmUsedToday: 40
+    });
+    expect(outcome.nextBoard.towers[3]).toBe(true);
+    expect(outcome.nextBoard.day).toBe(3);
+    expect(outcome.nextBoard.kmUsedToday).toBe(0);
+    expect(outcome.isTurnEnd).toBe(true);
+  });
+
+  it('starts day 1 with a tower already on the architect\'s vertex', () => {
+    const board = generateStartBoard();
+    expect(board.towers).toHaveLength(VERTEX_COUNT);
+    expect(board.architectPosition).toBe(0);
+    expect(board.towers[0]).toBe(true);
+    expect(board.towers.filter(Boolean)).toHaveLength(1);
+    expect(board.day).toBe(1);
   });
 });

--- a/src/components/games/bacteria/gameplay.spec.ts
+++ b/src/components/games/bacteria/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import {
-  distanceFromDangerousAttackZone, isDangerous, moves, applyAttackMove,
+  distanceFromDangerousAttackZone, isDangerous, moves, applyAttackMove, totalBacteria,
   hasBacterium, isAttackAllowed, ATTACKER, DEFENDER, type MoveType
 } from "./gameplay";
 import { reverse } from 'lodash';
@@ -107,6 +107,56 @@ describe('moves', () => {
     }
   });
 })
+
+// The rule moves and divides a whole cell at once: a shift takes *all* the
+// bacteria of the cell one step sideways, and a division sends a copy of *every*
+// bacterium on it to each of the two cells ahead — doubling the stack. Every
+// other test here uses a single bacterium, where "all of them" and "one of them"
+// are indistinguishable.
+describe('a whole cell moves at once', () => {
+  const withStack = (count: number) => ({
+    bacteria: [
+      [0, count, 0],
+        [0, 0],
+      [0, 0, 0]
+    ],
+    goals: [1]
+  });
+
+  it('shifts every bacterium of the cell, not just one', () => {
+    const { nextBoard } = applyAttackMove(withStack(4), { type: 'shiftRight', row: 0, col: 1 });
+    expect(nextBoard.bacteria[0]).toEqual([0, 0, 4]);
+  });
+
+  it('gives each of the division targets a copy of the whole stack', () => {
+    // From the wide row 0 the two cells ahead are (1,0) and (1,1), so a stack of
+    // three becomes three in each — six bacteria from three.
+    const { nextBoard } = applyAttackMove(withStack(3), { type: 'spread', row: 0, col: 1 });
+    expect(nextBoard.bacteria[0]).toEqual([0, 0, 0]);
+    expect(nextBoard.bacteria[1]).toEqual([3, 3]);
+    expect(totalBacteria(nextBoard)).toBe(6);
+  });
+
+  it('adds the stack to whatever the target cell already holds', () => {
+    const board = {
+      bacteria: [
+        [0, 2, 0],
+          [5, 0],
+        [0, 0, 0]
+      ],
+      goals: [1]
+    };
+    const { nextBoard } = applyAttackMove(board, { type: 'spread', row: 0, col: 1 });
+    expect(nextBoard.bacteria[1]).toEqual([7, 2]);
+  });
+
+  it('moves a single bacterium on a jump, however tall the stack', () => {
+    const { nextBoard } = applyAttackMove(withStack(4), { type: 'jump', row: 0, col: 1 });
+    expect(nextBoard.bacteria[0]).toEqual([0, 3, 0]);
+    expect(nextBoard.bacteria[2]).toEqual([0, 1, 0]);
+    expect(totalBacteria(nextBoard)).toBe(4);
+  });
+});
 
 describe('legality', () => {
   // Three rows: wide (3), narrow (2), wide (3). A single bacterium sits in the

--- a/src/components/games/chess-knight/gameplay.spec.ts
+++ b/src/components/games/chess-knight/gameplay.spec.ts
@@ -1,9 +1,76 @@
-import { generateStartBoard, getAllowedMoves, moves } from './gameplay';
+import { range } from 'lodash';
+import { generateStartBoard, getAllowedMoves, moves, type Board, type CellValue } from './gameplay';
 import { makeCtx } from '../../../test-utils';
+
+// A 4x4 board with the knight at `knightPosition` and `visited` already toured.
+const boardWith = (knightPosition: { row: number; col: number }, visited: number[][] = []): Board => {
+  const chessBoard: CellValue[][] = range(4).map(() => range(4).map((): CellValue => null));
+  visited.forEach(([row, col]) => { chessBoard[row][col] = 'visited'; });
+  chessBoard[knightPosition.row][knightPosition.col] = 'knight';
+  return { chessBoard, knightPosition };
+};
+
+const sorted = (fields: { row: number; col: number }[]) =>
+  [...fields].sort((a, b) => a.row - b.row || a.col - b.col);
+
+describe('getAllowedMoves', () => {
+  it('offers exactly the knight jumps that stay on the 4x4 board', () => {
+    // From (1,1) only four of the eight L-shapes land on the board; the other
+    // four run off the top or the left edge.
+    expect(sorted(getAllowedMoves(boardWith({ row: 1, col: 1 })))).toEqual(sorted([
+      { row: 0, col: 3 }, { row: 2, col: 3 }, { row: 3, col: 0 }, { row: 3, col: 2 }
+    ]));
+  });
+
+  it('never offers a step that is not an L-shape', () => {
+    for (const { row, col } of getAllowedMoves(boardWith({ row: 1, col: 2 }))) {
+      const dRow = Math.abs(row - 1), dCol = Math.abs(col - 2);
+      expect([dRow, dCol].sort()).toEqual([1, 2]);
+    }
+  });
+
+  it('drops every square the knight has already visited', () => {
+    const free = getAllowedMoves(boardWith({ row: 0, col: 0 }));
+    expect(free).toContainEqual({ row: 1, col: 2 });
+
+    const withVisit = getAllowedMoves(boardWith({ row: 0, col: 0 }, [[1, 2]]));
+    expect(withVisit).not.toContainEqual({ row: 1, col: 2 });
+    expect(withVisit).toContainEqual({ row: 2, col: 1 });
+  });
+
+  it('leaves the knight stranded once every reachable square is visited', () => {
+    // The corner (0,0) reaches only (1,2) and (2,1).
+    expect(getAllowedMoves(boardWith({ row: 0, col: 0 }, [[1, 2], [2, 1]]))).toEqual([]);
+  });
+});
+
+describe('generateStartBoard', () => {
+  it('puts a single knight on the board and marks nothing visited', () => {
+    for (let i = 0; i < 50; i++) {
+      const { chessBoard, knightPosition } = generateStartBoard();
+      const cells = chessBoard.flat();
+      expect(cells.filter(cell => cell === 'knight')).toHaveLength(1);
+      expect(cells.filter(cell => cell === 'visited')).toHaveLength(0);
+      expect(chessBoard[knightPosition.row][knightPosition.col]).toBe('knight');
+    }
+  });
+});
 
 // The knight may never revisit a square, so the tour dies out on its own; the
 // player who makes the last move wins.
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
+
+describe('moves.moveKnight', () => {
+  it('marks the square the knight leaves, so it can never be re-entered', () => {
+    const board = boardWith({ row: 0, col: 0 });
+    const { nextBoard } = moves.moveKnight.apply(board, asPlayer(0), { row: 1, col: 2 });
+    expect(nextBoard.chessBoard[0][0]).toBe('visited');
+    expect(nextBoard.chessBoard[1][2]).toBe('knight');
+    expect(nextBoard.knightPosition).toEqual({ row: 1, col: 2 });
+    // the start square is off limits from now on, exactly as the rule says
+    expect(getAllowedMoves(nextBoard)).not.toContainEqual({ row: 0, col: 0 });
+  });
+});
 
 describe('end of game', () => {
   it('ends exactly on the move that strands the knight', () => {

--- a/src/components/games/thief-sheriff-mean/gameplay.spec.ts
+++ b/src/components/games/thief-sheriff-mean/gameplay.spec.ts
@@ -1,4 +1,4 @@
-import { isCardAvailable, type Board } from './gameplay';
+import { hasWinningTriple, isCardAvailable, type Board } from './gameplay';
 
 // cards[Sheriff] first, then cards[Thief].
 const board: Board = { cards: [[2, 5], [3]], numTurns: 0 };
@@ -23,5 +23,43 @@ describe('isCardAvailable', () => {
     // 8 and 9 exist in the nine-card variant but not in the seven-card one
     expect(isCardAvailable(board, 9, 8)).toBe(true);
     expect(isCardAvailable(board, 7, 8)).toBe(false);
+  });
+});
+
+// The whole rule turns on this: the thief wins by holding three cards where one
+// number is the average of the other two — equivalently, three in arithmetic
+// progression, in any order.
+describe('hasWinningTriple', () => {
+  it('finds three cards in arithmetic progression', () => {
+    expect(hasWinningTriple([1, 2, 3])).toBe(true);
+    expect(hasWinningTriple([1, 5, 9])).toBe(true);
+    expect(hasWinningTriple([2, 6, 4])).toBe(true); // 4 is the average of 2 and 6
+  });
+
+  it('does not care what order the cards were collected in', () => {
+    expect(hasWinningTriple([9, 1, 5])).toBe(true);
+    expect(hasWinningTriple([5, 9, 1])).toBe(true);
+  });
+
+  it('finds a triple hidden among other cards', () => {
+    // 3, 5, 7 is the progression; 2 and 8 are noise
+    expect(hasWinningTriple([2, 3, 5, 7, 8])).toBe(true);
+  });
+
+  it('rejects a hand with no such triple', () => {
+    expect(hasWinningTriple([1, 2, 4])).toBe(false);
+    // none of {1,2,6}, {1,2,7}, {1,6,7}, {2,6,7} is a progression
+    expect(hasWinningTriple([1, 2, 6, 7])).toBe(false);
+  });
+
+  it('needs three cards — a pair is never enough', () => {
+    expect(hasWinningTriple([])).toBe(false);
+    expect(hasWinningTriple([5])).toBe(false);
+    expect(hasWinningTriple([2, 4])).toBe(false);
+  });
+
+  it('needs three *different* cards, not one used twice', () => {
+    // 2 and 6 average to 4, but the hand has no 4 to hold
+    expect(hasWinningTriple([2, 6])).toBe(false);
   });
 });


### PR DESCRIPTION
Follow-up from the rule-text cross-check. Tests only — no source changes. In each of these the rule says something distinctive and the spec never checked it, so a regression would have gone through green.

### `bacteria` — a whole cell moves at once

The rule shifts **all** the bacteria off a cell, and a division sends a copy of **every** bacterium to each of the two cells ahead, doubling the stack. Every existing test used a cell holding exactly one bacterium, where *all of them* and *one of them* are indistinguishable.

Mutation-checked: replacing `count` with `1` in `applyAttackMove` passed the entire suite before this PR; it now fails three tests.

```
AssertionError: expected [ 0, 0, 1 ] to deeply equal [ 0, 0, 4 ]
AssertionError: expected [ 1, 1 ] to deeply equal [ 3, 3 ]
AssertionError: expected [ 6, 1 ] to deeply equal [ 7, 2 ]
```

Also pins that a jump moves a *single* bacterium however tall the stack — the one attacker move that isn't a whole-cell move.

### `chess-knight` — the move rule itself

The 26-line spec only played a game out, so `getAllowedMoves` — the L-shape, the board bounds and the no-revisit rule, i.e. the entire rule set — was never asserted. A broken generator would have surfaced only as a hung or suspiciously short playout.

Adds the L-shape and bounds from a corner and an interior square, the no-revisit rule, the stranded case, that `generateStartBoard` places exactly one knight and marks nothing visited, and that the square the knight *leaves* becomes off limits (the rule's "including the starting square").

### `architect-and-bandits` — the tower-building clause

The rule raises a tower wherever the journey touches a bare vertex, *"including at the very start or end of the day"*. That happens in three places the end-of-game tests never reach:

- `moveArchitect` raising one at the target, and spending an edge of the day's allowance
- `startNextDay` standing one back up under the architect at dawn — which is what makes a night raid on the architect's own vertex pointless
- `generateStartBoard` opening day 1 with A already built

Added to both variants, since the moves are per-variant.

### `thief-sheriff-mean` — `hasWinningTriple`

The predicate the whole rule turns on ("one number is the average of the other two") had no direct test at all, only two incidental end-of-game cases. Now covers order-independence, a triple hidden among other cards, and the two ways to have no triple: no progression at all, and a pair whose average the hand does not hold.

### Verification

`npm test` green: 1607 tests across 171 files, plus lint and `tsc --noEmit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01832SpPq9YC5AGcYZn5NYkZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01832SpPq9YC5AGcYZn5NYkZ)_