### PR TITLE
Narrow 16 exports nothing outside their module reads

### DIFF
--- a/src/components/games/add-reduce-double/gameplay.ts
+++ b/src/components/games/add-reduce-double/gameplay.ts
@@ -3,7 +3,7 @@ import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
 
 export type Board = number[];
 export type Piece = { pileId: number; pieceId: number };
-export type Transfer = { pileId: number; pieceCount: number };
+type Transfer = { pileId: number; pieceCount: number };
 
 // An even number of pieces, at least two, and no more than the pile holds —
 // half of them then go to the other pile. Both players draw on the same two

--- a/src/components/games/bacteria/gameplay.ts
+++ b/src/components/games/bacteria/gameplay.ts
@@ -4,7 +4,7 @@ import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
 export type Board = { bacteria: number[][], goals: number[] };
 export type Cell = { row: number; col: number };
 // A cell paired with the attacking cell it is being judged against.
-export type AttackZone = Cell & { attackRow: number; attackCol: number };
+type AttackZone = Cell & { attackRow: number; attackCol: number };
 
 // Board geometry ------------------------------------------------------------
 // Rows are indexed from the bottom (row 0 = start row, last row = goal row).

--- a/src/components/games/gameList.ts
+++ b/src/components/games/gameList.ts
@@ -17,7 +17,7 @@ import type { I18nString } from '../../language';
 export const categories = ['A', 'B', 'C', 'D', 'E', 'E+'] as const;
 export type Category = typeof categories[number];
 
-export type Round = 'döntő' | 'online'
+type Round = 'döntő' | 'online'
 export type GameList = Record<string, GameEntry>;
 
 // Canonical list of icon keys into the overview icon registry

