### PR TITLE
Resolve the sweep's variants through resolveVariants

### DIFF
--- a/src/components/games/plays-to-an-end.spec.ts
+++ b/src/components/games/plays-to-an-end.spec.ts
@@ -1,5 +1,8 @@
 import * as games from './index';
-import { runMatch, type StrategyGame } from '../strategy-game-factory';
+import {
+  resolveVariants, runMatch,
+  type BotStrategy, type Gameplay, type StrategyGame
+} from '../strategy-game-factory';
 
 // Plays every registered game headlessly, through the real moves, the real
 // validators and the real reducer. `runMatch` throws on everything this is
@@ -41,11 +44,25 @@ const SLOW_VARIANTS = new Set([
 const MAX_MATCHES = 8;
 const MATCH_BUDGET_MS = 15;
 
-type Case = { name: string; Game: StrategyGame<unknown>; variantIndex: number };
+type Case = {
+  name: string
+  gameplay: Gameplay<unknown>
+  generateStartBoard: () => unknown
+  botStrategy: BotStrategy<unknown>
+};
 
+// Resolved exactly as the factory resolves them, so a variant that inherits its
+// bot or its start boards from the default one is swept the way it is played.
 const allCases: Case[] = Object.entries(games as Record<string, StrategyGame<unknown>>)
-  .flatMap(([name, Game]) =>
-    Game.variants.map((_, variantIndex) => ({ name: `${name}[${variantIndex}]`, Game, variantIndex })));
+  .flatMap(([name, Game]) => {
+    const { defaultVariant, resolvedVariants } = resolveVariants(Game.variants);
+    return resolvedVariants.map((variant, variantIndex) => ({
+      name: `${name}[${variantIndex}]`,
+      gameplay: Game.gameplay,
+      generateStartBoard: variant.generateStartBoard ?? defaultVariant.generateStartBoard!,
+      botStrategy: variant.botStrategy!
+    }));
+  });
 
 const cases = allCases.filter(({ name }) => !SLOW_VARIANTS.has(name));
 
@@ -62,12 +79,7 @@ describe('every game plays to a decided end', () => {
     expect(dropped).toEqual(['AmorAndCupido', 'TriangularGridRopes15']);
   });
 
-  it.each(cases)('$name', ({ Game, variantIndex }) => {
-    const variant = Game.variants[variantIndex]!;
-    const defaultVariant = Game.variants[Math.max(Game.variants.findIndex(v => v.isDefault), 0)]!;
-    const generateStartBoard = variant.generateStartBoard ?? defaultVariant.generateStartBoard!;
-    const botStrategy = variant.botStrategy!;
-
+  it.each(cases)('$name', ({ gameplay, generateStartBoard, botStrategy }) => {
     // Start boards are random, so one match samples one line of play. Keep
     // playing fresh boards until the cheap games have had a handful or the
     // budget runs out — which spends the time where matches are cheap instead
@@ -75,7 +87,7 @@ describe('every game plays to a decided end', () => {
     const deadline = performance.now() + MATCH_BUDGET_MS;
     for (let match = 0; match < MAX_MATCHES; match++) {
       const { winnerIndex } = runMatch({
-        gameplay: Game.gameplay,
+        gameplay,
         strategies: [botStrategy, botStrategy],
         startBoard: generateStartBoard()
       });

--- a/src/components/strategy-game-factory/index.ts
+++ b/src/components/strategy-game-factory/index.ts
@@ -6,6 +6,7 @@ export type {
   StrategyArgs, BotStrategy, BotMove, BoardClientProps,
   Variant, VariantInput
 } from './types';
+export { resolveVariants } from './helpers/resolve-variants';
 export { runMatch } from './engine/run-match';
 export type { MatchMove, MatchResult } from './engine/run-match';
 export { GameBoard } from './game-parts/game-board';


### PR DESCRIPTION
`plays-to-an-end.spec.ts` re-derived the default variant by hand
(`Math.max(variants.findIndex(v => v.isDefault), 0)`) and applied the
start-board fallback itself, so the factory's variant-resolution rules lived in
two places. `resolveVariants` was only reachable through a deep import, which is
probably why.

- Export `resolveVariants` from the `strategy-game-factory` barrel.
- Build the sweep's cases from its `resolvedVariants` at collection time, so
  each case carries the `gameplay`, `generateStartBoard` and `botStrategy` it
  plays with and the test body is just the match loop.

One real bug fell out of it: the old code read `variant.botStrategy!` off the
**raw** variant, which is `undefined` for any variant that inherits its bot from
the default one — those would have gone into `runMatch` as a non-function.
`resolvedVariants` applies the same fallback the factory does, so the sweep now
plays each variant the way the site plays it.

The start-board fallback stays one `??` in the spec: `resolveVariants`
deliberately leaves `generateStartBoard` unresolved, because the factory
distinguishes "has its own start boards" from "inherits them" when filtering
variants for vsHuman mode.

`tsc --noEmit` clean; `plays-to-an-end.spec.ts` (139) and
`resolve-variants.spec.ts` (10) pass. ESLint could not run in my container
(`eslint-plugin-react-hooks` not installed), so I checked `max-len: 120` by hand
and split the import, which was at 121 — CI covers the rest.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVVRtteR7nej6bhKtLejEA)_