### PR TITLE
Remove unreferenced exports (bacteria danger helpers, BOARD_SIZES)

### DIFF
--- a/src/components/games/bacteria/gameplay.spec.ts
+++ b/src/components/games/bacteria/gameplay.spec.ts
@@ -1,57 +1,9 @@
 import {
-  distanceFromDangerousAttackZone, isDangerous, moves, applyAttackMove, totalBacteria,
+  moves, applyAttackMove, totalBacteria,
   hasBacterium, isAttackAllowed, ATTACKER, DEFENDER, type MoveType
 } from './gameplay';
 import { reverse } from 'lodash';
 import { makeCtx } from '../../../test-utils';
-
-describe('distanceFromDangerousAttackZone', () => {
-  it('returns 0 for winning attack position', () => {
-    const bacteria = [
-      [0, 0, 0],
-        [0, 0],
-      [0, 0, 0]
-    ];
-    const board = { bacteria, goals: [1] };
-    expect(distanceFromDangerousAttackZone(board, { row: 2, col: 1 }).dist).toEqual(0);
-    expect(distanceFromDangerousAttackZone(board, { row: 2, col: 0 }).dist).toEqual(0);
-    expect(distanceFromDangerousAttackZone(board, { row: 1, col: 1 }).dist).toEqual(0);
-    // (1,0) sits on the left half-step: pins leftEdge using floor (not ceil).
-    expect(distanceFromDangerousAttackZone(board, { row: 1, col: 0 }).dist).toEqual(0);
-    expect(distanceFromDangerousAttackZone(board, { row: 0, col: 1 }).dist).toEqual(0);
-  });
-
-  it('returns distance for losing attack position', () => {
-    const bacteria = [
-      [0, 0, 0],
-       [0, 0],
-      [0, 0, 0]
-    ];
-    const board = { bacteria, goals: [0] };
-    expect(distanceFromDangerousAttackZone(board, { row: 2, col: 1 }).dist).toEqual(0);
-    expect(distanceFromDangerousAttackZone(board, { row: 2, col: 2 }).dist).toEqual(1);
-    expect(distanceFromDangerousAttackZone(board, { row: 1, col: 1 }).dist).toEqual(1);
-    expect(distanceFromDangerousAttackZone(board, { row: 0, col: 2 }).dist).toEqual(2);
-  });
-});
-
-describe('isDangerous', () => {
-  it('odd edge is not dangerous unless 1 jump left', () => {
-    const bacteria = [
-      [0, 0, 0],
-        [0, 0],
-      [0, 0, 0],
-        [0, 0],
-      [0, 0, 0]
-    ];
-    const board = { bacteria, goals: [0, 1, 2] };
-    expect(isDangerous(board, { row: 0, col: 0 })).toBe(false);
-    // (0,1) is exactly one step (dist 1) from the danger zone: still NOT
-    // dangerous. Pins the strict `=== 0` boundary against a `<= 1` slip.
-    expect(isDangerous(board, { row: 0, col: 1 })).toBe(false);
-    expect(isDangerous(board, { row: 2, col: 0 })).toBe(true);
-  });
-});
 
 describe('moves', () => {
   const meta = { ctx: makeCtx({ currentPlayer: DEFENDER }) };

--- a/src/components/games/bacteria/gameplay.ts
+++ b/src/components/games/bacteria/gameplay.ts
@@ -1,4 +1,4 @@
-import { cloneDeep, last } from 'lodash';
+import { cloneDeep } from 'lodash';
 import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
 
 export type Board = { bacteria: number[][], goals: number[] };
@@ -159,38 +159,4 @@ const areAllBacteriaRemoved = (bacteria: number[][]) => {
   return true;
 };
 
-export const lastCol = (bacteria: number[][], row: number) => bacteria[0].length - 0.5 - 0.5 * (-1) ** row;
-
-/* Currently only correct for board with adjacent goals */
-export const isDangerous = (board: Board, { row, col }: Cell) => {
-  return distanceFromDangerousAttackZone(board, { row, col }).dist === 0;
-};
-
-export const distanceFromDangerousAttackZone = (board: Board, { row, col }: Cell) => {
-  const boardWidth = board.bacteria[0].length;
-  const goalRowIdx = board.bacteria.length - 1;
-  const finalLeft = board.goals[0] === 0 ? 0 : board.goals[0] - 1;
-  const leftEdge = finalLeft + Math.floor((goalRowIdx - row)/2);
-  const finalRight = last(board.goals) === boardWidth - 1 ? boardWidth - 1 : last(board.goals)! + 1;
-  const rightEdge = finalRight - Math.ceil((goalRowIdx - row)/2);
-  if (board.goals[0] === 0) {
-    if (col === 0 && row === (goalRowIdx - 2)) {
-      return { dist: 0, dir: 'center' };
-    }
-  }
-  if (last(board.goals) === boardWidth - 1) {
-    if (col === (boardWidth - 1) && row === (goalRowIdx - 2)) {
-      return { dist: 0, dir: 'center' };
-    }
-  }
-  if (col >= leftEdge && col <= rightEdge) {
-    return { dist: 0, dir: 'center' };
-  } else if (col < leftEdge) {
-    return { dist: leftEdge - col, dir: 'left' };
-  } else {
-    return { dist: col - rightEdge, dir: 'right' };
-  };
-};
-
-export const isOddEdge = (bacteria: number[][], { row, col }: Cell) =>
-  (col === 0 || col === lastCol(bacteria, row)) && row % 2 === 0;
+const lastCol = (bacteria: number[][], row: number) => bacteria[0].length - 0.5 - 0.5 * (-1) ** row;

--- a/src/components/games/recolouring-discs/gameplay.ts
+++ b/src/components/games/recolouring-discs/gameplay.ts
@@ -122,7 +122,6 @@ export const startCells = (n: number): Cell[] => {
 // doubles per cell, so larger boards are not exactly solvable.
 export const FIRST_PLAYER_WIN_SIZES = [7, 9, 10, 11];
 export const SECOND_PLAYER_WIN_SIZES = [8, 12];
-export const BOARD_SIZES = [...FIRST_PLAYER_WIN_SIZES, ...SECOND_PLAYER_WIN_SIZES];
 
 export const generateStartBoard = (): Board => {
   const pool = sample([FIRST_PLAYER_WIN_SIZES, SECOND_PLAYER_WIN_SIZES])!;


### PR DESCRIPTION
Dead code found while reviewing comments, in two commits.

## bacteria's danger helpers

`bacteria/gameplay.ts` carried a standing caveat — `/* Currently only correct for board with adjacent goals */` — on a helper that nothing in the shipped game calls.

`isDangerous` and `distanceFromDangerousAttackZone` have no caller outside `gameplay.spec.ts`. The bot reasons about danger through `danger.ts`, whose solver handles any goal layout, so the caveat was guarding code no variant reaches. `isOddEdge` had no caller at all, not even a test.

`lastCol` stays — `areAllBacteriaRemoved` uses it — but loses its `export`, which nothing outside the module read. The two `describe` blocks covering the removed helpers go with them.

## recolouring-discs' BOARD_SIZES

Nothing reads it — not the module itself, not a spec. `generateStartBoard` samples one of `FIRST_PLAYER_WIN_SIZES` / `SECOND_PLAYER_WIN_SIZES` directly.

---

These were the only two genuinely dead exports in `src/` — a sweep of all 1260 exports turned up nothing else that is defined, exported and never read. Everything else flagged falls into two benign groups: symbols a spec imports on purpose (validators, bot helpers) and symbols used inside their own module but exported needlessly. The latter are listed in the review notes rather than changed here, since narrowing an export is a judgement call per case.

Lint, typecheck and the full suite pass.