--- a/src/components/games/matches-on-edges/gameplay.ts
+++ b/src/components/games/matches-on-edges/gameplay.ts
@@ -32,7 +32,7 @@ export const blocks = (board: Board): { start: number; length: number }[] => {
 // Largest allowed window size (1, or a multiple of 4) that fits *strictly*
 // inside a block of length `maxBlockLength`. Returns null when no block can host
 // any window, i.e. the game is over.
-export const allowedWindowSize = (maxBlockLength: number): number | null => {
+const allowedWindowSize = (maxBlockLength: number): number | null => {
   if (maxBlockLength < 2) return null;
   let k = 1;
   for (let c = 4; c < maxBlockLength; c += 4) k = c;

--- a/src/components/games/remove-divisor-multiple/bot-strategy.ts
+++ b/src/components/games/remove-divisor-multiple/bot-strategy.ts
@@ -3,7 +3,7 @@ import { range, sample } from 'lodash';
 import type { BotStrategy } from '../../strategy-game-factory';
 // generated with scripts/pre-generate-ai-moves/remove-divisor-multiple.py
 /* eslint-disable quotes -- pasted verbatim from the generator's JSON output */
-export const strategyDict = {
+const strategyDict = {
   "6": {
     "6_28": [3],
     "2_60": [4],

--- a/src/components/games/remove-row-or-column/gameplay.ts
+++ b/src/components/games/remove-row-or-column/gameplay.ts
@@ -3,7 +3,7 @@ import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
 export type Grid = boolean[][]
 export type Board = { grid: Grid }
 export type Orientation = 'row' | 'col'
-export interface Rect { minR: number; maxR: number; minC: number; maxC: number }
+interface Rect { minR: number; maxR: number; minC: number; maxC: number }
 export interface Move { r: number; c: number; orientation: Orientation }
 
 const inBounds = (grid: Grid, r: number, c: number) =>

--- a/src/components/games/single-number-increase/increment-or-double/bot-strategy.ts
+++ b/src/components/games/single-number-increase/increment-or-double/bot-strategy.ts
@@ -6,7 +6,7 @@ import { type Board, type Moves } from './gameplay';
 // move is always x+1 (which hands the opponent an odd number). From 0 this plays
 // the forced opening 1. From an odd (losing) board both moves hand the opponent an
 // even, winning number, so play randomly to maximise the chance the human errs.
-export const getBotNextNumber = (board: Board): number => {
+const getBotNextNumber = (board: Board): number => {
   if (board % 2 === 0) return board + 1;
   return sample([board + 1, board * 2])!;
 };

--- a/src/components/games/tictactoe-alikes/tictactoe/gameplay.ts
+++ b/src/components/games/tictactoe-alikes/tictactoe/gameplay.ts
@@ -15,7 +15,7 @@ export const botColor = 'red';
 
 export const inPlacingPhase = (board: Board) => board.find(isNull) !== undefined;
 
-export const currentPlayerColor = (ctx: Ctx) =>
+const currentPlayerColor = (ctx: Ctx) =>
   ctx.isHumanVsHumanGame
     ? (ctx.currentPlayer === 0 ? 'blue' : 'red')
     : (ctx.currentPlayer === ctx.chosenRoleIndex ? pColor : botColor);

--- a/src/components/games/triangle-circle-game/geometry.ts
+++ b/src/components/games/triangle-circle-game/geometry.ts
@@ -8,7 +8,7 @@
 // draw each shape) is derived once, here, from that lattice — nothing is
 // hand-transcribed, so the counts can't silently drift.
 
-export const GRID_SIZE = 6;
+const GRID_SIZE = 6;
 export const TRIANGLE_COUNT = 36;
 export const EDGE_COUNT = 63;
 

--- a/src/components/games/triangle-circle-game/strategy/bot-strategy.ts
+++ b/src/components/games/triangle-circle-game/strategy/bot-strategy.ts
@@ -170,12 +170,12 @@ const chooseCircleMove = (board: Board, searchOpts: SearchOpts): number => {
   return undecided.length > 0 ? undecided[0] : ordered[0].t;
 };
 
-// Random moves for the test bot / property tests. The line side still takes an
+// Random moves for the test bot. The line side still takes an
 // immediate win (a triangle at two shaded sides) when one is on the board; the
 // circle side's only one-move win is filling the last triangle, which a random
 // pick makes anyway.
-export const randomLineMove = (board: Board): number => {
+const randomLineMove = (board: Board): number => {
   const winning = freeEdges(board).filter(e => isWinningShade(board, e));
   return sample(winning.length > 0 ? winning : freeEdges(board))!;
 };
-export const randomCircleMove = (board: Board): number => sample(freeTriangles(board))!;
+const randomCircleMove = (board: Board): number => sample(freeTriangles(board))!;

--- a/src/components/games/triangle-circle-game/strategy/search.ts
+++ b/src/components/games/triangle-circle-game/strategy/search.ts
@@ -18,7 +18,7 @@ import { type Board, LINE, CIRCLE } from '../gameplay';
 // line win; a lone threat forces the circle player's reply) to see far along
 // forced lines cheaply.
 
-export type Outcome = 'lineWins' | 'lineLoses' | 'unknown';
+type Outcome = 'lineWins' | 'lineLoses' | 'unknown';
 
 // Precomputed bit machinery. Edges (up to 63) and triangles (36) live in BigInt
 // masks so a whole position is two integers.
@@ -181,7 +181,7 @@ export const evaluatePosition = (
 // Evaluate the position that results from a single move, reusing one budget/memo
 // across many candidate moves (so earlier, better-ordered candidates get the
 // most search and later ones benefit from the shared memo).
-export interface MoveEvaluator {
+interface MoveEvaluator {
   evalAfterShade: (board: Board, edgeId: number) => Outcome;
   evalAfterCircle: (board: Board, triangleId: number) => Outcome;
 }

--- a/src/components/strategy-game-factory/engine/reducer.ts
+++ b/src/components/strategy-game-factory/engine/reducer.ts
@@ -3,7 +3,7 @@ import type { MoveOutcome, MoveDefinition } from '../types';
 import { buildCtx } from './build-ctx';
 import type { CoreState } from './store';
 
-export type MoveTransition<TBoard> = {
+type MoveTransition<TBoard> = {
   state: CoreState<TBoard>
   // validate rejected the dispatch; state is unchanged (same reference)
   illegal?: boolean

--- a/src/components/strategy-game-factory/engine/store.ts
+++ b/src/components/strategy-game-factory/engine/store.ts
@@ -36,7 +36,7 @@ export const createInitialCoreState = <TBoard>(
   currentTurnHasMoves: false
 });
 
-export type GameStore<TBoard> = {
+type GameStore<TBoard> = {
   getState: () => CoreState<TBoard>
   setState: (patch: Partial<CoreState<TBoard>>) => void
   subscribe: (listener: () => void) => () => void

--- a/src/components/strategy-game-factory/types.ts
+++ b/src/components/strategy-game-factory/types.ts
@@ -75,7 +75,7 @@ export type ClientGameMoves<TBoard> = Record<
 export type StrategyArgs<TBoard> = { board: TBoard; ctx: Ctx }
 // A game's `moves` object seen as a type — what a game exports as `Moves` so
 // its bots can name moves out of it.
-export type AnyMoves = Record<string, MoveDefinition<any>>
+type AnyMoves = Record<string, MoveDefinition<any>>
 // What a move takes beyond the board and the meta object: exactly the tail a
 // bot has to supply as `args`.
 type MoveArgs<TApply> =


### PR DESCRIPTION
The tail of the dead-code sweep: symbols that *are* used, but only inside the file that defines them, so the `export` widened the module's surface without buying a consumer. Re-exporting any of them is a one-keystroke change if a use case turns up.

**Values** — `allowedWindowSize` (matches-on-edges), `strategyDict` (remove-divisor-multiple), `getBotNextNumber` (increment-or-double), `currentPlayerColor` (tictactoe), `GRID_SIZE` (triangle-circle geometry), `randomLineMove` / `randomCircleMove` (triangle-circle bot)

**Types** — `Transfer`, `AttackZone`, `Round`, `Rect`, `Outcome`, `MoveEvaluator`, `MoveTransition`, `GameStore`, `AnyMoves`

Two of those deserve a note, since both look like they might break a consumer and do not:

- `AnyMoves` is the constraint of the exported `BotMove` and `BotStrategy` generics. A constraint does not have to be exported for the generic to be usable, so `BotStrategy<Board, Moves>` keeps working in every game's `bot-strategy.ts`.
- `GameStore`, `MoveTransition` and `Outcome` are return types of exported functions. Call sites outside the module still infer them; they just can no longer name them.

`npm run build` passes alongside lint, typecheck and all 1613 tests — worth checking here specifically, because a type that only `tsc --noEmit` validates could still have broken the bundle.

## Deliberately not included

Four types are exported from their module **and** re-exported by a barrel, with no importer anywhere: `MatchMove`, `Presentation` (strategy-game-factory), `MoveFunction` (types), `Translatable` (language). Narrowing those means deleting them from the barrel, which is a different decision — the barrel is the deliberate public API surface aimed at `durer-aion` (#313), where "no consumer in this repo" is expected rather than evidence of disuse. Happy to remove them in a follow-up if you'd rather the barrel only carried what is used today.

Also untouched: `ThiefSheriffMean7`, which a sweep flags as unreferenced but which the games barrel aliases to `ThiefSheriffMean` for the router's dynamic lookup.

After this, no export in `src/` is unread by anything outside its own module.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NcWvHUVTH4sQKQX7ifdAy3)_