### PR TITLE
Comment cleanup: outdated, redundant, and the optimality trackers

### DIFF
--- a/src/components/games/add-reduce-double/add-reduce-double.tsx
+++ b/src/components/games/add-reduce-double/add-reduce-double.tsx
@@ -121,7 +121,6 @@ export const AddReduceDouble = strategyGameFactory({
       label: { hu: 'Teszt', en: 'Test' }
     },
     {
-      // smart bot: verified as optimal
       botStrategy: smartBotStrategy,
       generateStartBoard: () => ([random(3, 10), random(3, 10)]),
       label: { hu: 'Teljes', en: 'Full' },

--- a/src/components/games/amor-and-cupido/amor-and-cupido.tsx
+++ b/src/components/games/amor-and-cupido/amor-and-cupido.tsx
@@ -29,7 +29,6 @@ export const AmorAndCupido = strategyGameFactory({
   },
   BoardClient,
   gameplay: { moves },
-  // Smart bot: verified as optimal.
   variants: [{
     botStrategy: smartBotStrategy,
     generateStartBoard

--- a/src/components/games/bacteria/bacteria.tsx
+++ b/src/components/games/bacteria/bacteria.tsx
@@ -258,7 +258,6 @@ export const Bacteria = strategyGameFactory({
       generateStartBoard: generateTestStartBoard,
       label: { hu: 'Teszt', en: 'Test' }
     },
-    // smart bot: verified as optimal (danger.ts solver; handles any goal layout)
     {
       botStrategy: smartBotStrategy,
       generateStartBoard: generateAdjacentStartBoard,

--- a/src/components/games/bank-robbers/bank-robbers.tsx
+++ b/src/components/games/bank-robbers/bank-robbers.tsx
@@ -94,7 +94,6 @@ export const BankRobbers = strategyGameFactory({
   gameplay: { moves },
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
-    // smart bot: verified as optimal
     { botStrategy: smartBotStrategy, generateStartBoard, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/chess-bishops/bot-strategy.ts
+++ b/src/components/games/chess-bishops/bot-strategy.ts
@@ -54,7 +54,7 @@ export const smartBotStrategy: Bot = ({ board }) => {
   }
   // try to win from bad position if player does not play optimally
   if (bishopCount >= 4) {
-    // sample + find has the same effect as filter + sample: find a random
+    // shuffle + find has the same effect as filter + sample: find a random
     // from the optimal moves
     const optimalPlace = shuffle(allowedMoves).find(({ row, col }) => {
       const boardCopy = cloneDeep(board);

--- a/src/components/games/chess-bishops/chess-bishops.tsx
+++ b/src/components/games/chess-bishops/chess-bishops.tsx
@@ -95,7 +95,6 @@ export const ChessBishops = strategyGameFactory({
   gameplay: { moves },
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
-    // smart bot: verified as optimal
     { botStrategy: smartBotStrategy, generateStartBoard, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/chess-ducks/bot-strategy.ts
+++ b/src/components/games/chess-ducks/bot-strategy.ts
@@ -4,7 +4,8 @@ import { shuffle, sample } from 'lodash';
 
 type Bot = BotStrategy<Board, Moves>
 
-/* This strategy file is relevant for the 4x7 case */
+/* The pre-generated opening books below are for the 4x7 board; the 4x6 one is
+searched live (see the colCount checks in smartBotStrategy). */
 const [ROWS, COLS] = [4, 7];
 const [DUCK] = [1];
 

--- a/src/components/games/chess-ducks/chess-ducks.tsx
+++ b/src/components/games/chess-ducks/chess-ducks.tsx
@@ -116,7 +116,6 @@ export const ChessDucks = strategyGameFactory({
       generateStartBoard: generateTestStartBoard,
       label: { hu: 'Teszt', en: 'Test' }
     },
-    // smart bot: verified as optimal
     {
       botStrategy: smartBotStrategy,
       generateStartBoard: generateStartBoard(4, 6),

--- a/src/components/games/chess-ducks/rubber-duck-svg.tsx
+++ b/src/components/games/chess-ducks/rubber-duck-svg.tsx
@@ -2,32 +2,32 @@ export const DuckSvg = () => {
   return (
     <svg style={{ display: 'none' }}>
       <symbol id="game-duck" viewBox="0 0 200 200">
-        {/*<!-- Duck body -->*/}
+        {/* Duck body */}
         <ellipse cx="100" cy="130" rx="70" ry="40" fill="#ffdd00" stroke="#e6c200" strokeWidth="2"/>
 
-        {/*<!-- Duck head -->*/}
+        {/* Duck head */}
         <circle cx="130" cy="80" r="28" fill="#ffdd00" stroke="#e6c200" strokeWidth="2"/>
 
-        {/*<!-- Duck wing -->*/}
+        {/* Duck wing */}
         <ellipse cx="85" cy="120" rx="25" ry="12" fill="#f0c814" stroke="#d4b012" strokeWidth="2"/>
 
-        {/*<!-- Duck tail -->*/}
+        {/* Duck tail */}
         <path d="M 35 115 C 20 105, 15 115, 22 130 C 28 140, 40 138, 42 125 Z"
               fill="#ffdd00" stroke="#e6c200" strokeWidth="2"/>
 
-        {/*<!-- Duck beak -->*/}
+        {/* Duck beak */}
         <ellipse cx="160" cy="85" rx="15" ry="8" fill="#ffa500" stroke="#e6940a" strokeWidth="1"/>
 
-        {/*<!-- Duck eye -->*/}
+        {/* Duck eye */}
         <circle cx="135" cy="72" r="4" fill="#333"/>
 
-        {/*<!-- Duck legs -->*/}
+        {/* Duck legs */}
         <g stroke="currentColor" strokeWidth="3" fill="none">
-          {/*<!-- Left leg -->*/}
+          {/* Left leg */}
           <line x1="90" y1="165" x2="90" y2="175"/>
           <path d="M 85 175 L 90 175 L 95 175 M 85 178 L 90 175 L 95 178" strokeWidth="2"/>
 
-          {/*<!-- Right leg -->*/}
+          {/* Right leg */}
           <line x1="110" y1="165" x2="110" y2="175"/>
           <path d="M 105 175 L 110 175 L 115 175 M 105 178 L 110 175 L 115 178" strokeWidth="2"/>
         </g>

--- a/src/components/games/chess-knight/chess-knight.tsx
+++ b/src/components/games/chess-knight/chess-knight.tsx
@@ -72,7 +72,6 @@ export const ChessKnight = strategyGameFactory({
   gameplay: { moves },
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
-    // smart bot: verified as optimal
     { botStrategy: smartBotStrategy, generateStartBoard, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/chess-rook/chess-rook.tsx
+++ b/src/components/games/chess-rook/chess-rook.tsx
@@ -75,7 +75,6 @@ export const ChessRook = strategyGameFactory({
   gameplay: { moves },
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
-    // smart bot: verified as optimal
     { botStrategy: smartBotStrategy, generateStartBoard, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/chocolate-breaking/chocolate-breaking.tsx
+++ b/src/components/games/chocolate-breaking/chocolate-breaking.tsx
@@ -153,7 +153,6 @@ export const ChocolateBreaking = strategyGameFactory({
       label: { hu: 'Teszt', en: 'Test' }
     },
     {
-      // smart bot: optimal via Sprague–Grundy values (see bot-strategy.ts)
       botStrategy: smartBotStrategy,
       generateStartBoard,
       label: { hu: 'Teljes', en: 'Full' },

--- a/src/components/games/coins-in-3-piles/coins-in-3-piles.tsx
+++ b/src/components/games/coins-in-3-piles/coins-in-3-piles.tsx
@@ -59,7 +59,6 @@ export const CoinsIn3Piles = strategyGameFactory({
       generateStartBoard: generateTestStartBoard,
       label: { hu: 'Teszt', en: 'Test' }
     },
-    // smart bot: verified as optimal
     {
       botStrategy: smartBotStrategy,
       generateStartBoard: generateFixedStartBoard,

--- a/src/components/games/cube-coloring/cube-coloring.tsx
+++ b/src/components/games/cube-coloring/cube-coloring.tsx
@@ -165,7 +165,6 @@ export const CubeColoring = strategyGameFactory({
   gameplay: { moves },
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
-    // smart bot: verified as optimal
     { botStrategy: smartBotStrategy, generateStartBoard, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/discs-flip-or-remove/discs-flip-or-remove.tsx
+++ b/src/components/games/discs-flip-or-remove/discs-flip-or-remove.tsx
@@ -147,7 +147,6 @@ export const DiscsFlipOrRemove = strategyGameFactory({
       generateStartBoard: generateTestStartBoard,
       label: { hu: 'Teszt', en: 'Test' }
     },
-    // smart bot: verified as optimal
     {
       botStrategy: smartBotStrategy,
       generateStartBoard: generateStartBoard(6),

--- a/src/components/games/distinct-squares/five-squares/five-squares.tsx
+++ b/src/components/games/distinct-squares/five-squares/five-squares.tsx
@@ -80,7 +80,6 @@ export const FiveSquares = strategyGameFactory({
   gameplay: { moves },
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
-    // smart bot: verified as optimal
     { botStrategy: smartBotStrategy, generateStartBoard, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/distinct-squares/two-times-two/two-times-two.tsx
+++ b/src/components/games/distinct-squares/two-times-two/two-times-two.tsx
@@ -58,7 +58,6 @@ export const TwoTimesTwo = strategyGameFactory({
   gameplay: { moves },
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
-    // smart bot: verified as optimal
     { botStrategy: smartBotStrategy, generateStartBoard, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/five-connected-fields/five-connected-fields.tsx
+++ b/src/components/games/five-connected-fields/five-connected-fields.tsx
@@ -30,6 +30,5 @@ export const FiveConnectedFields = strategyGameFactory({
   },
   BoardClient,
   gameplay: { moves },
-  // smart bot: verified as optimal
   variants: [{ botStrategy: smartBotStrategy, generateStartBoard }]
 });

--- a/src/components/games/five-five-card/five-five-card.tsx
+++ b/src/components/games/five-five-card/five-five-card.tsx
@@ -71,7 +71,6 @@ export const FiveFiveCard = strategyGameFactory({
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
     {
-      // smart bot: verified as optimal
       botStrategy: smartBotStrategy,
       generateStartBoard: () => [[1, 2, 3, 4, 5], [1, 2, 3, 4, 5]],
       label: { hu: 'Teljes', en: 'Full' },

--- a/src/components/games/four-connected-fields/four-connected-fields.tsx
+++ b/src/components/games/four-connected-fields/four-connected-fields.tsx
@@ -41,7 +41,6 @@ export const FourConnectedFields = strategyGameFactory({
       label: { hu: 'Teszt', en: 'Test' }
     },
     {
-      // smart bot: verified as optimal
       botStrategy: smartBotStrategy,
       generateStartBoard: (): Board => [0, 0, 0, 0],
       label: { hu: 'Teljes', en: 'Full' },

--- a/src/components/games/four-connected-fields/gameplay.ts
+++ b/src/components/games/four-connected-fields/gameplay.ts
@@ -39,8 +39,6 @@ export const moves = {
     apply: (board: Board, { ctx }: { ctx: Ctx }, node: number): MoveOutcome<Board> => {
       const nextBoard = board.slice();
       nextBoard[node] += 1;
-      // No move remains once every field is occupied and no line has equal
-      // endpoints.
       if (!hasAnyMove(nextBoard)) {
         return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };
       }

--- a/src/components/games/four-piles-spread-ahead/four-piles-spread-ahead.tsx
+++ b/src/components/games/four-piles-spread-ahead/four-piles-spread-ahead.tsx
@@ -152,7 +152,6 @@ export const FourPilesSpreadAhead = strategyGameFactory({
       generateStartBoard: generateTestStartBoard,
       label: { hu: 'Teszt', en: 'Test' }
     },
-    // smart bot: verified as optimal
     { botStrategy: smartBotStrategy, generateStartBoard, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/four-piles-two-grabs/four-piles-two-grabs.tsx
+++ b/src/components/games/four-piles-two-grabs/four-piles-two-grabs.tsx
@@ -154,7 +154,6 @@ export const FourPilesTwoGrabs = strategyGameFactory({
       generateStartBoard,
       label: { hu: 'Teszt', en: 'Test' }
     },
-    // smart bot: verified as optimal (see bot-strategy.spec.ts exhaustive minimax check)
     {
       botStrategy: smartBotStrategy,
       generateStartBoard,

--- a/src/components/games/four-piles-two-grabs/gameplay.ts
+++ b/src/components/games/four-piles-two-grabs/gameplay.ts
@@ -15,7 +15,6 @@ export const canMove = (board: Board): boolean =>
 
 export const isTerminal = (board: Board): boolean => !canMove(board);
 
-// Remove the chosen amount from each pile.
 export const applyMove = (board: Board, move: Move): Board =>
   board.map((v, i) => v - move[i]);
 

--- a/src/components/games/hunyadi-and-the-janissaries/gameplay.ts
+++ b/src/components/games/hunyadi-and-the-janissaries/gameplay.ts
@@ -10,7 +10,8 @@ export const generateStartBoard = (): Board => {
   // and not single-step game
   const rowCount = 5;
   let board: SoldierColor[][] = [];
-  // for debugging purposes
+  // Complexity score: a soldier counts for more the closer to the castle it
+  // starts. The threshold below rejects boards that would be over too quickly.
   let totalScore = 0;
   for (let i = 0; i < (rowCount - 1); i++) {
     const row: SoldierColor[] = [];

--- a/src/components/games/hunyadi-and-the-janissaries/hunyadi-and-the-janissaries.tsx
+++ b/src/components/games/hunyadi-and-the-janissaries/hunyadi-and-the-janissaries.tsx
@@ -146,6 +146,5 @@ export const HunyadiAndTheJanissaries = strategyGameFactory({
   },
   BoardClient,
   gameplay: { moves, endOfTurnMove: 'stepUp' },
-  // smart bot: verified as optimal
   variants: [{ botStrategy: smartBotStrategy, generateStartBoard }]
 });

--- a/src/components/games/latin-square-filling/latin-square-filling.tsx
+++ b/src/components/games/latin-square-filling/latin-square-filling.tsx
@@ -136,7 +136,6 @@ export const LatinSquareFilling = strategyGameFactory({
       generateStartBoard,
       label: { hu: 'Teszt', en: 'Test' }
     },
-    // smart bot: exhaustive minimax, verified optimal (see bot-strategy.spec.ts)
     {
       botStrategy: smartBotStrategy,
       generateStartBoard,

--- a/src/components/games/magic-box/magic-box-a/magic-box-a.tsx
+++ b/src/components/games/magic-box/magic-box-a/magic-box-a.tsx
@@ -49,7 +49,6 @@ export const MagicBox = strategyGameFactory({
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
     {
-      // smart bot: verified as optimal, second player always wins
       botStrategy: smartBotStrategy,
       generateStartBoard: generateEmptyBoard,
       label: { hu: 'Teljes', en: 'Full' },

--- a/src/components/games/magic-box/magic-box-b/magic-box-b.tsx
+++ b/src/components/games/magic-box/magic-box-b/magic-box-b.tsx
@@ -53,7 +53,6 @@ export const MagicBoxB = strategyGameFactory({
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
     {
-      // smart bot: verified as optimal
       botStrategy: smartBotStrategy,
       generateStartBoard: generateEmptyBoard,
       label: { hu: 'Teljes', en: 'Full' },

--- a/src/components/games/matches-on-edges/matches-on-edges.tsx
+++ b/src/components/games/matches-on-edges/matches-on-edges.tsx
@@ -49,7 +49,6 @@ export const MatchesOnEdges = strategyGameFactory({
       generateStartBoard,
       label: { hu: 'Teszt', en: 'Test' }
     },
-    // smart bot: verified as optimal (see bot-strategy.spec.ts)
     {
       botStrategy: smartBotStrategy,
       generateStartBoard,

--- a/src/components/games/matchstick-piles/matchstick-piles.tsx
+++ b/src/components/games/matchstick-piles/matchstick-piles.tsx
@@ -135,7 +135,6 @@ export const MatchstickPiles = strategyGameFactory({
       label: { hu: 'Teszt', en: 'Test' }
     },
     {
-      // smart bot: verified as optimal (Grundy/XOR characterisation)
       botStrategy: smartBotStrategy,
       generateStartBoard,
       label: { hu: 'Teljes', en: 'Full' },

--- a/src/components/games/number-covering/number-covering.tsx
+++ b/src/components/games/number-covering/number-covering.tsx
@@ -74,7 +74,6 @@ export const NumberCovering = strategyGameFactory({
       generateStartBoard: generateTestStartBoard,
       label: { hu: 'Teszt', en: 'Test' }
     },
-    // smart bot: verified as optimal
     {
       botStrategy: smartBotStrategy,
       generateStartBoard: () => range(1, 9),

--- a/src/components/games/number-pyramid/number-pyramid.tsx
+++ b/src/components/games/number-pyramid/number-pyramid.tsx
@@ -46,7 +46,6 @@ export const NumberPyramid = strategyGameFactory({
       label: { hu: 'Teszt', en: 'Test' }
     },
     {
-      // smart bot: verified as optimal
       botStrategy: smartBotStrategy,
       generateStartBoard,
       label: { hu: 'Teljes', en: 'Full' },

--- a/src/components/games/pairs-of-numbers/pairs-of-numbers.tsx
+++ b/src/components/games/pairs-of-numbers/pairs-of-numbers.tsx
@@ -69,7 +69,6 @@ export const PairsOfNumbers = strategyGameFactory({
       generateStartBoard: generateTestStartBoard,
       label: { hu: 'Teszt', en: 'Test' }
     },
-    // smart bot: verified as optimal
     {
       botStrategy: smartBotStrategy,
       generateStartBoard,

--- a/src/components/games/pile-splitting-games/pile-splitter-3/pile-splitter-3.tsx
+++ b/src/components/games/pile-splitting-games/pile-splitter-3/pile-splitter-3.tsx
@@ -80,10 +80,10 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const currentChoiceDescription = (pileId) => {
     const pieceCountInPile = board[pileId];
 
-    // pieceCountInPile can be 0 in intermediateBoard during AI turn
+    // A pile is 0 between the bot's `removePile` and its `splitPile`.
     if (!ctx.isClientMoveAllowed) return pieceCountInPile || '🗑️';
     if (pileId === removedPileId) {
-      // pieceCountInPile can be 0 in intermediateBoard
+      // and likewise between the player's own two moves
       return pieceCountInPile ? `${pieceCountInPile} → 🗑️` : '🗑️';
     }
     if (removedPileId === null) {

--- a/src/components/games/pile-splitting-games/pile-splitter-3/pile-splitter-3.tsx
+++ b/src/components/games/pile-splitting-games/pile-splitter-3/pile-splitter-3.tsx
@@ -165,7 +165,6 @@ export const PileSplitter3 = strategyGameFactory({
   gameplay: { moves },
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
-    // smart bot: verified as optimal
     { botStrategy: smartBotStrategy, generateStartBoard, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/pile-splitting-games/pile-splitter-4/pile-splitter-4.tsx
+++ b/src/components/games/pile-splitting-games/pile-splitter-4/pile-splitter-4.tsx
@@ -94,10 +94,10 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const currentChoiceDescription = (pileId) => {
     const pieceCountInPile = board[pileId];
 
-    // pieceCountInPile can be 0 in intermediateBoard during AI turn
+    // A pile is 0 between the bot's `removePile` and its `splitPile`.
     if (!ctx.isClientMoveAllowed) return pieceCountInPile || '🗑️';
     if (pileId === removedPileId) {
-      // pieceCountInPile can be 0 in intermediateBoard
+      // and likewise between the player's own two moves
       return pieceCountInPile ? `${pieceCountInPile} → 🗑️` : '🗑️';
     }
     if (removedPileId === null) {

--- a/src/components/games/pile-splitting-games/pile-splitter-4/pile-splitter-4.tsx
+++ b/src/components/games/pile-splitting-games/pile-splitter-4/pile-splitter-4.tsx
@@ -182,7 +182,6 @@ export const PileSplitter4 = strategyGameFactory({
       generateStartBoard: generateTestStartBoard,
       label: { hu: 'Teszt', en: 'Test' }
     },
-    // smart bot: verified as optimal
     { botStrategy: smartBotStrategy, generateStartBoard, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/pile-splitting-games/pile-splitter/pile-splitter.tsx
+++ b/src/components/games/pile-splitting-games/pile-splitter/pile-splitter.tsx
@@ -124,7 +124,6 @@ export const PileSplitter = strategyGameFactory({
       generateStartBoard: () => ([random(2, 5), random(2, 5)])
     },
     {
-      // smart bot: verified as optimal
       botStrategy: smartBotStrategy,
       generateStartBoard: () => ([random(3, 10), random(3, 10)]),
       label: { hu: 'Teljes', en: 'Full' },

--- a/src/components/games/pile-union/pile-union.tsx
+++ b/src/components/games/pile-union/pile-union.tsx
@@ -219,10 +219,6 @@ export const PileUnion = strategyGameFactory({
       label: { hu: 'Teszt', en: 'Test' }
     },
     {
-      // smart bot: verified as optimal — so no notAlwaysOptimal flag. Since the
-      // fix in #413 that is also checked mechanically: bot-strategy.spec.ts
-      // plays every board up to four piles of six and asserts the bot's move
-      // leaves the opponent a lost one.
       botStrategy: smartBotStrategy,
       generateStartBoard: () => {
         const numPiles = random(2, 4);

--- a/src/components/games/policeman-thief/policeman-thief-ab/bot-strategy.ts
+++ b/src/components/games/policeman-thief/policeman-thief-ab/bot-strategy.ts
@@ -10,7 +10,6 @@ export const smartBotStrategy: Bot = ({ board, ctx }) =>
 // Both policemen step in the same turn, planned together from the position they
 // start in, so the turn is named as a whole.
 const policemenMoves = (board: Board): BotMove<Moves>[] => {
-  //policeman0 Step
   let index0 = board.policemen[0];
   // where it would catch the thief outright, which overrides any later choice
   let catchIndex0: number | null = null;
@@ -30,7 +29,6 @@ const policemenMoves = (board: Board): BotMove<Moves>[] => {
     index0 = neighbours[board.policemen[0]][random(0, 2)];
   }
 
-  //policeman1 Step
   let index1 = board.policemen[1];
   let catchIndex1: number | null = null;
   for (let i = 0; i < 3; i++) {

--- a/src/components/games/policeman-thief/policeman-thief-ab/policeman-thief-ab.tsx
+++ b/src/components/games/policeman-thief/policeman-thief-ab/policeman-thief-ab.tsx
@@ -80,7 +80,6 @@ export const Policemanthief = strategyGameFactory({
   BoardClient,
   gameplay: { moves },
   variants: [
-    // smart bot: verified as optimal
     {
       botStrategy: smartBotStrategy,
       generateStartBoard: generateStartBoardA,

--- a/src/components/games/policeman-thief/policeman-thief-c/policeman-thief-c.tsx
+++ b/src/components/games/policeman-thief/policeman-thief-c/policeman-thief-c.tsx
@@ -75,7 +75,6 @@ export const PolicemanthiefC = strategyGameFactory({
       label: { hu: 'Teszt', en: 'Test' }
     },
     {
-      // Smart bot: provably optimal (full minimax on the fixed graph).
       botStrategy: smartBotStrategy,
       generateStartBoard,
       label: { hu: 'Teljes', en: 'Full' },

--- a/src/components/games/polynomial-building/polynomial-building.tsx
+++ b/src/components/games/polynomial-building/polynomial-building.tsx
@@ -51,7 +51,6 @@ export const PolynomialBuilding = strategyGameFactory({
       label: { hu: 'Teszt', en: 'Test' }
     },
     {
-      // smart bot: verified as optimal
       botStrategy: smartBotStrategy,
       generateStartBoard: (): Board => ({ a: null, b: null, c: null }),
       label: { hu: 'Teljes', en: 'Full' },

--- a/src/components/games/recolouring-discs/recolouring-discs.tsx
+++ b/src/components/games/recolouring-discs/recolouring-discs.tsx
@@ -63,7 +63,6 @@ export const RecolouringDiscs = strategyGameFactory({
       botStrategy: randomBotStrategy,
       label: { hu: 'Teszt', en: 'Test' }
     },
-    // smart bot: verified optimal in solver.spec.ts / bot-strategy.spec.ts
     {
       botStrategy: smartBotStrategy,
       generateStartBoard,

--- a/src/components/games/remove-divisor-multiple/gameplay.ts
+++ b/src/components/games/remove-divisor-multiple/gameplay.ts
@@ -5,9 +5,9 @@ export type Board = { numbersOnTable: boolean[], previousMove: number | null }
 
 // The number must still be on the table, and — from the second move on — be a
 // divisor or a multiple of the number the other player just removed. The
-// on-the-table check used to be skipped for the opening move, where every
-// number is still there anyway; hoisting it above the previousMove branch
-// changes nothing for a real opening move but keeps a bogus argument out.
+// on-the-table check sits above the previousMove branch so that a bogus
+// argument is rejected on the opening move too, where every number is still
+// there and the check would otherwise be vacuous.
 export const isAllowed = (board: Board, n: number) => {
   if (!Number.isInteger(n) || n < 1 || n > board.numbersOnTable.length) return false;
   if (board.numbersOnTable[n - 1] === false) return false;

--- a/src/components/games/remove-divisor-multiple/remove-divisor-multiple.tsx
+++ b/src/components/games/remove-divisor-multiple/remove-divisor-multiple.tsx
@@ -74,7 +74,6 @@ export const RemoveDivisorMultiple = strategyGameFactory({
       label: { hu: 'Teszt', en: 'Test' }
     },
     {
-      // smart bot: verified as optimal
       botStrategy: smartBotStrategy,
       generateStartBoard,
       label: { hu: 'Teljes', en: 'Full' },

--- a/src/components/games/remove-row-or-column/remove-row-or-column.tsx
+++ b/src/components/games/remove-row-or-column/remove-row-or-column.tsx
@@ -74,7 +74,6 @@ export const RemoveRowOrColumn = strategyGameFactory({
       generateStartBoard: generateTestStartBoard,
       label: { hu: 'Teszt', en: 'Test' }
     },
-    // smart bot: optimal (Sprague–Grundy; moves to a zero position when winning)
     {
       botStrategy: smartBotStrategy,
       generateStartBoard: generateSingleBoard,

--- a/src/components/games/rock-paper-scissor/rock-paper-scissor.tsx
+++ b/src/components/games/rock-paper-scissor/rock-paper-scissor.tsx
@@ -69,7 +69,6 @@ export const RockPaperScissor = strategyGameFactory({
   gameplay: { moves },
   variants: [
     {
-      // smart bot: verified as optimal
       botStrategy: smartBotStrategy,
       generateStartBoard: (): Board => [['rock', 'paper', 'scissor'], ['rock', 'paper', 'scissor']]
     }

--- a/src/components/games/rook-to-corner/rook-to-corner.tsx
+++ b/src/components/games/rook-to-corner/rook-to-corner.tsx
@@ -76,7 +76,6 @@ export const RookToCorner = strategyGameFactory({
   gameplay: { moves },
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
-    // smart bot: verified as optimal (2-heap Nim, P-positions are the main diagonal)
     { botStrategy: smartBotStrategy, generateStartBoard, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/single-number-increase/increment-or-double/increment-or-double.tsx
+++ b/src/components/games/single-number-increase/increment-or-double/increment-or-double.tsx
@@ -57,6 +57,5 @@ export const IncrementOrDouble = strategyGameFactory({
   },
   BoardClient,
   gameplay: { moves },
-  // smart bot: verified as optimal
   variants: [{ botStrategy: smartBotStrategy, generateStartBoard: () => 0 }]
 });

--- a/src/components/games/single-number-increase/plus-one-two-three/plus-one-two-three.tsx
+++ b/src/components/games/single-number-increase/plus-one-two-three/plus-one-two-three.tsx
@@ -51,6 +51,5 @@ export const PlusOneTwoThree = strategyGameFactory({
   },
   BoardClient,
   gameplay: { moves },
-  // smart bot: verified as optimal
   variants: [{ botStrategy: smartBotStrategy, generateStartBoard: () => 0 }]
 });

--- a/src/components/games/single-number-increase/superstitious-counting/superstitious-counting.tsx
+++ b/src/components/games/single-number-increase/superstitious-counting/superstitious-counting.tsx
@@ -80,7 +80,6 @@ export const SuperstitiousCounting = strategyGameFactory({
       generateStartBoard: generateTestStartBoard,
       label: { hu: 'Teszt', en: 'Test' }
     },
-    // smart bot: verified as optimal
     { botStrategy: smartBotStrategy, generateStartBoard, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/single-pile-removal/doubling-reduction/doubling-reduction.tsx
+++ b/src/components/games/single-pile-removal/doubling-reduction/doubling-reduction.tsx
@@ -34,7 +34,6 @@ export const DoublingReduction = strategyGameFactory({
       label: { hu: 'Teszt', en: 'Test' }
     },
     {
-      // smart bot: verified as optimal
       botStrategy: smartBotStrategy,
       generateStartBoard,
       label: { hu: 'Teljes', en: 'Full' },

--- a/src/components/games/single-pile-removal/prime-exponentials/prime-exponentials.tsx
+++ b/src/components/games/single-pile-removal/prime-exponentials/prime-exponentials.tsx
@@ -119,7 +119,6 @@ export const PrimeExponentials = strategyGameFactory({
       label: { hu: 'Teszt', en: 'Test' }
     },
     {
-      // smart bot: verified as optimal
       botStrategy: smartBotStrategy,
       generateStartBoard,
       label: { hu: 'Teljes', en: 'Full' },

--- a/src/components/games/single-pile-removal/take-1-or-halve/take-1-or-halve.tsx
+++ b/src/components/games/single-pile-removal/take-1-or-halve/take-1-or-halve.tsx
@@ -89,7 +89,6 @@ export const Take1OrHalve = strategyGameFactory({
       label: { hu: 'Teszt', en: 'Test' }
     },
     {
-      // smart bot: verified as optimal
       botStrategy: smartBotStrategy,
       generateStartBoard: () => random(20, 27),
       label: { hu: 'Teljes', en: 'Full' },

--- a/src/components/games/single-pile-removal/take-power-of-two/take-power-of-two.tsx
+++ b/src/components/games/single-pile-removal/take-power-of-two/take-power-of-two.tsx
@@ -84,7 +84,6 @@ export const TakePowerOfTwo = strategyGameFactory({
       generateStartBoard: generateTestStartBoard,
       label: { hu: 'Teszt', en: 'Test' }
     },
-    // smart bot: verified as optimal
     { botStrategy: smartBotStrategy, generateStartBoard, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/single-pile-removal/three-more/three-more.tsx
+++ b/src/components/games/single-pile-removal/three-more/three-more.tsx
@@ -25,6 +25,5 @@ export const ThreeMore = strategyGameFactory({
   },
   BoardClient,
   gameplay: { moves },
-  // smart bot: verified as optimal
   variants: [{ botStrategy: smartBotStrategy, generateStartBoard }]
 });

--- a/src/components/games/single-pile-removal/waning-stones/waning-stones.tsx
+++ b/src/components/games/single-pile-removal/waning-stones/waning-stones.tsx
@@ -32,7 +32,6 @@ export const WaningStones = strategyGameFactory({
       label: { hu: 'Teszt', en: 'Test' }
     },
     {
-      // smart bot: verified as optimal
       botStrategy: smartBotStrategy,
       generateStartBoard,
       label: { hu: 'Teljes', en: 'Full' },

--- a/src/components/games/six-fields-circle/six-fields-circle.tsx
+++ b/src/components/games/six-fields-circle/six-fields-circle.tsx
@@ -48,7 +48,6 @@ export const SixFieldsCircle = strategyGameFactory({
       label: { hu: 'Teszt', en: 'Test' }
     },
     {
-      // smart bot: verified as optimal (keeps every opposite-pair sum even)
       botStrategy: smartBotStrategy,
       generateStartBoard,
       label: { hu: 'Teljes', en: 'Full' },

--- a/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
+++ b/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
@@ -89,7 +89,6 @@ export const StonesRemoveOneNotTwiceFromLeft = strategyGameFactory({
       label: { hu: 'Teszt', en: 'Test' }
     },
     {
-      // smart bot: verified as optimal
       botStrategy: smartBotStrategy,
       generateStartBoard,
       label: { hu: 'Teljes', en: 'Full' },

--- a/src/components/games/sum-fifteen/sum-fifteen.tsx
+++ b/src/components/games/sum-fifteen/sum-fifteen.tsx
@@ -102,7 +102,6 @@ export const SumFifteen = strategyGameFactory({
       label: { hu: 'Teszt', en: 'Test' }
     },
     {
-      // smart bot: full optimal search (see winnerOptimal in bot-strategy.ts)
       botStrategy: smartBotStrategy,
       generateStartBoard,
       label: { hu: 'Teljes', en: 'Full' },

--- a/src/components/games/take-and-point/take-and-point.tsx
+++ b/src/components/games/take-and-point/take-and-point.tsx
@@ -51,7 +51,6 @@ export const TakeAndPoint = strategyGameFactory({
       generateStartBoard,
       label: { hu: 'Teszt', en: 'Test' }
     },
-    // smart bot: verified as optimal (see bot-strategy.spec.ts)
     {
       botStrategy: smartBotStrategy,
       generateStartBoard,

--- a/src/components/games/ten-coins/ten-coins.tsx
+++ b/src/components/games/ten-coins/ten-coins.tsx
@@ -176,7 +176,6 @@ export const TenCoins = strategyGameFactory({
       generateStartBoard: generateTestStartBoard,
       label: { hu: 'Teszt', en: 'Test' }
     },
-    // smart bot: verified as optimal
     {
       botStrategy: smartBotStrategy,
       generateStartBoard: generateStartBoardC,

--- a/src/components/games/ten-digit-number/ten-digit-number.tsx
+++ b/src/components/games/ten-digit-number/ten-digit-number.tsx
@@ -91,7 +91,6 @@ export const TenDigitNumber = strategyGameFactory({
       label: { hu: 'Teszt', en: 'Test' }
     },
     {
-      // smart bot: verified as optimal
       botStrategy: smartBotStrategy,
       generateStartBoard: () => ({ digits: [], sumMod9: 0 }),
       label: { hu: 'Teljes', en: 'Full' },

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/thief-sheriff-mean-7.tsx
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/thief-sheriff-mean-7.tsx
@@ -82,7 +82,6 @@ export const ThiefSheriffMean7 = strategyGameFactory({
   gameplay: { moves },
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
-    // smart bot: verified as optimal
     { botStrategy: smartBotStrategy, generateStartBoard, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/thief-sheriff-mean-9.tsx
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/thief-sheriff-mean-9.tsx
@@ -71,7 +71,6 @@ export const ThiefSheriffMean9 = strategyGameFactory({
   gameplay: { moves },
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
-    // smart bot: verified as optimal
     { botStrategy: smartBotStrategy, generateStartBoard, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/three-piles-rebuild/three-piles-rebuild.tsx
+++ b/src/components/games/three-piles-rebuild/three-piles-rebuild.tsx
@@ -201,7 +201,6 @@ export const ThreePilesRebuild = strategyGameFactory({
       generateStartBoard: generateTestStartBoard,
       label: { hu: 'Teszt', en: 'Test' }
     },
-    // smart bot: verified as optimal
     {
       botStrategy: smartBotStrategy,
       generateStartBoard,

--- a/src/components/games/tictactoe-alikes/anti-tictactoe/anti-tictactoe.tsx
+++ b/src/components/games/tictactoe-alikes/anti-tictactoe/anti-tictactoe.tsx
@@ -63,7 +63,6 @@ export const AntiTicTacToe = strategyGameFactory({
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
     {
-      // smart bot: verified as optimal
       botStrategy: smartBotStrategy,
       generateStartBoard: generateEmptyTicTacToeBoard,
       label: { hu: 'Teljes', en: 'Full' },

--- a/src/components/games/tictactoe-alikes/tictactoe-doublestart/tictactoe-doublestart.tsx
+++ b/src/components/games/tictactoe-alikes/tictactoe-doublestart/tictactoe-doublestart.tsx
@@ -77,7 +77,6 @@ export const TicTacToeDoubleStart = strategyGameFactory({
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
     {
-      // smart bot: verified as optimal
       botStrategy: smartBotStrategy,
       generateStartBoard: generateEmptyTicTacToeBoard,
       label: { hu: 'Teljes', en: 'Full' },

--- a/src/components/games/tictactoe-alikes/tictactoe/tictactoe.tsx
+++ b/src/components/games/tictactoe-alikes/tictactoe/tictactoe.tsx
@@ -94,7 +94,6 @@ export const TicTacToe = strategyGameFactory({
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
     {
-      // smart bot: verified as optimal
       botStrategy: smartBotStrategy,
       generateStartBoard: generateEmptyTicTacToeBoard,
       label: { hu: 'Teljes', en: 'Full' },

--- a/src/components/games/totem-poles/triangular-grid-ropes-10/triangular-grid-ropes-10.tsx
+++ b/src/components/games/totem-poles/triangular-grid-ropes-10/triangular-grid-ropes-10.tsx
@@ -135,7 +135,6 @@ export const TriangularGridRopes = strategyGameFactory({
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
     {
-      // smart bot: verified as optimal
       botStrategy: smartBotStrategy,
       generateStartBoard: (): Board => [],
       label: { hu: 'Teljes', en: 'Full' },

--- a/src/components/games/totem-poles/triangular-grid-ropes-15/gameplay.spec.ts
+++ b/src/components/games/totem-poles/triangular-grid-ropes-15/gameplay.spec.ts
@@ -28,7 +28,7 @@ describe('15 totem poles geometry', () => {
   });
 
   it('auto-extends a rope to its maximal collinear segment', () => {
-    // 6-7 lies on the bottom row 10..14? no: 6-9 is a row; 6-7 extends to 6-9
+    // 6-7 sits on the row 6..9, so the rope stretches to the whole of it
     expect(getAllowedSuperset([], { from: 6, to: 7 })).toEqual({ from: 6, to: 9 });
   });
 

--- a/src/components/games/totem-poles/triangular-grid-ropes-15/solver.ts
+++ b/src/components/games/totem-poles/triangular-grid-ropes-15/solver.ts
@@ -153,7 +153,7 @@ const toRopeIndices = (board: Board): number[] => {
 
 // Returns a move that wins from `board` for the player to move, or null if the
 // position is lost (every move leaves the opponent winning). Deterministic: it
-// returns the verified winning move, matching generate-strategy.mjs.
+// returns the verified winning move, matching verify-optimality.mjs.
 export const findWinningMove = (board: Board): Edge | null => {
   const ris = toRopeIndices(board);
   const moves = allowedMoveIndices(ris).slice().sort((a, b) => (ropes[a].str < ropes[b].str ? -1 : 1));

--- a/src/components/games/totem-poles/triangular-grid-ropes-15/triangular-grid-ropes-15.tsx
+++ b/src/components/games/totem-poles/triangular-grid-ropes-15/triangular-grid-ropes-15.tsx
@@ -135,7 +135,6 @@ export const TriangularGridRopes15 = strategyGameFactory({
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
     {
-      // smart bot: verified as optimal
       botStrategy: smartBotStrategy,
       generateStartBoard: (): Board => [],
       label: { hu: 'Teljes', en: 'Full' },

--- a/src/components/games/triangle-coloring/triangle-coloring.tsx
+++ b/src/components/games/triangle-coloring/triangle-coloring.tsx
@@ -112,7 +112,6 @@ export const TriangleColoring = strategyGameFactory({
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
     {
-      // smart bot: verified as optimal
       botStrategy: smartBotStrategy,
       generateStartBoard: () => Array(16).fill(ALLOWED),
       label: { hu: 'Teljes', en: 'Full' },

--- a/src/components/games/twelve-squares/twelve-squares.tsx
+++ b/src/components/games/twelve-squares/twelve-squares.tsx
@@ -77,7 +77,6 @@ export const TwelveSquares = strategyGameFactory({
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
     {
-      // smart bot: verified as optimal
       botStrategy: optimalBotStrategy,
       generateStartBoard,
       label: { hu: 'Teljes', en: 'Full' },

--- a/src/components/games/two-of-three-takeaway/gameplay.ts
+++ b/src/components/games/two-of-three-takeaway/gameplay.ts
@@ -14,7 +14,6 @@ export const canMove = (board: Board): boolean =>
 
 export const isTerminal = (board: Board): boolean => !canMove(board);
 
-// Take one chip from each of the two chosen piles.
 export const applyMove = (board: Board, [i, j]: Move): Board =>
   board.map((v, idx) => (idx === i || idx === j ? v - 1 : v));
 

--- a/src/components/games/two-of-three-takeaway/two-of-three-takeaway.tsx
+++ b/src/components/games/two-of-three-takeaway/two-of-three-takeaway.tsx
@@ -121,7 +121,6 @@ export const TwoOfThreeTakeaway = strategyGameFactory({
       generateStartBoard,
       label: { hu: 'Teszt', en: 'Test' }
     },
-    // smart bot: verified as optimal (see bot-strategy.spec.ts exhaustive minimax check)
     {
       botStrategy: smartBotStrategy,
       generateStartBoard,

--- a/src/components/overview/filters/filters.tsx
+++ b/src/components/overview/filters/filters.tsx
@@ -5,7 +5,7 @@ import { useTranslation, type I18nString } from '../../../language';
 import { GameIcon, iconLabels } from '../game-icons';
 
 // Keep only games matching at least one of the selected categories. An empty
-// selection matches everything. Mirrors the previous `shouldShow` semantics.
+// selection matches everything.
 export const filterByCategories = (
   ids: string[],
   selected: Category[],


### PR DESCRIPTION
A sweep of every comment in `src/` for ones that are wrong, stale, or pure restatement. Two commits, reviewable separately.

## 1. Outdated and redundant comments

Wrong or stale:

- **chess-bishops** — comment said "sample + find" over a `shuffle(...).find(...)`; the sibling chess-ducks comment has it right
- **chess-ducks** — "This strategy file is relevant for the 4x7 case" predates the 4×6 variant, which the same file serves (and which is the default). Only the pre-generated books and the `ROWS`/`COLS` flip constants under it are 4×7-only
- **hunyadi** — `totalScore` is not "for debugging purposes"; it is the complexity score the regeneration threshold reads
- **pile-splitter-3 / -4** — four comments explaining a 0 pile "in intermediateBoard", a concept that no longer exists anywhere in the repo
- **filters** — "Mirrors the previous `shouldShow` semantics" points at a function that is gone
- **remove-divisor-multiple** — narrated the refactor that moved the on-the-table check; now states why it sits where it does
- **totem-poles-15 spec** — a rejected first guess was left in the comment verbatim

Pure restatement, removed:

- **four-piles-two-grabs**, **two-of-three-takeaway** — comments restating `applyMove`
- **four-connected-fields** — a game-end comment duplicating the one on `hasAnyMove` ten lines above

## 2. The "verified as optimal" markers

66 blocks across the game files. They tracked which games' bots had been checked for optimality; every game has been checked, so the marker no longer distinguishes anything.

Two comments are kept deliberately: **modified-mill** and **triangle-circle-game** explain why that variant carries `notAlwaysOptimal`, which is live configuration rather than progress through the sweep. The `bot-strategy.ts` headers describing *how* a bot plays are also untouched.

Same commit: `rubber-duck-svg`'s JSX comments were wrapping HTML comments (`{/*<!-- Duck body -->*/}`), left over from the original SVG paste; and `policeman-thief-ab` loses `//policeman0 Step` / `//policeman1 Step`, which restate the line under them.

No behaviour changes — comments only. Lint, typecheck and the full suite pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NcWvHUVTH4sQKQX7ifdAy3)_