### PR TITLE
Settle the game-end dialog inside act in its spec

### DIFF
--- a/src/components/strategy-game-factory/game-parts/game-end-dialog.spec.tsx
+++ b/src/components/strategy-game-factory/game-parts/game-end-dialog.spec.tsx
@@ -43,15 +43,26 @@ const Harness = ({ isHumanVsHumanGame = false }: { isHumanVsHumanGame?: boolean 
   );
 };
 
+// Headless UI's `Dialog` keeps working after the synchronous render — it
+// portals the panel and wraps it in a `Transition`. A test that reads the
+// controls straight off `render` can therefore finish before that work lands,
+// and React reports the late state update as one escaping `act(...)`. Awaiting
+// a control keeps the settling inside `act`.
+const openDialog = async (props: { isHumanVsHumanGame?: boolean } = {}) => {
+  const view = render(<Harness {...props} />);
+  await view.findByTestId('mode-vsComputer');
+  return view;
+};
+
 describe('GameEndDialog', () => {
-  it('seeds the draft mode from the game that just ended', () => {
-    const { getByTestId } = render(<Harness isHumanVsHumanGame />);
+  it('seeds the draft mode from the game that just ended', async () => {
+    const { getByTestId } = await openDialog({ isHumanVsHumanGame: true });
 
     expect((getByTestId('mode-vsHuman') as HTMLInputElement).checked).toBe(true);
   });
 
-  it('lets the player draft a different mode', () => {
-    const { getByTestId } = render(<Harness />);
+  it('lets the player draft a different mode', async () => {
+    const { getByTestId } = await openDialog();
 
     fireEvent.click(getByTestId('mode-vsHuman'));
 
@@ -61,7 +72,7 @@ describe('GameEndDialog', () => {
   // The behaviour the removed effect existed for: a draft the player walked
   // away from must not come back the next time the dialog opens.
   it('discards an abandoned draft when reopened', async () => {
-    const { getByTestId, queryByTestId, getByText, findByTestId } = render(<Harness />);
+    const { getByTestId, queryByTestId, getByText, findByTestId } = await openDialog();
 
     fireEvent.click(getByTestId('mode-vsHuman'));
     expect((getByTestId('mode-vsHuman') as HTMLInputElement).checked).toBe(true);


### PR DESCRIPTION
Two tests in `game-end-dialog.spec.tsx` printed React's "An update to `Ie` inside a test was not wrapped in act(...)" to stderr. The tests passed, but the warning is real: `Ie` is the minified `Transition` component in `@headlessui/react`, which `Dialog` wraps its panel in (and portals), so the dialog keeps committing state after the synchronous `render()`. Both tests asserted straight off `render()` and ended synchronously, letting that commit land outside `act`. The third test never warned, because `waitFor`/`findBy` run inside testing-library's `act`-wrapping async wrapper.

All three tests now open the dialog through a helper that awaits a control first — the shape the reopen test already had:

```tsx
const openDialog = async (props: { isHumanVsHumanGame?: boolean } = {}) => {
  const view = render(<Harness {...props} />);
  await view.findByTestId('mode-vsComputer');
  return view;
};
```

Test-only change; no production code touched.

**Verification**
- `game-end-dialog.spec.tsx`: 3/3 pass
- full suite: 1610 tests / 177 files pass
- `tsc --noEmit` clean

**Caveats**
- The warning could not be reproduced in the sandbox I worked in — not in isolation, not in the full suite, not with `--no-file-parallelism`, and not with a probe that idled 300 ms outside `act` after mounting the dialog. It is timing-dependent (`isolate: false` shares a worker context across files, so scheduling differs per machine). This change closes the window rather than being confirmed against a live repro.
- `npm run lint` could not run there: `eslint-plugin-react-hooks` was missing from that environment's `node_modules`, so ESLint failed to load the config. CI lint is the real check.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoJwRbeZJC94tB2MLB9Lr1)_