### PR TITLE
Path aliases for `test-utils`, `strategy-game-factory` and `language`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,8 @@ change, not as an afterthought.
 
 Game-specific logic is also worth testing when the winning strategy is
 non-trivial. Because bots name their moves, a spec can read a decision straight
-off the return value (`botNextMoveArgs` in `test-utils`), and `runMatch`
+off the return value (`botNextMoveArgs` in `test-utils`, imported by specs as
+`from 'test-utils'` — an alias, so no `../../../`), and `runMatch`
 (`strategy-game-factory/engine/run-match.ts`) plays two strategies against each
 other through the real moves and the real reducer — no fake `moves` object, no
 hand-rolled game loop. That is what turns "the AI is truly optimal" into a test:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,8 @@ sibling of `games/`):
   turn-taking, end-of-game detection, restart/clean state. Defines a
   well-specified API that every game must implement. Games import everything
   through the `strategy-game-factory` barrel (`index.ts`) — no deep imports.
+  `strategy-game-factory` is a path alias, so no `../../` either; it is anchored
+  to the barrel, which is what makes the no-deep-imports rule self-enforcing.
 
 **Per-game responsibility:**
 Each game folder implements the optimal strategy (computer AI) and game-specific

--- a/README.md
+++ b/README.md
@@ -283,7 +283,8 @@ it is fine to add new games with Hungarian only.
 
 The `t()` helper from `translate.ts` resolves a value to the active language.
 The value can be a plain string if there are no translations available, or a
-`{ hu, en }` object.
+`{ hu, en }` object. It is reached through the `language` barrel, which is a
+path alias — `import { useTranslation } from 'language';`, no `../../../`.
 
 Check the [Dürer Archive](https://durerinfo.hu/archivum/feladatsorok/) for
 existing translations.

--- a/docs/project-review-2026-08.md
+++ b/docs/project-review-2026-08.md
@@ -298,7 +298,9 @@ rules specs relative to module size.
 - CI: ~~`pr_test.yml` has no `concurrency` group (stacked runs on busy PRs) and
   no npm cache~~ ✅ (#401); the two workflows still duplicate their build block
   verbatim.
-- No path alias for `test-utils` — 97 specs import `../../../test-utils`.
+- ~~No path alias for `test-utils` — 97 specs import `../../../test-utils`.~~ ✅
+  — a `test-utils` alias (`vite.config.js` + tsconfig `paths`) now serves all
+  107 spec imports.
 - 7 `console.*` calls in shipped game code (`triangular-grid-ropes-10`,
   `stones-remove-one-not-twice-from-left`, `cube-coloring`) as "unexpected
   state" fallbacks — arguably should throw in dev like the engine does.

--- a/docs/project-review-2026-08.md
+++ b/docs/project-review-2026-08.md
@@ -299,8 +299,10 @@ rules specs relative to module size.
   no npm cache~~ ✅ (#401); the two workflows still duplicate their build block
   verbatim.
 - ~~No path alias for `test-utils` — 97 specs import `../../../test-utils`.~~ ✅
-  — a `test-utils` alias (`vite.config.js` + tsconfig `paths`) now serves all
-  107 spec imports.
+  — `test-utils` and `strategy-game-factory` are now aliases (`vite.config.js` +
+  tsconfig `paths`), covering 107 spec imports and 262 barrel imports. The
+  barrel alias is anchored, so `strategy-game-factory/engine/…` does not
+  resolve — the no-deep-imports rule now enforces itself.
 - 7 `console.*` calls in shipped game code (`triangular-grid-ropes-10`,
   `stones-remove-one-not-twice-from-left`, `cube-coloring`) as "unexpected
   state" fallbacks — arguably should throw in dev like the engine does.

--- a/docs/project-review-2026-08.md
+++ b/docs/project-review-2026-08.md
@@ -299,10 +299,13 @@ rules specs relative to module size.
   no npm cache~~ ✅ (#401); the two workflows still duplicate their build block
   verbatim.
 - ~~No path alias for `test-utils` — 97 specs import `../../../test-utils`.~~ ✅
-  — `test-utils` and `strategy-game-factory` are now aliases (`vite.config.js` +
-  tsconfig `paths`), covering 107 spec imports and 262 barrel imports. The
-  barrel alias is anchored, so `strategy-game-factory/engine/…` does not
-  resolve — the no-deep-imports rule now enforces itself.
+  — `test-utils`, `strategy-game-factory` and `language` are now aliases
+  (`vite.config.js` + tsconfig `paths`), covering 107 spec imports, 262 barrel
+  imports and 52 i18n imports. Every alias is anchored, so
+  `strategy-game-factory/engine/…` does not resolve — the no-deep-imports rule
+  now enforces itself. What is left relative is the imports that are genuinely
+  local: within `src/language/`, within the factory folder, and `test-utils.ts`
+  reaching into `./components/`.
 - ~~7 `console.*` calls in shipped game code (`triangular-grid-ropes-10`,
   `stones-remove-one-not-twice-from-left`, `cube-coloring`) as "unexpected
   state" fallbacks — arguably should throw in dev like the engine does.~~ ✅

--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -2,7 +2,7 @@ import { StrictMode, type ComponentType } from 'react';
 import { createHashRouter, RouterProvider, Outlet } from 'react-router';
 import { Overview } from '../overview/overview';
 import { ErrorPage } from '../error-page/error-page';
-import { LanguageProvider } from '../../language';
+import { LanguageProvider } from 'language';
 import { ThemeProvider } from '../../theme';
 import { usePageviewTracking } from '../../tracking';
 import { gameList } from '../games/gameList';

--- a/src/components/games/add-reduce-double/add-reduce-double.tsx
+++ b/src/components/games/add-reduce-double/add-reduce-double.tsx
@@ -1,5 +1,5 @@
 import { range, random } from 'lodash';
-import { strategyGameFactory, type BoardClientProps, GameBoard, useHoverPreview } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard, useHoverPreview } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { moves, type Board, type Piece } from './gameplay';
 

--- a/src/components/games/add-reduce-double/bot-strategy.spec.ts
+++ b/src/components/games/add-reduce-double/bot-strategy.spec.ts
@@ -1,7 +1,7 @@
 import { range, uniq } from 'lodash';
 import { getSmartBotStep } from './bot-strategy';
 import { moves, type Board } from './gameplay';
-import { moveValidator } from '../../../test-utils';
+import { moveValidator } from 'test-utils';
 
 const isTransferAllowed = moveValidator(moves.moveHalvedPieces);
 

--- a/src/components/games/add-reduce-double/bot-strategy.ts
+++ b/src/components/games/add-reduce-double/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { random, sample, range } from 'lodash';
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import type { Board, Moves } from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>

--- a/src/components/games/add-reduce-double/gameplay.spec.ts
+++ b/src/components/games/add-reduce-double/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { moves } from './gameplay';
-import { makeCtx, moveValidator } from '../../../test-utils';
+import { makeCtx, moveValidator } from 'test-utils';
 
 const isTransferAllowed = moveValidator(moves.moveHalvedPieces);
 

--- a/src/components/games/add-reduce-double/gameplay.ts
+++ b/src/components/games/add-reduce-double/gameplay.ts
@@ -1,5 +1,5 @@
 import { isEqual, cloneDeep } from 'lodash';
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
 export type Board = number[];
 export type Piece = { pileId: number; pieceId: number };

--- a/src/components/games/amor-and-cupido/amor-and-cupido.tsx
+++ b/src/components/games/amor-and-cupido/amor-and-cupido.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory } from '../../strategy-game-factory';
+import { strategyGameFactory } from 'strategy-game-factory';
 import { generateStartBoard, moves } from './gameplay';
 import { smartBotStrategy } from './bot-strategy';
 import { BoardClient } from './board-client';

--- a/src/components/games/amor-and-cupido/board-client.tsx
+++ b/src/components/games/amor-and-cupido/board-client.tsx
@@ -1,4 +1,4 @@
-import { GameBoard, type BoardClientProps } from '../../strategy-game-factory';
+import { GameBoard, type BoardClientProps } from 'strategy-game-factory';
 import { type Board, EDGES, findWinningTriangle } from './gameplay';
 
 // Hexagon coordinates (viewBox 0 0 100 100), first vertex at the top.

--- a/src/components/games/amor-and-cupido/bot-strategy.spec.ts
+++ b/src/components/games/amor-and-cupido/bot-strategy.spec.ts
@@ -1,5 +1,5 @@
 import { edgeIndex, generateStartBoard } from './gameplay';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 import { getBotScore, smartBotStrategy } from './bot-strategy';
 
 describe('optimal solver (negamax)', () => {

--- a/src/components/games/amor-and-cupido/bot-strategy.ts
+++ b/src/components/games/amor-and-cupido/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { sample } from 'lodash';
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import { canonicalKey, completesTriangle, getAllowedMoves, type Board, type Moves } from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>

--- a/src/components/games/amor-and-cupido/gameplay.spec.ts
+++ b/src/components/games/amor-and-cupido/gameplay.spec.ts
@@ -8,7 +8,7 @@ import {
   getAllowedMoves,
   moves
 } from './gameplay';
-import { makeCtx, moveValidator } from '../../../test-utils';
+import { makeCtx, moveValidator } from 'test-utils';
 
 const isClaimAllowed = moveValidator(moves.claimEdge);
 

--- a/src/components/games/amor-and-cupido/gameplay.ts
+++ b/src/components/games/amor-and-cupido/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 // Triangle achievement game on the complete graph K6 (6 people, 15 possible
 // pairs/edges). Each edge is owned by player 0, player 1, or nobody (null).
 // A player wins by owning all three edges of one of the 20 triangles.

--- a/src/components/games/architect-and-bandits/architect-and-bandits-a/architect-and-bandits-a.tsx
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-a/architect-and-bandits-a.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory } from '../../../strategy-game-factory';
+import { strategyGameFactory } from 'strategy-game-factory';
 import { ARCHITECT } from '../gameplay';
 import { makeBoardClient } from '../board-client';
 import { smartBotStrategy } from './bot-strategy';

--- a/src/components/games/architect-and-bandits/architect-and-bandits-a/bot-strategy.ts
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-a/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { maxBy } from 'lodash';
-import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
+import type { BotMove, BotStrategy } from 'strategy-game-factory';
 import type { Board } from '../gameplay';
 import { VERTEX_COUNT, type Moves } from './gameplay';
 import { makeCyclePaths } from '../cycle-paths';

--- a/src/components/games/architect-and-bandits/architect-and-bandits-a/gameplay.spec.ts
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-a/gameplay.spec.ts
@@ -1,6 +1,6 @@
 import { generateStartBoard, moves } from './gameplay';
 import { ARCHITECT, BANDITS, KM_PER_EDGE, type Board } from '../gameplay';
-import { makeCtx } from '../../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 // After the fourth day the architect wins exactly when every vertex carries a
 // tower.

--- a/src/components/games/architect-and-bandits/architect-and-bandits-b/architect-and-bandits-b.tsx
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-b/architect-and-bandits-b.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory } from '../../../strategy-game-factory';
+import { strategyGameFactory } from 'strategy-game-factory';
 import { ARCHITECT } from '../gameplay';
 import { makeBoardClient } from '../board-client';
 import { smartBotStrategy } from './bot-strategy';

--- a/src/components/games/architect-and-bandits/architect-and-bandits-b/bot-strategy.ts
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-b/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { maxBy, sample } from 'lodash';
-import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
+import type { BotMove, BotStrategy } from 'strategy-game-factory';
 import type { Board } from '../gameplay';
 import { VERTEX_COUNT, type Moves } from './gameplay';
 import { makeCyclePaths } from '../cycle-paths';

--- a/src/components/games/architect-and-bandits/architect-and-bandits-b/gameplay.spec.ts
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-b/gameplay.spec.ts
@@ -1,6 +1,6 @@
 import { generateStartBoard, moves } from './gameplay';
 import { ARCHITECT, BANDITS, KM_PER_EDGE, type Board } from '../gameplay';
-import { makeCtx } from '../../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 // After the fourth day the architect wins exactly when every vertex carries a
 // tower.

--- a/src/components/games/architect-and-bandits/board-client.tsx
+++ b/src/components/games/architect-and-bandits/board-client.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 import { GameBoard, type BoardClientProps } from 'strategy-game-factory';
 import { type Board, ARCHITECT } from './gameplay';
 

--- a/src/components/games/architect-and-bandits/board-client.tsx
+++ b/src/components/games/architect-and-bandits/board-client.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from '../../../language';
-import { GameBoard, type BoardClientProps } from '../../strategy-game-factory';
+import { GameBoard, type BoardClientProps } from 'strategy-game-factory';
 import { type Board, ARCHITECT } from './gameplay';
 
 const VERTEX_LABELS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J'];

--- a/src/components/games/architect-and-bandits/gameplay.ts
+++ b/src/components/games/architect-and-bandits/gameplay.ts
@@ -1,5 +1,5 @@
 import { cloneDeep } from 'lodash';
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
 // Both variants play the same game on a regular polygon, differing only in how
 // many vertices the wall has and how far the architect may walk in a day.

--- a/src/components/games/bacteria/bacteria.tsx
+++ b/src/components/games/bacteria/bacteria.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { range } from 'lodash';
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import {
   isJump,

--- a/src/components/games/bacteria/bot-strategy.ts
+++ b/src/components/games/bacteria/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { cloneDeep, sample, maxBy } from 'lodash';
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import { computeLettered, computeSinks, deficiency } from './danger';
 import {
   type Board,

--- a/src/components/games/bacteria/gameplay.spec.ts
+++ b/src/components/games/bacteria/gameplay.spec.ts
@@ -3,7 +3,7 @@ import {
   hasBacterium, isAttackAllowed, ATTACKER, DEFENDER, type MoveType
 } from './gameplay';
 import { reverse } from 'lodash';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 describe('moves', () => {
   const meta = { ctx: makeCtx({ currentPlayer: DEFENDER }) };

--- a/src/components/games/bacteria/gameplay.ts
+++ b/src/components/games/bacteria/gameplay.ts
@@ -1,5 +1,5 @@
 import { cloneDeep } from 'lodash';
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
 export type Board = { bacteria: number[][], goals: number[] };
 export type Cell = { row: number; col: number };

--- a/src/components/games/bank-robbers/bank-robbers.tsx
+++ b/src/components/games/bank-robbers/bank-robbers.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { range } from 'lodash';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 import { generateStartBoard, isRobbable, moves, type Board } from './gameplay';

--- a/src/components/games/bank-robbers/bot-strategy.spec.ts
+++ b/src/components/games/bank-robbers/bot-strategy.spec.ts
@@ -1,6 +1,6 @@
 import { smartBotStrategy } from './bot-strategy';
 import type { Board } from './gameplay';
-import { botNextMoveArgs, makeCtx } from '../../../test-utils';
+import { botNextMoveArgs, makeCtx } from 'test-utils';
 
 const robbedBank = (board: Board): number => botNextMoveArgs(smartBotStrategy({ board, ctx: makeCtx() }))[0];
 

--- a/src/components/games/bank-robbers/bot-strategy.ts
+++ b/src/components/games/bank-robbers/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { random, sample } from 'lodash';
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import { getAllowedBanks, type Board, type Moves } from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>

--- a/src/components/games/bank-robbers/gameplay.spec.ts
+++ b/src/components/games/bank-robbers/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { isRobbable, moves, type Board } from './gameplay';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
 

--- a/src/components/games/bank-robbers/gameplay.ts
+++ b/src/components/games/bank-robbers/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { range, cloneDeep, random, sample } from 'lodash';
 
 export type Board = { circle: boolean[], lastMove: number | null, firstMove: number | null }

--- a/src/components/games/chess-bishops/bot-strategy.spec.ts
+++ b/src/components/games/chess-bishops/bot-strategy.spec.ts
@@ -1,7 +1,7 @@
 import lodash from 'lodash';
 import { smartBotStrategy } from './bot-strategy';
 import { generateStartBoard, BISHOP, markForbiddenFields, type Board, type Field } from './gameplay'
-import { botNextMoveArgs, makeCtx } from '../../../test-utils';
+import { botNextMoveArgs, makeCtx } from 'test-utils';
 
 const smartBotPlacement = (board: Board): Field =>
   botNextMoveArgs(smartBotStrategy({ board, ctx: makeCtx() }))[0];

--- a/src/components/games/chess-bishops/bot-strategy.ts
+++ b/src/components/games/chess-bishops/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { sample, cloneDeep, random, shuffle } from 'lodash';
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import {
   BISHOP,
   boardIndices,

--- a/src/components/games/chess-bishops/chess-bishops.tsx
+++ b/src/components/games/chess-bishops/chess-bishops.tsx
@@ -1,5 +1,5 @@
 import { range, isEqual } from 'lodash';
-import { strategyGameFactory, type BoardClientProps, GameBoard, useHoverPreview } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard, useHoverPreview } from 'strategy-game-factory';
 import { ChessBishopSvg } from './chess-bishop-svg';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { BISHOP, FORBIDDEN, generateStartBoard, moves, type Board, type Field } from './gameplay';

--- a/src/components/games/chess-bishops/gameplay.spec.ts
+++ b/src/components/games/chess-bishops/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { FORBIDDEN, generateStartBoard, getAllowedMoves, markForbiddenFields, moves } from './gameplay';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 describe('markForbiddenFields', () => {
   it('should mark forbidden fields', () => {

--- a/src/components/games/chess-bishops/gameplay.ts
+++ b/src/components/games/chess-bishops/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { flatMap, range, some, isEqual, cloneDeep } from 'lodash';
 
 export const BISHOP = 1 as const;

--- a/src/components/games/chess-ducks/bot-strategy.spec.ts
+++ b/src/components/games/chess-ducks/bot-strategy.spec.ts
@@ -6,7 +6,7 @@ import {
 import {
   smartBotStrategy, randomBotStrategy, smartBotOptimalSecondSteps, smartBotOptimalThirdSteps
 } from './bot-strategy';
-import { botNextMoveArgs, makeCtx } from '../../../test-utils';
+import { botNextMoveArgs, makeCtx } from 'test-utils';
 
 const emptyBoard = (rows: number, cols: number): Board =>
   range(rows).map(() => range(cols).map(() => null));

--- a/src/components/games/chess-ducks/bot-strategy.spec.ts
+++ b/src/components/games/chess-ducks/bot-strategy.spec.ts
@@ -1,5 +1,5 @@
 import { range } from 'lodash';
-import { runMatch, type MatchResult } from '../../strategy-game-factory';
+import { runMatch, type MatchResult } from 'strategy-game-factory';
 import {
   getAllowedMoves, isPlacementAllowed, withDuckPlaced, moves, type Board, type Field
 } from './gameplay';

--- a/src/components/games/chess-ducks/bot-strategy.ts
+++ b/src/components/games/chess-ducks/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { getBoardIndices, withDuckPlaced, getAllowedMoves, type Board, type Field, type Moves } from './gameplay';
-import { type BotStrategy } from '../../strategy-game-factory';
+import { type BotStrategy } from 'strategy-game-factory';
 import { shuffle, sample } from 'lodash';
 
 type Bot = BotStrategy<Board, Moves>

--- a/src/components/games/chess-ducks/chess-ducks.tsx
+++ b/src/components/games/chess-ducks/chess-ducks.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { range, sample } from 'lodash';
 import { DuckSvg } from './rubber-duck-svg';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';

--- a/src/components/games/chess-ducks/gameplay.spec.ts
+++ b/src/components/games/chess-ducks/gameplay.spec.ts
@@ -2,7 +2,7 @@ import { range } from 'lodash';
 import {
   DUCK, FORBIDDEN, moves, isPlacementAllowed, getAllowedMoves, withDuckPlaced, type Board
 } from './gameplay';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
 

--- a/src/components/games/chess-ducks/gameplay.ts
+++ b/src/components/games/chess-ducks/gameplay.ts
@@ -1,5 +1,5 @@
 import { flatMap, range, cloneDeep } from 'lodash';
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
 export const DUCK = 1 as const;
 export const FORBIDDEN = 2 as const;

--- a/src/components/games/chess-knight/bot-strategy.ts
+++ b/src/components/games/chess-knight/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { sample } from 'lodash';
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import { getAllowedMoves, type Board, type Field, type Moves } from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>

--- a/src/components/games/chess-knight/chess-knight.tsx
+++ b/src/components/games/chess-knight/chess-knight.tsx
@@ -1,5 +1,5 @@
 import { range } from 'lodash';
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { generateStartBoard, moves, type Board, type Field } from './gameplay';
 import { ChessKnightSvg } from './chess-knight-svg';

--- a/src/components/games/chess-knight/gameplay.spec.ts
+++ b/src/components/games/chess-knight/gameplay.spec.ts
@@ -1,6 +1,6 @@
 import { range } from 'lodash';
 import { generateStartBoard, getAllowedMoves, moves, type Board, type CellValue } from './gameplay';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 // A 4x4 board with the knight at `knightPosition` and `visited` already toured.
 const boardWith = (knightPosition: { row: number; col: number }, visited: number[][] = []): Board => {

--- a/src/components/games/chess-knight/gameplay.ts
+++ b/src/components/games/chess-knight/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { range, random, some, isEqual, cloneDeep } from 'lodash';
 
 export type CellValue = null | 'knight' | 'visited';

--- a/src/components/games/chess-rook/bot-strategy.spec.ts
+++ b/src/components/games/chess-rook/bot-strategy.spec.ts
@@ -1,6 +1,6 @@
 import { smartBotStrategy } from './bot-strategy';
 import { generateStartBoard, markVisitedFields, type Board, type Field } from './gameplay';
-import { botNextMoveArgs, makeCtx } from '../../../test-utils';
+import { botNextMoveArgs, makeCtx } from 'test-utils';
 import { isEqual, cloneDeep } from 'lodash';
 
 const smartBotTarget = (board: Board): Field =>

--- a/src/components/games/chess-rook/bot-strategy.ts
+++ b/src/components/games/chess-rook/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { last, random, sample } from 'lodash';
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import { getAllowedMoves, type Board, type Moves } from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>

--- a/src/components/games/chess-rook/chess-rook.tsx
+++ b/src/components/games/chess-rook/chess-rook.tsx
@@ -1,5 +1,5 @@
 import { range } from 'lodash';
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { generateStartBoard, moves, type Board, type Field } from './gameplay';
 import { RookSvg } from '../shared/rook-svg';

--- a/src/components/games/chess-rook/gameplay.spec.ts
+++ b/src/components/games/chess-rook/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { generateStartBoard, getAllowedMoves, markVisitedFields, moves } from './gameplay';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 describe('markVisitedFields', () => {
   it('should mark visited fields', () => {

--- a/src/components/games/chess-rook/gameplay.ts
+++ b/src/components/games/chess-rook/gameplay.ts
@@ -1,5 +1,5 @@
 import { cloneDeep, isEqual, range, some } from 'lodash';
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
 export type CellValue = null | 'rook' | 'visited';
 export type Field = { row: number; col: number };

--- a/src/components/games/chocolate-breaking/bot-strategy.ts
+++ b/src/components/games/chocolate-breaking/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { sample } from 'lodash';
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import {
   allMoves, applyBreak, grundy, hasSafeBreak, type Board, type Move, type Moves, type Piece
 } from './gameplay';

--- a/src/components/games/chocolate-breaking/chocolate-breaking.tsx
+++ b/src/components/games/chocolate-breaking/chocolate-breaking.tsx
@@ -5,7 +5,7 @@ import {
   type Ctx,
   GameBoard,
   useHoverPreview
-} from '../../strategy-game-factory';
+} from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import {
   generateStartBoard,

--- a/src/components/games/chocolate-breaking/gameplay.spec.ts
+++ b/src/components/games/chocolate-breaking/gameplay.spec.ts
@@ -8,7 +8,7 @@ import {
   type Board,
   type Move
 } from './gameplay';
-import { makeCtx, moveValidator } from '../../../test-utils';
+import { makeCtx, moveValidator } from 'test-utils';
 
 const isBreakAllowed = moveValidator(moves.breakPiece);
 

--- a/src/components/games/chocolate-breaking/gameplay.ts
+++ b/src/components/games/chocolate-breaking/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { random } from 'lodash';
 
 export type Piece = { id: number; w: number; h: number };

--- a/src/components/games/coins-in-3-piles/board-client.tsx
+++ b/src/components/games/coins-in-3-piles/board-client.tsx
@@ -1,5 +1,5 @@
 import { range } from 'lodash';
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 import type { Board } from './gameplay';
 import { GameBoard, type BoardClientProps, useHoverPreview } from 'strategy-game-factory';
 

--- a/src/components/games/coins-in-3-piles/board-client.tsx
+++ b/src/components/games/coins-in-3-piles/board-client.tsx
@@ -1,7 +1,7 @@
 import { range } from 'lodash';
 import { useTranslation } from '../../../language';
 import type { Board } from './gameplay';
-import { GameBoard, type BoardClientProps, useHoverPreview } from '../../strategy-game-factory';
+import { GameBoard, type BoardClientProps, useHoverPreview } from 'strategy-game-factory';
 
 const getCoinBgColor = (coinValue) => {
   if (coinValue === 1) return 'bg-yellow-700';

--- a/src/components/games/coins-in-3-piles/bot-strategy.spec.ts
+++ b/src/components/games/coins-in-3-piles/bot-strategy.spec.ts
@@ -1,4 +1,4 @@
-import { runMatch } from '../../strategy-game-factory';
+import { runMatch } from 'strategy-game-factory';
 import { isLostForMover, moves, type Board } from './gameplay';
 import { makeCtx } from 'test-utils';
 import { planTurn, smartBotStrategy, randomBotStrategy } from './bot-strategy';

--- a/src/components/games/coins-in-3-piles/bot-strategy.spec.ts
+++ b/src/components/games/coins-in-3-piles/bot-strategy.spec.ts
@@ -1,6 +1,6 @@
 import { runMatch } from '../../strategy-game-factory';
 import { isLostForMover, moves, type Board } from './gameplay';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 import { planTurn, smartBotStrategy, randomBotStrategy } from './bot-strategy';
 
 describe('coins-in-3-piles planTurn', () => {

--- a/src/components/games/coins-in-3-piles/bot-strategy.ts
+++ b/src/components/games/coins-in-3-piles/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { findIndex, sample, range } from 'lodash';
-import type { BotMove, BotStrategy } from '../../strategy-game-factory';
+import type { BotMove, BotStrategy } from 'strategy-game-factory';
 import type { Board, Moves } from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>

--- a/src/components/games/coins-in-3-piles/coins-in-3-piles.tsx
+++ b/src/components/games/coins-in-3-piles/coins-in-3-piles.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory } from '../../strategy-game-factory';
+import { strategyGameFactory } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { BoardClient } from './board-client';
 import {

--- a/src/components/games/coins-in-3-piles/gameplay.spec.ts
+++ b/src/components/games/coins-in-3-piles/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { moves, type Board } from './gameplay';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 describe('coins-in-3-piles move validators', () => {
   type TurnState = { removedCoinValue: number } | null;

--- a/src/components/games/coins-in-3-piles/gameplay.ts
+++ b/src/components/games/coins-in-3-piles/gameplay.ts
@@ -1,5 +1,5 @@
 import { cloneDeep, isEqual, random, sample, sum } from 'lodash';
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
 export type Board = number[]
 

--- a/src/components/games/cube-coloring/bot-strategy.ts
+++ b/src/components/games/cube-coloring/bot-strategy.ts
@@ -1,6 +1,6 @@
 import { difference, range, shuffle, sample } from 'lodash';
 import { isAllowedStep, isColored, neighbours, colors, type Board, type Moves } from './gameplay';
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 
 type Bot = BotStrategy<Board, Moves>
 

--- a/src/components/games/cube-coloring/cube-coloring.tsx
+++ b/src/components/games/cube-coloring/cube-coloring.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { range, map } from 'lodash';
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { generateStartBoard, edges, moves, type Board } from './gameplay';
 import { useTranslation } from '../../../language';

--- a/src/components/games/cube-coloring/cube-coloring.tsx
+++ b/src/components/games/cube-coloring/cube-coloring.tsx
@@ -3,7 +3,7 @@ import { range, map } from 'lodash';
 import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { generateStartBoard, edges, moves, type Board } from './gameplay';
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 
 // Screen position of each node; the drawn skeleton (see `edges` in gameplay)
 // connects these by node id.

--- a/src/components/games/cube-coloring/gameplay.spec.ts
+++ b/src/components/games/cube-coloring/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { isAllowedStep, generateStartBoard, moves, neighbours, type Board } from './gameplay';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 describe('cube-coloring isAllowedStep', () => {
   const empty = (): Board => generateStartBoard();

--- a/src/components/games/cube-coloring/gameplay.ts
+++ b/src/components/games/cube-coloring/gameplay.ts
@@ -1,5 +1,5 @@
 import { cloneDeep, every, range, some } from 'lodash';
-import type { MoveOutcome } from '../../strategy-game-factory';
+import type { MoveOutcome } from 'strategy-game-factory';
 
 export type Board = string[]
 

--- a/src/components/games/digit-subtraction/bot-strategy.ts
+++ b/src/components/games/digit-subtraction/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { sample } from 'lodash';
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import { type Board, type Moves } from './gameplay';
 
 const digitsOf = (n: number): number[] =>

--- a/src/components/games/digit-subtraction/digit-subtraction.tsx
+++ b/src/components/games/digit-subtraction/digit-subtraction.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { generateStartBoard, moves, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 

--- a/src/components/games/digit-subtraction/gameplay.spec.ts
+++ b/src/components/games/digit-subtraction/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { moves } from './gameplay';
-import { makeCtx, moveValidator } from '../../../test-utils';
+import { makeCtx, moveValidator } from 'test-utils';
 
 const isSubtractableDigit = moveValidator(moves.subtractDigit);
 

--- a/src/components/games/digit-subtraction/gameplay.ts
+++ b/src/components/games/digit-subtraction/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
 export type Board = number
 

--- a/src/components/games/discs-flip-or-remove/bot-strategy.spec.ts
+++ b/src/components/games/discs-flip-or-remove/bot-strategy.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { playBotMove } from '../../../test-utils';
+import { playBotMove } from 'test-utils';
 import { smartBotStrategy } from './bot-strategy';
 import { moves as gameMoves } from './gameplay';
 

--- a/src/components/games/discs-flip-or-remove/bot-strategy.ts
+++ b/src/components/games/discs-flip-or-remove/bot-strategy.ts
@@ -1,4 +1,4 @@
-import type { BotMove, BotStrategy } from '../../strategy-game-factory';
+import type { BotMove, BotStrategy } from 'strategy-game-factory';
 import { random, sample, filter } from 'lodash';
 import { type Board, type Moves } from './gameplay';
 

--- a/src/components/games/discs-flip-or-remove/discs-flip-or-remove.tsx
+++ b/src/components/games/discs-flip-or-remove/discs-flip-or-remove.tsx
@@ -1,6 +1,6 @@
 import { strategyGameFactory, type BoardClientProps, GameBoard, useHoverPreview } from 'strategy-game-factory';
 import { range, isEqual } from 'lodash';
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 import { generateStartBoard, generateTestStartBoard, moves, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 

--- a/src/components/games/discs-flip-or-remove/discs-flip-or-remove.tsx
+++ b/src/components/games/discs-flip-or-remove/discs-flip-or-remove.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory, type BoardClientProps, GameBoard, useHoverPreview } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard, useHoverPreview } from 'strategy-game-factory';
 import { range, isEqual } from 'lodash';
 import { useTranslation } from '../../../language';
 import { generateStartBoard, generateTestStartBoard, moves, type Board } from './gameplay';

--- a/src/components/games/discs-flip-or-remove/gameplay.spec.ts
+++ b/src/components/games/discs-flip-or-remove/gameplay.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { isRemovalAllowed, moves } from './gameplay';
-import { makeCtx, moveValidator } from '../../../test-utils';
+import { makeCtx, moveValidator } from 'test-utils';
 
 const isFlipAllowed = moveValidator(moves.turnDiscs);
 

--- a/src/components/games/discs-flip-or-remove/gameplay.ts
+++ b/src/components/games/discs-flip-or-remove/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { range, isEqual, random, sample, difference, cloneDeep } from 'lodash';
 
 export type Board = [number, number]

--- a/src/components/games/distinct-squares/five-squares/bot-strategy.spec.ts
+++ b/src/components/games/distinct-squares/five-squares/bot-strategy.spec.ts
@@ -2,7 +2,7 @@ import { range, uniq } from 'lodash';
 import { runMatch, type MatchResult } from '../../../strategy-game-factory';
 import { moves, generateStartBoard, type Board } from './gameplay';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
-import { makeCtx } from '../../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 const startBoardOn = (square: number): Board => {
   const board = Array(5).fill(0);

--- a/src/components/games/distinct-squares/five-squares/bot-strategy.spec.ts
+++ b/src/components/games/distinct-squares/five-squares/bot-strategy.spec.ts
@@ -1,5 +1,5 @@
 import { range, uniq } from 'lodash';
-import { runMatch, type MatchResult } from '../../../strategy-game-factory';
+import { runMatch, type MatchResult } from 'strategy-game-factory';
 import { moves, generateStartBoard, type Board } from './gameplay';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { makeCtx } from 'test-utils';

--- a/src/components/games/distinct-squares/five-squares/bot-strategy.ts
+++ b/src/components/games/distinct-squares/five-squares/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { sum, isEqual, sample, range } from 'lodash';
-import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
+import type { BotMove, BotStrategy } from 'strategy-game-factory';
 import type { Board, Moves } from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>

--- a/src/components/games/distinct-squares/five-squares/five-squares.tsx
+++ b/src/components/games/distinct-squares/five-squares/five-squares.tsx
@@ -1,5 +1,5 @@
 import { range } from 'lodash';
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { generateStartBoard, moves, type Board, type TurnState } from './gameplay';
 

--- a/src/components/games/distinct-squares/five-squares/gameplay.spec.ts
+++ b/src/components/games/distinct-squares/five-squares/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { moves } from './gameplay';
-import { makeCtx } from '../../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 // The game always ends on the tenth square; the second player wins only if the
 // five counts are all distinct by then.

--- a/src/components/games/distinct-squares/five-squares/gameplay.ts
+++ b/src/components/games/distinct-squares/five-squares/gameplay.ts
@@ -1,5 +1,5 @@
 import { sum, isEqual, random, cloneDeep } from 'lodash';
-import type { Ctx, MoveOutcome } from '../../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { isPlacementAllowed } from '../gameplay';
 
 export type Board = number[]

--- a/src/components/games/distinct-squares/two-times-two/bot-strategy.spec.ts
+++ b/src/components/games/distinct-squares/two-times-two/bot-strategy.spec.ts
@@ -1,5 +1,5 @@
 import { isEqual } from 'lodash';
-import { runMatch, type MatchResult } from '../../../strategy-game-factory';
+import { runMatch, type MatchResult } from 'strategy-game-factory';
 import { type Board, generateStartBoard, moves } from './gameplay';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 

--- a/src/components/games/distinct-squares/two-times-two/bot-strategy.ts
+++ b/src/components/games/distinct-squares/two-times-two/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { sum, isEqual, sample, range } from 'lodash';
-import type { BotStrategy } from '../../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import type { Board, Moves } from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>

--- a/src/components/games/distinct-squares/two-times-two/gameplay.spec.ts
+++ b/src/components/games/distinct-squares/two-times-two/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { moves } from './gameplay';
-import { makeCtx } from '../../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 // The game always ends on the sixth square; the second player wins only if the
 // four counts are all distinct by then.

--- a/src/components/games/distinct-squares/two-times-two/gameplay.ts
+++ b/src/components/games/distinct-squares/two-times-two/gameplay.ts
@@ -1,5 +1,5 @@
 import { sum, isEqual, cloneDeep } from 'lodash';
-import type { MoveOutcome } from '../../../strategy-game-factory';
+import type { MoveOutcome } from 'strategy-game-factory';
 import { isPlacementAllowed } from '../gameplay';
 
 export type Board = number[]

--- a/src/components/games/distinct-squares/two-times-two/two-times-two.tsx
+++ b/src/components/games/distinct-squares/two-times-two/two-times-two.tsx
@@ -1,5 +1,5 @@
 import { range } from 'lodash';
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { generateStartBoard, moves, type Board } from './gameplay';
 

--- a/src/components/games/dominoes-4x4/bot-strategy.spec.ts
+++ b/src/components/games/dominoes-4x4/bot-strategy.spec.ts
@@ -1,4 +1,4 @@
-import { botNextMoveArgs, makeCtx } from '../../../test-utils';
+import { botNextMoveArgs, makeCtx } from 'test-utils';
 import { smartBotStrategy, randomBotStrategy, isWinningForPlayerToMove } from './bot-strategy';
 import { getPossibleMoves, type Board, type Domino, type Field } from './gameplay';
 

--- a/src/components/games/dominoes-4x4/bot-strategy.ts
+++ b/src/components/games/dominoes-4x4/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { sample } from 'lodash';
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import { type Board, type Domino, BOARDSIZE, type Moves } from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>

--- a/src/components/games/dominoes-4x4/dominoes-4x4.tsx
+++ b/src/components/games/dominoes-4x4/dominoes-4x4.tsx
@@ -6,7 +6,7 @@ import {
   type BoardClientProps,
   GameBoard,
   useHoverPreview
-} from '../../strategy-game-factory';
+} from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { isCovered, moves, BOARDSIZE, type Board, type Domino, type Field } from './gameplay';
 

--- a/src/components/games/dominoes-4x4/gameplay.spec.ts
+++ b/src/components/games/dominoes-4x4/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { isDominoAllowed, moves, getPossibleMoves, type Board, type Domino } from './gameplay';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
 

--- a/src/components/games/dominoes-4x4/gameplay.ts
+++ b/src/components/games/dominoes-4x4/gameplay.ts
@@ -1,5 +1,5 @@
 import { range, cloneDeep, isEqual, flatMap } from 'lodash';
-import type { MoveOutcome, Ctx } from '../../strategy-game-factory';
+import type { MoveOutcome, Ctx } from 'strategy-game-factory';
 
 export type Field = { row: number, col: number }
 export type Domino = [Field, Field]

--- a/src/components/games/dominoes-on-chessboard/bot-strategy.spec.ts
+++ b/src/components/games/dominoes-on-chessboard/bot-strategy.spec.ts
@@ -1,5 +1,5 @@
 import { isEqual } from 'lodash';
-import { botNextMoveArgs, makeCtx } from '../../../test-utils';
+import { botNextMoveArgs, makeCtx } from 'test-utils';
 import { getExactWinningMove, smartBotStrategy } from './bot-strategy';
 import { ALL_FIELDS, BOARDSIZE, type Board, type Domino, type Field } from './gameplay';
 

--- a/src/components/games/dominoes-on-chessboard/bot-strategy.ts
+++ b/src/components/games/dominoes-on-chessboard/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { sample, last } from 'lodash';
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import { type Board, type Domino, type Field, type Moves, ALL_FIELDS, BOARDSIZE, getPossibleMoves } from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>

--- a/src/components/games/dominoes-on-chessboard/dominoes-on-chessboard.tsx
+++ b/src/components/games/dominoes-on-chessboard/dominoes-on-chessboard.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { range, isEqual } from 'lodash';
-import { strategyGameFactory, type BoardClientProps, GameBoard, useHoverPreview } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard, useHoverPreview } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { isCovered, moves, BOARDSIZE, type Board, type Field } from './gameplay';
 

--- a/src/components/games/dominoes-on-chessboard/gameplay.spec.ts
+++ b/src/components/games/dominoes-on-chessboard/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { isDominoAllowed, moves, getPossibleMoves, type Board, type Domino } from './gameplay';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
 

--- a/src/components/games/dominoes-on-chessboard/gameplay.ts
+++ b/src/components/games/dominoes-on-chessboard/gameplay.ts
@@ -1,5 +1,5 @@
 import { range, cloneDeep, isEqual, flatMap } from 'lodash';
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
 export type Field = { row: number, col: number }
 export type Domino = [Field, Field]

--- a/src/components/games/five-connected-fields/board-client.tsx
+++ b/src/components/games/five-connected-fields/board-client.tsx
@@ -1,5 +1,5 @@
 import { range } from 'lodash';
-import { GameBoard, type BoardClientProps } from '../../strategy-game-factory';
+import { GameBoard, type BoardClientProps } from 'strategy-game-factory';
 import { type Board, side1, side2 } from './gameplay';
 
 // A deliberately non-obvious drawing of the K(2,3) graph: the two hub fields

--- a/src/components/games/five-connected-fields/bot-strategy.ts
+++ b/src/components/games/five-connected-fields/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { sample } from 'lodash';
-import { type BotStrategy } from '../../strategy-game-factory';
+import { type BotStrategy } from 'strategy-game-factory';
 import { createWinLossSolver } from '../shared/win-loss-solver';
 import { type Board, type Moves, legalNodes } from './gameplay';
 

--- a/src/components/games/five-connected-fields/five-connected-fields.tsx
+++ b/src/components/games/five-connected-fields/five-connected-fields.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory } from '../../strategy-game-factory';
+import { strategyGameFactory } from 'strategy-game-factory';
 import { generateStartBoard, moves } from './gameplay';
 import { smartBotStrategy } from './bot-strategy';
 import { BoardClient } from './board-client';

--- a/src/components/games/five-connected-fields/gameplay.spec.ts
+++ b/src/components/games/five-connected-fields/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { hasAnyMove, isNodePlayable, legalNodes, moves, type Board } from './gameplay';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 // K(2,3): 0=A and 1=B are the hubs, each joined to 2=C, 3=D and 4=E. Neither
 // hub is joined to the other, and C, D, E are not joined to each other.

--- a/src/components/games/five-connected-fields/gameplay.ts
+++ b/src/components/games/five-connected-fields/gameplay.ts
@@ -1,5 +1,5 @@
 import { range } from 'lodash';
-import type { Ctx } from '../../strategy-game-factory';
+import type { Ctx } from 'strategy-game-factory';
 
 // The board is the K(2,3) bipartite graph of 5 fields, holding coin counts.
 // Indices 0=A, 1=B are the two "hub" fields (side 1, each adjacent to all of

--- a/src/components/games/five-five-card/bot-strategy.spec.ts
+++ b/src/components/games/five-five-card/bot-strategy.spec.ts
@@ -1,4 +1,4 @@
-import { runMatch, type MatchResult } from '../../strategy-game-factory';
+import { runMatch, type MatchResult } from 'strategy-game-factory';
 import { type Board, getWinnerIndex, moves } from './gameplay';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 

--- a/src/components/games/five-five-card/bot-strategy.ts
+++ b/src/components/games/five-five-card/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { sample, range } from 'lodash';
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import { type Board, getWinnerIndex, type Moves } from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>

--- a/src/components/games/five-five-card/five-five-card.tsx
+++ b/src/components/games/five-five-card/five-five-card.tsx
@@ -1,5 +1,5 @@
 import { range } from 'lodash';
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { useTranslation } from '../../../language';
 import { moves, type Board } from './gameplay';

--- a/src/components/games/five-five-card/five-five-card.tsx
+++ b/src/components/games/five-five-card/five-five-card.tsx
@@ -1,7 +1,7 @@
 import { range } from 'lodash';
 import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 import { moves, type Board } from './gameplay';
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {

--- a/src/components/games/five-five-card/gameplay.spec.ts
+++ b/src/components/games/five-five-card/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { isRemovalAllowed, moves, type Board } from './gameplay';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
 

--- a/src/components/games/five-five-card/gameplay.ts
+++ b/src/components/games/five-five-card/gameplay.ts
@@ -1,5 +1,5 @@
 import { cloneDeep } from 'lodash';
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
 export type Board = (number | null)[][]
 

--- a/src/components/games/four-connected-fields/board-client.tsx
+++ b/src/components/games/four-connected-fields/board-client.tsx
@@ -1,5 +1,5 @@
 import { range } from 'lodash';
-import { GameBoard, type BoardClientProps } from '../../strategy-game-factory';
+import { GameBoard, type BoardClientProps } from 'strategy-game-factory';
 import { type Board, hubs, others } from './gameplay';
 
 // Drawing of the graph (K4 minus the C-D edge) as a rhomboid: the two hub fields

--- a/src/components/games/four-connected-fields/bot-strategy.ts
+++ b/src/components/games/four-connected-fields/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { sample } from 'lodash';
-import { type BotStrategy } from '../../strategy-game-factory';
+import { type BotStrategy } from 'strategy-game-factory';
 import { createWinLossSolver } from '../shared/win-loss-solver';
 import { hasAnyMove, legalNodes, type Board, type Moves } from './gameplay';
 

--- a/src/components/games/four-connected-fields/four-connected-fields.tsx
+++ b/src/components/games/four-connected-fields/four-connected-fields.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory } from '../../strategy-game-factory';
+import { strategyGameFactory } from 'strategy-game-factory';
 import { moves, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 import { BoardClient } from './board-client';

--- a/src/components/games/four-connected-fields/gameplay.spec.ts
+++ b/src/components/games/four-connected-fields/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { hasAnyMove, isNodePlayable, moves, type Board } from './gameplay';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 // 0=A and 1=B are the hubs, joined to each other and to both 2=C and 3=D;
 // C and D are not joined.

--- a/src/components/games/four-connected-fields/gameplay.ts
+++ b/src/components/games/four-connected-fields/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { range } from 'lodash';
 
 // The board is a 4-field graph holding coin counts: K4 minus one edge. Indices

--- a/src/components/games/four-piles-spread-ahead/bot-strategy.ts
+++ b/src/components/games/four-piles-spread-ahead/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { random, sample, range } from 'lodash';
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import type { Board, Moves } from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>

--- a/src/components/games/four-piles-spread-ahead/four-piles-spread-ahead.tsx
+++ b/src/components/games/four-piles-spread-ahead/four-piles-spread-ahead.tsx
@@ -1,5 +1,5 @@
 import { range } from 'lodash';
-import { strategyGameFactory, type BoardClientProps, GameBoard, useHoverPreview } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard, useHoverPreview } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { useLanguage } from '../../../language';
 import { generateStartBoard, generateTestStartBoard, moves, type Board, type Piece } from './gameplay';

--- a/src/components/games/four-piles-spread-ahead/four-piles-spread-ahead.tsx
+++ b/src/components/games/four-piles-spread-ahead/four-piles-spread-ahead.tsx
@@ -1,7 +1,7 @@
 import { range } from 'lodash';
 import { strategyGameFactory, type BoardClientProps, GameBoard, useHoverPreview } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
-import { useLanguage } from '../../../language';
+import { useLanguage } from 'language';
 import { generateStartBoard, generateTestStartBoard, moves, type Board, type Piece } from './gameplay';
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {

--- a/src/components/games/four-piles-spread-ahead/gameplay.spec.ts
+++ b/src/components/games/four-piles-spread-ahead/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { moves, type Board } from './gameplay';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
 

--- a/src/components/games/four-piles-spread-ahead/gameplay.ts
+++ b/src/components/games/four-piles-spread-ahead/gameplay.ts
@@ -1,5 +1,5 @@
 import { random, cloneDeep } from 'lodash';
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
 export type Board = number[];
 export type Piece = { pileId: number; pieceId: number };

--- a/src/components/games/four-piles-two-grabs/bot-strategy.ts
+++ b/src/components/games/four-piles-two-grabs/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { sample } from 'lodash';
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import {
   applyMove,
   getLegalMoves,

--- a/src/components/games/four-piles-two-grabs/four-piles-two-grabs.tsx
+++ b/src/components/games/four-piles-two-grabs/four-piles-two-grabs.tsx
@@ -1,7 +1,7 @@
 import { range } from 'lodash';
 import {
   strategyGameFactory, useMoveScopedState, type BoardClientProps, GameBoard
-} from '../../strategy-game-factory';
+} from 'strategy-game-factory';
 import { useTranslation } from '../../../language';
 import { generateStartBoard, moves, type Board, type Move } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';

--- a/src/components/games/four-piles-two-grabs/four-piles-two-grabs.tsx
+++ b/src/components/games/four-piles-two-grabs/four-piles-two-grabs.tsx
@@ -2,7 +2,7 @@ import { range } from 'lodash';
 import {
   strategyGameFactory, useMoveScopedState, type BoardClientProps, GameBoard
 } from 'strategy-game-factory';
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 import { generateStartBoard, moves, type Board, type Move } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 

--- a/src/components/games/four-piles-two-grabs/gameplay.spec.ts
+++ b/src/components/games/four-piles-two-grabs/gameplay.spec.ts
@@ -9,7 +9,7 @@ import {
   moves,
   type Board
 } from './gameplay';
-import { makeCtx, moveValidator } from '../../../test-utils';
+import { makeCtx, moveValidator } from 'test-utils';
 
 const isMoveLegal = moveValidator(moves.takeStones);
 

--- a/src/components/games/four-piles-two-grabs/gameplay.ts
+++ b/src/components/games/four-piles-two-grabs/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { random, sortBy } from 'lodash';
 
 // Stones in each of the four piles.

--- a/src/components/games/gameList.ts
+++ b/src/components/games/gameList.ts
@@ -11,7 +11,7 @@ game-component graph into every metadata consumer's bundle. This file is importe
 `app.tsx` pairs them: it loops these keys and looks each up in the `index.ts`
 namespace. `gameList.spec.ts` guards that the two stay 1-to-1 in sync.
 */
-import type { I18nString } from '../../language';
+import type { I18nString } from 'language';
 
 // Canonical list of competition categories in increasing difficulty order.
 export const categories = ['A', 'B', 'C', 'D', 'E', 'E+'] as const;

--- a/src/components/games/hunyadi-and-the-janissaries/bot-strategy.ts
+++ b/src/components/games/hunyadi-and-the-janissaries/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { random } from 'lodash';
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import { SULTAN, type Board, type SoldierColor, type Soldier, type Moves } from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>

--- a/src/components/games/hunyadi-and-the-janissaries/gameplay.spec.ts
+++ b/src/components/games/hunyadi-and-the-janissaries/gameplay.spec.ts
@@ -2,7 +2,7 @@ import {
   moves, generateStartBoard, HUNYADI, SULTAN, type Board, type SoldierColor
 } from './gameplay';
 import { uniq, flatten } from 'lodash';
-import { makeCtx, moveValidator } from '../../../test-utils';
+import { makeCtx, moveValidator } from 'test-utils';
 
 const isKillAllowed = moveValidator(moves.killGroup, makeCtx({ currentPlayer: HUNYADI }));
 const isSoldierAssignmentAllowed = moveValidator(moves.setGroupOfSoldiers, makeCtx({ currentPlayer: SULTAN }));

--- a/src/components/games/hunyadi-and-the-janissaries/hunyadi-and-the-janissaries.tsx
+++ b/src/components/games/hunyadi-and-the-janissaries/hunyadi-and-the-janissaries.tsx
@@ -5,7 +5,7 @@ import { CastleSvg } from './assets/castle-svg';
 import { SoldierSvg } from './assets/soldier-svg';
 import { smartBotStrategy } from './bot-strategy';
 import { generateStartBoard, moves, SULTAN, type Board, type SoldierColor } from './gameplay';
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 
 type Piece = { rowIndex: number, pieceIndex: number }
 

--- a/src/components/games/hunyadi-and-the-janissaries/hunyadi-and-the-janissaries.tsx
+++ b/src/components/games/hunyadi-and-the-janissaries/hunyadi-and-the-janissaries.tsx
@@ -1,6 +1,6 @@
 import {
   strategyGameFactory, type BoardClientProps, type Ctx, GameBoard, useHoverPreview
-} from '../../strategy-game-factory';
+} from 'strategy-game-factory';
 import { CastleSvg } from './assets/castle-svg';
 import { SoldierSvg } from './assets/soldier-svg';
 import { smartBotStrategy } from './bot-strategy';

--- a/src/components/games/latin-square-filling/bot-strategy.spec.ts
+++ b/src/components/games/latin-square-filling/bot-strategy.spec.ts
@@ -14,7 +14,7 @@ import {
   type Board,
   type Move
 } from './gameplay';
-import { moveValidator } from '../../../test-utils';
+import { moveValidator } from 'test-utils';
 
 const isLegalPlacement = moveValidator(moves.placeDigit);
 

--- a/src/components/games/latin-square-filling/bot-strategy.ts
+++ b/src/components/games/latin-square-filling/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { sample } from 'lodash';
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import {
   applyMove,
   isFull,

--- a/src/components/games/latin-square-filling/gameplay.spec.ts
+++ b/src/components/games/latin-square-filling/gameplay.spec.ts
@@ -9,7 +9,7 @@ import {
   playerToMove,
   type Board
 } from './gameplay';
-import { makeCtx, moveValidator } from '../../../test-utils';
+import { makeCtx, moveValidator } from 'test-utils';
 
 const isLegalPlacement = moveValidator(moves.placeDigit);
 

--- a/src/components/games/latin-square-filling/gameplay.ts
+++ b/src/components/games/latin-square-filling/gameplay.ts
@@ -1,4 +1,4 @@
-import type { MoveOutcome } from '../../strategy-game-factory';
+import type { MoveOutcome } from 'strategy-game-factory';
 
 // A 3x3 grid, row-major. 0 = empty, 1 | 2 | 3 = a written digit.
 export type Board = number[]; // always length 9

--- a/src/components/games/latin-square-filling/latin-square-filling.tsx
+++ b/src/components/games/latin-square-filling/latin-square-filling.tsx
@@ -1,7 +1,7 @@
 import {
   strategyGameFactory, useMoveScopedState, type BoardClientProps, type Ctx, GameBoard
 } from 'strategy-game-factory';
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 import { generateStartBoard, moves, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 

--- a/src/components/games/latin-square-filling/latin-square-filling.tsx
+++ b/src/components/games/latin-square-filling/latin-square-filling.tsx
@@ -1,6 +1,6 @@
 import {
   strategyGameFactory, useMoveScopedState, type BoardClientProps, type Ctx, GameBoard
-} from '../../strategy-game-factory';
+} from 'strategy-game-factory';
 import { useTranslation } from '../../../language';
 import { generateStartBoard, moves, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';

--- a/src/components/games/magic-box/magic-box-a/bot-strategy.spec.ts
+++ b/src/components/games/magic-box/magic-box-a/bot-strategy.spec.ts
@@ -1,6 +1,6 @@
 import { smartBotStrategy } from './bot-strategy';
 import { generateEmptyBoard, isGameEnd, placeStone, type Board } from './gameplay';
-import { botNextMoveArgs, makeCtx } from '../../../../test-utils';
+import { botNextMoveArgs, makeCtx } from 'test-utils';
 
 const smartBotPlacement = (board: Board, chosenRoleIndex: number): number =>
   botNextMoveArgs(smartBotStrategy({ board, ctx: makeCtx({ chosenRoleIndex }) }))[0];

--- a/src/components/games/magic-box/magic-box-a/bot-strategy.ts
+++ b/src/components/games/magic-box/magic-box-a/bot-strategy.ts
@@ -1,6 +1,6 @@
 import { range, sample } from 'lodash';
 import { isGameEnd, placeStone, type Board, type Moves } from './gameplay';
-import type { BotStrategy } from '../../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 
 type Bot = BotStrategy<Board, Moves>
 

--- a/src/components/games/magic-box/magic-box-a/gameplay.spec.ts
+++ b/src/components/games/magic-box/magic-box-a/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { generateEmptyBoard, hasFullLine, isPlacementAllowed, moves } from './gameplay';
-import { makeCtx } from '../../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 describe('hasFullLine', () => {
   it('should be false for an empty board', () => {

--- a/src/components/games/magic-box/magic-box-a/gameplay.ts
+++ b/src/components/games/magic-box/magic-box-a/gameplay.ts
@@ -1,4 +1,4 @@
-import type { MoveOutcome, Ctx } from '../../../strategy-game-factory';
+import type { MoveOutcome, Ctx } from 'strategy-game-factory';
 export type Board = boolean[]
 
 /*

--- a/src/components/games/magic-box/magic-box-a/magic-box-a.tsx
+++ b/src/components/games/magic-box/magic-box-a/magic-box-a.tsx
@@ -1,5 +1,5 @@
 import { range } from 'lodash';
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { generateEmptyBoard, moves, type Board } from './gameplay';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 

--- a/src/components/games/magic-box/magic-box-b/board-client.tsx
+++ b/src/components/games/magic-box/magic-box-b/board-client.tsx
@@ -1,6 +1,6 @@
 import { range } from 'lodash';
 import { useTranslation, type I18nString } from '../../../../language';
-import { GameBoard, type BoardClientProps } from '../../../strategy-game-factory';
+import { GameBoard, type BoardClientProps } from 'strategy-game-factory';
 import { LINES, type Board } from './gameplay';
 
 const LINE_LABELS: I18nString[] = [

--- a/src/components/games/magic-box/magic-box-b/board-client.tsx
+++ b/src/components/games/magic-box/magic-box-b/board-client.tsx
@@ -1,5 +1,5 @@
 import { range } from 'lodash';
-import { useTranslation, type I18nString } from '../../../../language';
+import { useTranslation, type I18nString } from 'language';
 import { GameBoard, type BoardClientProps } from 'strategy-game-factory';
 import { LINES, type Board } from './gameplay';
 

--- a/src/components/games/magic-box/magic-box-b/bot-strategy.ts
+++ b/src/components/games/magic-box/magic-box-b/bot-strategy.ts
@@ -1,6 +1,6 @@
 import { range, sample } from 'lodash';
 import { LINES, emptyCellsInLine, isLineFull, placeStoneAt, type Board, type Moves } from './gameplay';
-import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
+import type { BotMove, BotStrategy } from 'strategy-game-factory';
 
 type Bot = BotStrategy<Board, Moves>
 

--- a/src/components/games/magic-box/magic-box-b/gameplay.spec.ts
+++ b/src/components/games/magic-box/magic-box-b/gameplay.spec.ts
@@ -7,7 +7,7 @@ import {
   placeStoneAt,
   type Board
 } from './gameplay';
-import { makeCtx, moveValidator } from '../../../../test-utils';
+import { makeCtx, moveValidator } from 'test-utils';
 
 const isDesignationAllowed = moveValidator(moves.designateLine);
 

--- a/src/components/games/magic-box/magic-box-b/gameplay.ts
+++ b/src/components/games/magic-box/magic-box-b/gameplay.ts
@@ -1,4 +1,4 @@
-import type { MoveOutcome, Ctx } from '../../../strategy-game-factory';
+import type { MoveOutcome, Ctx } from 'strategy-game-factory';
 
 export type Board = { stones: boolean[]; pendingLine: number | null }
 

--- a/src/components/games/magic-box/magic-box-b/magic-box-b.tsx
+++ b/src/components/games/magic-box/magic-box-b/magic-box-b.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory } from '../../../strategy-game-factory';
+import { strategyGameFactory } from 'strategy-game-factory';
 import { BoardClient } from './board-client';
 import { generateEmptyBoard, moves } from './gameplay';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';

--- a/src/components/games/matches-on-edges/board-client.tsx
+++ b/src/components/games/matches-on-edges/board-client.tsx
@@ -2,7 +2,7 @@ import { range } from 'lodash';
 import { useTranslation } from '../../../language';
 import {
   GameBoard, type BoardClientProps, useHoverPreview, useMoveScopedState
-} from '../../strategy-game-factory';
+} from 'strategy-game-factory';
 import { type Board, boundaryEdgesToPlace, currentWindowSize } from './gameplay';
 
 const Matchstick = ({ ghost = false }: { ghost?: boolean }) => (

--- a/src/components/games/matches-on-edges/board-client.tsx
+++ b/src/components/games/matches-on-edges/board-client.tsx
@@ -1,5 +1,5 @@
 import { range } from 'lodash';
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 import {
   GameBoard, type BoardClientProps, useHoverPreview, useMoveScopedState
 } from 'strategy-game-factory';

--- a/src/components/games/matches-on-edges/bot-strategy.spec.ts
+++ b/src/components/games/matches-on-edges/bot-strategy.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { sample } from 'lodash';
-import { botNextMoveArgs, makeCtx } from '../../../test-utils';
+import { botNextMoveArgs, makeCtx } from 'test-utils';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import {
   type Board,

--- a/src/components/games/matches-on-edges/bot-strategy.ts
+++ b/src/components/games/matches-on-edges/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { sample } from 'lodash';
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import {
   applyMove,
   blockMultiset,

--- a/src/components/games/matches-on-edges/gameplay.spec.ts
+++ b/src/components/games/matches-on-edges/gameplay.spec.ts
@@ -11,7 +11,7 @@ import {
   secondPlayerWins,
   type Board
 } from './gameplay';
-import { makeCtx, moveValidator } from '../../../test-utils';
+import { makeCtx, moveValidator } from 'test-utils';
 
 const isWindowAllowed = moveValidator(moves.placeWindow);
 

--- a/src/components/games/matches-on-edges/gameplay.ts
+++ b/src/components/games/matches-on-edges/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { random, sample } from 'lodash';
 
 // Board: a 1 x n strip of cells (indices 0..n-1). Between cell i and cell i+1

--- a/src/components/games/matches-on-edges/matches-on-edges.tsx
+++ b/src/components/games/matches-on-edges/matches-on-edges.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory } from '../../strategy-game-factory';
+import { strategyGameFactory } from 'strategy-game-factory';
 import { BoardClient } from './board-client';
 import { currentWindowSize, generateStartBoard, moves } from './gameplay';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';

--- a/src/components/games/matchstick-piles/bot-strategy.spec.ts
+++ b/src/components/games/matchstick-piles/bot-strategy.spec.ts
@@ -1,4 +1,4 @@
-import { runMatch, type MatchResult } from '../../strategy-game-factory';
+import { runMatch, type MatchResult } from 'strategy-game-factory';
 import { type Board, moves, generateStartBoard } from './gameplay';
 import { grundy, xorSum, smartBotStrategy, randomBotStrategy } from './bot-strategy';
 

--- a/src/components/games/matchstick-piles/bot-strategy.ts
+++ b/src/components/games/matchstick-piles/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { sample } from 'lodash';
-import type { BotMove, BotStrategy } from '../../strategy-game-factory';
+import type { BotMove, BotStrategy } from 'strategy-game-factory';
 import { type Board, type Moves } from './gameplay';
 
 // --- Optimal strategy -------------------------------------------------------

--- a/src/components/games/matchstick-piles/gameplay.spec.ts
+++ b/src/components/games/matchstick-piles/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { isRemovalAllowed, isSplitAllowed, moves, type Board } from './gameplay';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
 

--- a/src/components/games/matchstick-piles/gameplay.ts
+++ b/src/components/games/matchstick-piles/gameplay.ts
@@ -1,5 +1,5 @@
 import { range, random } from 'lodash';
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
 // A board is the list of pile sizes; every pile has at least one match.
 export type Board = number[];

--- a/src/components/games/matchstick-piles/matchstick-piles.tsx
+++ b/src/components/games/matchstick-piles/matchstick-piles.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from 'react';
 import { range, random } from 'lodash';
-import { strategyGameFactory, type BoardClientProps, GameBoard, useHoverPreview } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard, useHoverPreview } from 'strategy-game-factory';
 import { generateStartBoard, moves, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 

--- a/src/components/games/modified-mill/board-client.tsx
+++ b/src/components/games/modified-mill/board-client.tsx
@@ -1,5 +1,5 @@
 import { range } from 'lodash';
-import { GameBoard, type BoardClientProps } from '../../strategy-game-factory';
+import { GameBoard, type BoardClientProps } from 'strategy-game-factory';
 import { COORDS, LINES } from './board-data';
 import { type Board } from './gameplay';
 

--- a/src/components/games/modified-mill/bot-strategy.ts
+++ b/src/components/games/modified-mill/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { sample, maxBy } from 'lodash';
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import { SYMMETRIES } from './board-data';
 import { CELL_COUNT, boardMasks, completesLine, emptyCells, linesThrough, type Board, type Moves } from './gameplay';
 

--- a/src/components/games/modified-mill/gameplay.spec.ts
+++ b/src/components/games/modified-mill/gameplay.spec.ts
@@ -11,7 +11,7 @@ import {
   playerHasLine
 } from './gameplay';
 import { LINES } from './board-data';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 describe('modified mill helpers', () => {
   it('has a 24-cell board and 16 winning lines of three cells each', () => {

--- a/src/components/games/modified-mill/gameplay.ts
+++ b/src/components/games/modified-mill/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { range } from 'lodash';
 import { LINES, COORDS } from './board-data';
 

--- a/src/components/games/modified-mill/modified-mill.tsx
+++ b/src/components/games/modified-mill/modified-mill.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory } from '../../strategy-game-factory';
+import { strategyGameFactory } from 'strategy-game-factory';
 import { generateEmptyBoard, moves, type Board } from './gameplay';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { BoardClient } from './board-client';

--- a/src/components/games/number-covering/bot-strategy.spec.ts
+++ b/src/components/games/number-covering/bot-strategy.spec.ts
@@ -1,6 +1,6 @@
 import { smartBotStrategy } from './bot-strategy';
 import { COVERED, type Board } from './gameplay';
-import { botNextMoveArgs, makeCtx } from '../../../test-utils';
+import { botNextMoveArgs, makeCtx } from 'test-utils';
 
 const smartBotCover = (board: Board, currentPlayer: number): number =>
   botNextMoveArgs(smartBotStrategy({ board, ctx: makeCtx({ currentPlayer }) }))[0];

--- a/src/components/games/number-covering/bot-strategy.ts
+++ b/src/components/games/number-covering/bot-strategy.ts
@@ -1,4 +1,4 @@
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import { sample } from 'lodash';
 import { getRemaining, type Board, type Moves } from './gameplay';
 

--- a/src/components/games/number-covering/gameplay.spec.ts
+++ b/src/components/games/number-covering/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { moves, COVERED } from './gameplay';
-import { makeCtx, moveValidator } from '../../../test-utils';
+import { makeCtx, moveValidator } from 'test-utils';
 
 const isCoveringAllowed = moveValidator(moves.coverNumber);
 

--- a/src/components/games/number-covering/gameplay.ts
+++ b/src/components/games/number-covering/gameplay.ts
@@ -1,4 +1,4 @@
-import type { MoveOutcome } from '../../strategy-game-factory';
+import type { MoveOutcome } from 'strategy-game-factory';
 import { range, sum, sample, cloneDeep } from 'lodash';
 
 export type Board = number[]

--- a/src/components/games/number-covering/number-covering.tsx
+++ b/src/components/games/number-covering/number-covering.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { range, sum } from 'lodash';
 import { useTranslation } from '../../../language';
 import { generateTestStartBoard, getRemaining, moves, type Board, COVERED } from './gameplay';

--- a/src/components/games/number-covering/number-covering.tsx
+++ b/src/components/games/number-covering/number-covering.tsx
@@ -1,6 +1,6 @@
 import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { range, sum } from 'lodash';
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 import { generateTestStartBoard, getRemaining, moves, type Board, COVERED } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 

--- a/src/components/games/number-pyramid/board-client.tsx
+++ b/src/components/games/number-pyramid/board-client.tsx
@@ -1,7 +1,7 @@
 import { isEqual } from 'lodash';
 import { useTranslation } from '../../../language';
 import { hasActivePair, type Board } from './gameplay';
-import { GameBoard, type BoardClientProps } from '../../strategy-game-factory';
+import { GameBoard, type BoardClientProps } from 'strategy-game-factory';
 
 export type TurnState = { levelIdx: number; slotIdx: number } | null;
 

--- a/src/components/games/number-pyramid/board-client.tsx
+++ b/src/components/games/number-pyramid/board-client.tsx
@@ -1,5 +1,5 @@
 import { isEqual } from 'lodash';
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 import { hasActivePair, type Board } from './gameplay';
 import { GameBoard, type BoardClientProps } from 'strategy-game-factory';
 

--- a/src/components/games/number-pyramid/bot-strategy.spec.ts
+++ b/src/components/games/number-pyramid/bot-strategy.spec.ts
@@ -1,6 +1,6 @@
 import { isP2WinningPosition, randomBotStrategy, smartBotStrategy } from './bot-strategy';
 import type { Board, Slot } from './gameplay';
-import { botNextMoveArgs, makeCtx } from '../../../test-utils';
+import { botNextMoveArgs, makeCtx } from 'test-utils';
 
 const active = (value: number): Slot => ({ value, state: 'active' });
 const consumed = (value: number): Slot => ({ value, state: 'consumed' });

--- a/src/components/games/number-pyramid/bot-strategy.ts
+++ b/src/components/games/number-pyramid/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { orderBy, range, sample, sampleSize } from 'lodash';
-import type { BotMove, BotStrategy } from '../../strategy-game-factory';
+import type { BotMove, BotStrategy } from 'strategy-game-factory';
 import {
   activeSlotIndices, applyMoveToBoard, hasActivePair, type Board, type Level, type Moves
 } from './gameplay';

--- a/src/components/games/number-pyramid/gameplay.spec.ts
+++ b/src/components/games/number-pyramid/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { applyMoveToBoard, moves, type Board, type Slot } from './gameplay';
-import { makeCtx, moveValidator } from '../../../test-utils';
+import { makeCtx, moveValidator } from 'test-utils';
 
 const isCombineAllowed = moveValidator(moves.combineTwo);
 

--- a/src/components/games/number-pyramid/gameplay.ts
+++ b/src/components/games/number-pyramid/gameplay.ts
@@ -1,5 +1,5 @@
 import { random, sample, shuffle, sum } from 'lodash';
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
 export type Slot = { value: number; state: 'active' | 'consumed' };
 export type Level = (Slot | null)[];

--- a/src/components/games/number-pyramid/number-pyramid.tsx
+++ b/src/components/games/number-pyramid/number-pyramid.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory, type Ctx } from '../../strategy-game-factory';
+import { strategyGameFactory, type Ctx } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { generateStartBoard, moves } from './gameplay';
 import { BoardClient, type TurnState } from './board-client';

--- a/src/components/games/pairs-of-numbers/bot-strategy.ts
+++ b/src/components/games/pairs-of-numbers/bot-strategy.ts
@@ -1,4 +1,4 @@
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import { random } from 'lodash';
 import { type Board, type Moves } from './gameplay';
 

--- a/src/components/games/pairs-of-numbers/gameplay.spec.ts
+++ b/src/components/games/pairs-of-numbers/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { moves } from './gameplay';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 // Whoever first writes a pair that is not all-positive wins, which happens
 // exactly when `subtract` drives a - b to zero or below.

--- a/src/components/games/pairs-of-numbers/gameplay.ts
+++ b/src/components/games/pairs-of-numbers/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { random } from 'lodash';
 
 export type Board = number[]

--- a/src/components/games/pairs-of-numbers/pairs-of-numbers.tsx
+++ b/src/components/games/pairs-of-numbers/pairs-of-numbers.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { useTranslation } from '../../../language';
 import { generateStartBoard, generateTestStartBoard, moves, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';

--- a/src/components/games/pairs-of-numbers/pairs-of-numbers.tsx
+++ b/src/components/games/pairs-of-numbers/pairs-of-numbers.tsx
@@ -1,5 +1,5 @@
 import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 import { generateStartBoard, generateTestStartBoard, moves, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 

--- a/src/components/games/pile-splitting-games/pile-splitter-3/bot-strategy.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter-3/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { random, sample } from 'lodash';
-import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
+import type { BotMove, BotStrategy } from 'strategy-game-factory';
 import type { Board, Moves } from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>

--- a/src/components/games/pile-splitting-games/pile-splitter-3/gameplay.spec.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter-3/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { moves } from './gameplay';
-import { makeCtx } from '../../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 // A turn is two moves: empty one pile, then split another into it. The game
 // ends once every pile is down to a single piece, since a pile of one cannot

--- a/src/components/games/pile-splitting-games/pile-splitter-3/gameplay.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter-3/gameplay.ts
@@ -1,5 +1,5 @@
 import { isEqual, random, cloneDeep } from 'lodash';
-import type { Ctx, MoveOutcome } from '../../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { emptiedPileId, isRemovalAllowed, isSplitAllowed, withPileRemoved } from '../gameplay';
 
 export type Board = number[];

--- a/src/components/games/pile-splitting-games/pile-splitter-3/pile-splitter-3.tsx
+++ b/src/components/games/pile-splitting-games/pile-splitter-3/pile-splitter-3.tsx
@@ -6,7 +6,7 @@ import {
   GameBoard,
   useHoverPreview,
   useDeferredMove
-} from '../../../strategy-game-factory';
+} from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { isSplitAllowed, withPileRemoved } from '../gameplay';
 import { generateStartBoard, moves, type Board, type Piece } from './gameplay';

--- a/src/components/games/pile-splitting-games/pile-splitter-4/bot-strategy.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter-4/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { random, range, sample } from 'lodash';
-import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
+import type { BotMove, BotStrategy } from 'strategy-game-factory';
 import type { Board, Moves } from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>

--- a/src/components/games/pile-splitting-games/pile-splitter-4/gameplay.spec.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter-4/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { moves } from './gameplay';
-import { makeCtx } from '../../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 // A turn is two moves: empty one pile, then split another into it. The game
 // ends once every pile is down to a single piece, since a pile of one cannot

--- a/src/components/games/pile-splitting-games/pile-splitter-4/gameplay.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter-4/gameplay.ts
@@ -1,5 +1,5 @@
 import { emptiedPileId, isRemovalAllowed, isSplitAllowed, withPileRemoved } from '../gameplay';
-import type { Ctx, MoveOutcome } from '../../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { range, random, isEqual, cloneDeep } from 'lodash';
 
 export const generateStartBoard = (): Board => {

--- a/src/components/games/pile-splitting-games/pile-splitter-4/pile-splitter-4.tsx
+++ b/src/components/games/pile-splitting-games/pile-splitter-4/pile-splitter-4.tsx
@@ -6,7 +6,7 @@ import {
   GameBoard,
   useHoverPreview,
   useDeferredMove
-} from '../../../strategy-game-factory';
+} from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { isSplitAllowed, withPileRemoved } from '../gameplay';
 import { generateStartBoard, generateTestStartBoard, moves, type Board, type Piece } from './gameplay';

--- a/src/components/games/pile-splitting-games/pile-splitter/bot-strategy.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { random, sample } from 'lodash';
-import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
+import type { BotMove, BotStrategy } from 'strategy-game-factory';
 import type { Board, Moves } from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>

--- a/src/components/games/pile-splitting-games/pile-splitter/gameplay.spec.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { moves } from './gameplay';
-import { makeCtx } from '../../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 // A turn is two moves: empty one pile, then split another into it. The game
 // ends once every pile is down to a single piece, since a pile of one cannot

--- a/src/components/games/pile-splitting-games/pile-splitter/gameplay.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter/gameplay.ts
@@ -1,5 +1,5 @@
 import { isEqual } from 'lodash';
-import type { Ctx, MoveOutcome } from '../../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { isRemovalAllowed, isSplitAllowed, withPileRemoved } from '../gameplay';
 
 export type Board = number[];

--- a/src/components/games/pile-splitting-games/pile-splitter/pile-splitter.tsx
+++ b/src/components/games/pile-splitting-games/pile-splitter/pile-splitter.tsx
@@ -5,7 +5,7 @@ import {
   GameBoard,
   useHoverPreview,
   useDeferredMove
-} from '../../../strategy-game-factory';
+} from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { isSplitAllowed, withPileRemoved } from '../gameplay';
 import { moves, type Board, type Piece } from './gameplay';

--- a/src/components/games/pile-union/bot-strategy.spec.ts
+++ b/src/components/games/pile-union/bot-strategy.spec.ts
@@ -1,5 +1,5 @@
 import { sortBy, sum } from 'lodash';
-import { runMatch, type MatchResult } from '../../strategy-game-factory';
+import { runMatch, type MatchResult } from 'strategy-game-factory';
 import { type Board, moves } from './gameplay';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 

--- a/src/components/games/pile-union/bot-strategy.ts
+++ b/src/components/games/pile-union/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { sample, sortBy } from 'lodash';
-import type { BotMove, BotStrategy } from '../../strategy-game-factory';
+import type { BotMove, BotStrategy } from 'strategy-game-factory';
 import { createWinLossSolver } from '../shared/win-loss-solver';
 import type { Board, Moves } from './gameplay';
 

--- a/src/components/games/pile-union/gameplay.spec.ts
+++ b/src/components/games/pile-union/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { isPile, moves } from './gameplay';
-import { makeCtx, moveValidator } from '../../../test-utils';
+import { makeCtx, moveValidator } from 'test-utils';
 
 const isMergeAllowed = moveValidator(moves.mergePiles);
 

--- a/src/components/games/pile-union/gameplay.ts
+++ b/src/components/games/pile-union/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
 export type Board = number[]
 export type MoveType = 'remove' | 'merge'

--- a/src/components/games/pile-union/pile-union.tsx
+++ b/src/components/games/pile-union/pile-union.tsx
@@ -1,7 +1,7 @@
 import { useState, type ComponentProps } from 'react';
 import { range, random } from 'lodash';
 import { strategyGameFactory, type BoardClientProps, GameBoard, useHoverPreview } from 'strategy-game-factory';
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { moves, type Board, type MoveType, type TurnState } from './gameplay';
 

--- a/src/components/games/pile-union/pile-union.tsx
+++ b/src/components/games/pile-union/pile-union.tsx
@@ -1,6 +1,6 @@
 import { useState, type ComponentProps } from 'react';
 import { range, random } from 'lodash';
-import { strategyGameFactory, type BoardClientProps, GameBoard, useHoverPreview } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard, useHoverPreview } from 'strategy-game-factory';
 import { useTranslation } from '../../../language';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { moves, type Board, type MoveType, type TurnState } from './gameplay';

--- a/src/components/games/plays-to-an-end.spec.ts
+++ b/src/components/games/plays-to-an-end.spec.ts
@@ -1,5 +1,5 @@
 import * as games from './index';
-import { runMatch, type StrategyGame } from '../strategy-game-factory';
+import { runMatch, type StrategyGame } from 'strategy-game-factory';
 
 // Plays every registered game headlessly, through the real moves, the real
 // validators and the real reducer. `runMatch` throws on everything this is

--- a/src/components/games/policeman-thief/policeman-thief-ab/board-client.tsx
+++ b/src/components/games/policeman-thief/policeman-thief-ab/board-client.tsx
@@ -1,6 +1,6 @@
 import { range } from 'lodash';
 import { POLICE, THIEF, type Board } from './gameplay';
-import { GameBoard, type BoardClientProps } from '../../../strategy-game-factory';
+import { GameBoard, type BoardClientProps } from 'strategy-game-factory';
 
 const cubeCoords = [
   { cx: '30%', cy: '30%' },

--- a/src/components/games/policeman-thief/policeman-thief-ab/bot-strategy.ts
+++ b/src/components/games/policeman-thief/policeman-thief-ab/bot-strategy.ts
@@ -1,6 +1,6 @@
 import { random } from 'lodash';
 import { POLICE, neighbours, type Board, type Moves } from './gameplay';
-import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
+import type { BotMove, BotStrategy } from 'strategy-game-factory';
 
 type Bot = BotStrategy<Board, Moves>
 

--- a/src/components/games/policeman-thief/policeman-thief-ab/gameplay.spec.ts
+++ b/src/components/games/policeman-thief/policeman-thief-ab/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { POLICE, THIEF, VERTEX_COUNT, isNeighbour, isVertex, moves, neighbours, type Board } from './gameplay';
-import { makeCtx } from '../../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 describe('graph predicates', () => {
   it('accepts only the eight intersections', () => {

--- a/src/components/games/policeman-thief/policeman-thief-ab/gameplay.ts
+++ b/src/components/games/policeman-thief/policeman-thief-ab/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { range, random, sample, difference, cloneDeep } from 'lodash';
 export const neighbours = {
   0: [1, 2, 4],

--- a/src/components/games/policeman-thief/policeman-thief-ab/policeman-thief-ab.tsx
+++ b/src/components/games/policeman-thief/policeman-thief-ab/policeman-thief-ab.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory, type Ctx } from '../../../strategy-game-factory';
+import { strategyGameFactory, type Ctx } from 'strategy-game-factory';
 import { POLICE, generateStartBoardA, generateStartBoardB, moves, type Board } from './gameplay';
 import { smartBotStrategy } from './bot-strategy';
 import { BoardClient } from './board-client';

--- a/src/components/games/policeman-thief/policeman-thief-c/board-client.tsx
+++ b/src/components/games/policeman-thief/policeman-thief-c/board-client.tsx
@@ -1,7 +1,7 @@
 import { range } from 'lodash';
 import { POLICE, VERTEX_COUNT, coords, edges, type Board } from './gameplay';
 import { GameBoard, type BoardClientProps } from 'strategy-game-factory';
-import { useTranslation } from '../../../../language';
+import { useTranslation } from 'language';
 
 const COP_COLORS = ['var(--color-blue-800)', 'var(--color-green-600)', 'var(--color-amber-500)'];
 const THIEF_COLOR = 'var(--color-red-500)';

--- a/src/components/games/policeman-thief/policeman-thief-c/board-client.tsx
+++ b/src/components/games/policeman-thief/policeman-thief-c/board-client.tsx
@@ -1,6 +1,6 @@
 import { range } from 'lodash';
 import { POLICE, VERTEX_COUNT, coords, edges, type Board } from './gameplay';
-import { GameBoard, type BoardClientProps } from '../../../strategy-game-factory';
+import { GameBoard, type BoardClientProps } from 'strategy-game-factory';
 import { useTranslation } from '../../../../language';
 
 const COP_COLORS = ['var(--color-blue-800)', 'var(--color-green-600)', 'var(--color-amber-500)'];

--- a/src/components/games/policeman-thief/policeman-thief-c/bot-strategy.ts
+++ b/src/components/games/policeman-thief/policeman-thief-c/bot-strategy.ts
@@ -1,6 +1,6 @@
 import { sample, random, range } from 'lodash';
 import { THIEF, VERTEX_COUNT, dist, minDistToSet, neighbours, type Board, type Moves } from './gameplay';
-import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
+import type { BotMove, BotStrategy } from 'strategy-game-factory';
 
 type Bot = BotStrategy<Board, Moves>
 

--- a/src/components/games/policeman-thief/policeman-thief-c/gameplay.spec.ts
+++ b/src/components/games/policeman-thief/policeman-thief-c/gameplay.spec.ts
@@ -11,7 +11,7 @@ import {
   type Board
 } from './gameplay';
 import { range } from 'lodash';
-import { makeCtx } from '../../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 describe('modified Petersen graph', () => {
   it('has 15 vertices and 20 edges', () => {

--- a/src/components/games/policeman-thief/policeman-thief-c/gameplay.ts
+++ b/src/components/games/policeman-thief/policeman-thief-c/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { cloneDeep, random } from 'lodash';
 // Modified Petersen graph: the standard Petersen graph (outer 5-cycle, inner
 // pentagram, 5 spokes) with each of the 5 outer edges subdivided by an extra

--- a/src/components/games/policeman-thief/policeman-thief-c/policeman-thief-c.tsx
+++ b/src/components/games/policeman-thief/policeman-thief-c/policeman-thief-c.tsx
@@ -1,5 +1,5 @@
 
-import { strategyGameFactory, type Ctx } from '../../../strategy-game-factory';
+import { strategyGameFactory, type Ctx } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { POLICE, generateStartBoard, moves, type Board } from './gameplay';
 import { BoardClient } from './board-client';

--- a/src/components/games/polynomial-building/board-client.tsx
+++ b/src/components/games/polynomial-building/board-client.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { useTranslation } from '../../../language';
 import { type Board, type Coef, COEFS, integerRoots } from './gameplay';
 

--- a/src/components/games/polynomial-building/board-client.tsx
+++ b/src/components/games/polynomial-building/board-client.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { type BoardClientProps, GameBoard } from 'strategy-game-factory';
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 import { type Board, type Coef, COEFS, integerRoots } from './gameplay';
 
 // Any integer is allowed; the digit cap only keeps arithmetic exact (< 2^53).

--- a/src/components/games/polynomial-building/bot-strategy.spec.ts
+++ b/src/components/games/polynomial-building/bot-strategy.spec.ts
@@ -1,5 +1,5 @@
 import { type BotStrategy } from '../../strategy-game-factory';
-import { botNextMoveArgs, makeCtx } from '../../../test-utils';
+import { botNextMoveArgs, makeCtx } from 'test-utils';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { type Board, type Coef, hasThreeIntegerRoots, canComplete } from './gameplay';
 

--- a/src/components/games/polynomial-building/bot-strategy.spec.ts
+++ b/src/components/games/polynomial-building/bot-strategy.spec.ts
@@ -1,4 +1,4 @@
-import { type BotStrategy } from '../../strategy-game-factory';
+import { type BotStrategy } from 'strategy-game-factory';
 import { botNextMoveArgs, makeCtx } from 'test-utils';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { type Board, type Coef, hasThreeIntegerRoots, canComplete } from './gameplay';

--- a/src/components/games/polynomial-building/bot-strategy.ts
+++ b/src/components/games/polynomial-building/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { random, sample } from 'lodash';
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import {
   COEFS,
   canComplete,

--- a/src/components/games/polynomial-building/gameplay.spec.ts
+++ b/src/components/games/polynomial-building/gameplay.spec.ts
@@ -7,7 +7,7 @@ import {
   type Board,
   type Coef
 } from './gameplay';
-import { makeCtx, moveValidator } from '../../../test-utils';
+import { makeCtx, moveValidator } from 'test-utils';
 
 const isCoefficientChoiceAllowed = moveValidator(moves.setCoefficient);
 

--- a/src/components/games/polynomial-building/gameplay.ts
+++ b/src/components/games/polynomial-building/gameplay.ts
@@ -1,4 +1,4 @@
-import type { MoveOutcome } from '../../strategy-game-factory';
+import type { MoveOutcome } from 'strategy-game-factory';
 export type Coef = 'a' | 'b' | 'c'
 export type Board = { a: number | null; b: number | null; c: number | null }
 

--- a/src/components/games/polynomial-building/polynomial-building.tsx
+++ b/src/components/games/polynomial-building/polynomial-building.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory } from '../../strategy-game-factory';
+import { strategyGameFactory } from 'strategy-game-factory';
 import { COEFS, moves, type Board } from './gameplay';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { BoardClient } from './board-client';

--- a/src/components/games/recolouring-discs/board-client.tsx
+++ b/src/components/games/recolouring-discs/board-client.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { range } from 'lodash';
 import { useTranslation } from '../../../language';
-import { GameBoard, type BoardClientProps, useMoveScopedState } from '../../strategy-game-factory';
+import { GameBoard, type BoardClientProps, useMoveScopedState } from 'strategy-game-factory';
 import { type Board, type Cell, colorOf } from './gameplay';
 
 // Translucent version of each disc colour, used for the recolour pulse ring.

--- a/src/components/games/recolouring-discs/board-client.tsx
+++ b/src/components/games/recolouring-discs/board-client.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { range } from 'lodash';
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 import { GameBoard, type BoardClientProps, useMoveScopedState } from 'strategy-game-factory';
 import { type Board, type Cell, colorOf } from './gameplay';
 

--- a/src/components/games/recolouring-discs/bot-strategy.spec.ts
+++ b/src/components/games/recolouring-discs/bot-strategy.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { type BotStrategy } from '../../strategy-game-factory';
+import { type BotStrategy } from 'strategy-game-factory';
 import { botNextMove, makeCtx } from 'test-utils';
 import {
   type Board,

--- a/src/components/games/recolouring-discs/bot-strategy.spec.ts
+++ b/src/components/games/recolouring-discs/bot-strategy.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { type BotStrategy } from '../../strategy-game-factory';
-import { botNextMove, makeCtx } from '../../../test-utils';
+import { botNextMove, makeCtx } from 'test-utils';
 import {
   type Board,
   type Cell,

--- a/src/components/games/recolouring-discs/bot-strategy.ts
+++ b/src/components/games/recolouring-discs/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { sample } from 'lodash';
-import type { BotMove, BotStrategy } from '../../strategy-game-factory';
+import type { BotMove, BotStrategy } from 'strategy-game-factory';
 import {
   applyMove,
   colorOf,

--- a/src/components/games/recolouring-discs/gameplay.spec.ts
+++ b/src/components/games/recolouring-discs/gameplay.spec.ts
@@ -14,7 +14,7 @@ import {
   type Board,
   type Cell
 } from './gameplay';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 const isDiscMoveAllowed = (cells: Cell[], player: number, from: number, to: number) =>
   moves.moveDisc.validate({ cells }, { ctx: makeCtx({ currentPlayer: player }) }, from, to);

--- a/src/components/games/recolouring-discs/gameplay.ts
+++ b/src/components/games/recolouring-discs/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 // Recolouring discs — core game logic.
 //
 // A row of `n` fields. Field 0 starts with a red disc, field n-1 with a blue

--- a/src/components/games/recolouring-discs/recolouring-discs.tsx
+++ b/src/components/games/recolouring-discs/recolouring-discs.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory } from '../../strategy-game-factory';
+import { strategyGameFactory } from 'strategy-game-factory';
 import { BoardClient } from './board-client';
 import { PLY_CAP, RED, countColor, generateStartBoard, moves, targetCounts } from './gameplay';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';

--- a/src/components/games/remove-divisor-multiple/bot-strategy.ts
+++ b/src/components/games/remove-divisor-multiple/bot-strategy.ts
@@ -1,6 +1,6 @@
 import { isAllowed, type Board, type Moves } from './gameplay';
 import { range, sample } from 'lodash';
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 // generated with scripts/pre-generate-ai-moves/remove-divisor-multiple.py
 /* eslint-disable quotes -- pasted verbatim from the generator's JSON output */
 const strategyDict = {

--- a/src/components/games/remove-divisor-multiple/gameplay.spec.ts
+++ b/src/components/games/remove-divisor-multiple/gameplay.spec.ts
@@ -1,6 +1,6 @@
 import { range } from 'lodash';
 import { isAllowed, moves } from './gameplay';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
 

--- a/src/components/games/remove-divisor-multiple/gameplay.ts
+++ b/src/components/games/remove-divisor-multiple/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { range, cloneDeep, sample, random } from 'lodash';
 
 export type Board = { numbersOnTable: boolean[], previousMove: number | null }

--- a/src/components/games/remove-divisor-multiple/remove-divisor-multiple.tsx
+++ b/src/components/games/remove-divisor-multiple/remove-divisor-multiple.tsx
@@ -1,6 +1,6 @@
 import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { range } from 'lodash';
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 import { generateStartBoard, generateTestStartBoard, isAllowed, moves, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 

--- a/src/components/games/remove-divisor-multiple/remove-divisor-multiple.tsx
+++ b/src/components/games/remove-divisor-multiple/remove-divisor-multiple.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { range } from 'lodash';
 import { useTranslation } from '../../../language';
 import { generateStartBoard, generateTestStartBoard, isAllowed, moves, type Board } from './gameplay';

--- a/src/components/games/remove-row-or-column/board-client.tsx
+++ b/src/components/games/remove-row-or-column/board-client.tsx
@@ -2,7 +2,7 @@ import { range } from 'lodash';
 import {
   type BoardClientProps, type Ctx, GameBoard, useHoverPreview
 } from 'strategy-game-factory';
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 import { type Board, type Orientation, getRectangleAt } from './gameplay';
 
 type Selected = { r: number; c: number } | null

--- a/src/components/games/remove-row-or-column/board-client.tsx
+++ b/src/components/games/remove-row-or-column/board-client.tsx
@@ -1,7 +1,7 @@
 import { range } from 'lodash';
 import {
   type BoardClientProps, type Ctx, GameBoard, useHoverPreview
-} from '../../strategy-game-factory';
+} from 'strategy-game-factory';
 import { useTranslation } from '../../../language';
 import { type Board, type Orientation, getRectangleAt } from './gameplay';
 

--- a/src/components/games/remove-row-or-column/bot-strategy.spec.ts
+++ b/src/components/games/remove-row-or-column/bot-strategy.spec.ts
@@ -1,4 +1,4 @@
-import { runMatch, type MatchResult } from '../../strategy-game-factory';
+import { runMatch, type MatchResult } from 'strategy-game-factory';
 import {
   type Board, type Grid, applyMove, isEmpty, getAllMoves, moves
 } from './gameplay';

--- a/src/components/games/remove-row-or-column/bot-strategy.ts
+++ b/src/components/games/remove-row-or-column/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { sample, random } from 'lodash';
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import {
   type Board, type Grid, type Moves, getRectangles, getAllMoves, applyMove, isEmpty
 } from './gameplay';

--- a/src/components/games/remove-row-or-column/gameplay.spec.ts
+++ b/src/components/games/remove-row-or-column/gameplay.spec.ts
@@ -2,7 +2,7 @@ import {
   type Board, type Grid, type Move,
   getRectangleAt, getRectangles, applyMove, isEmpty, getAllMoves, isRemovalAllowed, moves
 } from './gameplay';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 const g = (rows: number[][]): Grid => rows.map(r => r.map(Boolean));
 

--- a/src/components/games/remove-row-or-column/gameplay.ts
+++ b/src/components/games/remove-row-or-column/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
 export type Grid = boolean[][]
 export type Board = { grid: Grid }

--- a/src/components/games/remove-row-or-column/remove-row-or-column.tsx
+++ b/src/components/games/remove-row-or-column/remove-row-or-column.tsx
@@ -1,5 +1,5 @@
 import { sample } from 'lodash';
-import { strategyGameFactory } from '../../strategy-game-factory';
+import { strategyGameFactory } from 'strategy-game-factory';
 import { BoardClient, getPlayerStepDescription } from './board-client';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { moves } from './gameplay';

--- a/src/components/games/rock-paper-scissor/bot-strategy.spec.ts
+++ b/src/components/games/rock-paper-scissor/bot-strategy.spec.ts
@@ -1,6 +1,6 @@
 import { smartBotStrategy } from './bot-strategy';
 import { moves, type Board } from './gameplay';
-import { botNextMoveArgs, makeCtx } from '../../../test-utils';
+import { botNextMoveArgs, makeCtx } from 'test-utils';
 
 const smartBotRemoval = (board: Board, currentPlayer: number): number =>
   botNextMoveArgs(smartBotStrategy({ board, ctx: makeCtx({ currentPlayer }) }))[0];

--- a/src/components/games/rock-paper-scissor/bot-strategy.ts
+++ b/src/components/games/rock-paper-scissor/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { random } from 'lodash';
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import type { Board, Moves } from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>

--- a/src/components/games/rock-paper-scissor/gameplay.spec.ts
+++ b/src/components/games/rock-paper-scissor/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { isRemovalAllowed, moves, type Board } from './gameplay';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
 

--- a/src/components/games/rock-paper-scissor/gameplay.ts
+++ b/src/components/games/rock-paper-scissor/gameplay.ts
@@ -1,5 +1,5 @@
 import { cloneDeep } from 'lodash';
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
 export type Board = ('rock' | 'paper' | 'scissor' | null)[][]
 

--- a/src/components/games/rock-paper-scissor/rock-paper-scissor.tsx
+++ b/src/components/games/rock-paper-scissor/rock-paper-scissor.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { smartBotStrategy } from './bot-strategy';
 import { RockSvg } from './symbols/rock-svg';
 import { PaperSvg } from './symbols/paper-svg';

--- a/src/components/games/rock-paper-scissor/rock-paper-scissor.tsx
+++ b/src/components/games/rock-paper-scissor/rock-paper-scissor.tsx
@@ -3,7 +3,7 @@ import { smartBotStrategy } from './bot-strategy';
 import { RockSvg } from './symbols/rock-svg';
 import { PaperSvg } from './symbols/paper-svg';
 import { ScissorSvg } from '../shared/scissor-svg';
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 import { moves, type Board } from './gameplay';
 
 const symbolSvgs = [RockSvg, PaperSvg, ScissorSvg];

--- a/src/components/games/rook-to-corner/bot-strategy.spec.ts
+++ b/src/components/games/rook-to-corner/bot-strategy.spec.ts
@@ -1,7 +1,7 @@
 import { range } from 'lodash';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { getAllowedMoves, isTarget, boardSize, type Field } from './gameplay';
-import { botNextMoveArgs, makeCtx } from '../../../test-utils';
+import { botNextMoveArgs, makeCtx } from 'test-utils';
 
 const isAllowed = (from: Field, to: Field) =>
   getAllowedMoves({ rookPosition: from }).some(m => m.row === to.row && m.col === to.col);

--- a/src/components/games/rook-to-corner/bot-strategy.ts
+++ b/src/components/games/rook-to-corner/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { sample } from 'lodash';
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import { getAllowedMoves, isTarget, type Board, type Moves } from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>

--- a/src/components/games/rook-to-corner/gameplay.spec.ts
+++ b/src/components/games/rook-to-corner/gameplay.spec.ts
@@ -1,6 +1,6 @@
 import { range } from 'lodash';
 import { boardSize, generateStartBoard, getAllowedMoves, isTarget, moves, target } from './gameplay';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 describe('rook to corner', () => {
   describe('getAllowedMoves()', () => {

--- a/src/components/games/rook-to-corner/gameplay.ts
+++ b/src/components/games/rook-to-corner/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { random, some, isEqual, cloneDeep } from 'lodash';
 
 export type Field = { row: number; col: number };

--- a/src/components/games/rook-to-corner/rook-to-corner.tsx
+++ b/src/components/games/rook-to-corner/rook-to-corner.tsx
@@ -1,5 +1,5 @@
 import { range, isEqual } from 'lodash';
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { boardSize, generateStartBoard, isTarget, moves, type Board, type Field } from './gameplay';
 import { RookSvg } from '../shared/rook-svg';

--- a/src/components/games/shark-chase/board-client.tsx
+++ b/src/components/games/shark-chase/board-client.tsx
@@ -5,7 +5,7 @@ import { SharkSvg } from './assets/shark-chase-shark-svg';
 import { SubmarineSvg } from './assets/shark-chase-submarine-svg';
 import { useTranslation } from '../../../language';
 import { type Board, RESEARCHERS, SHARK, sideLength } from './gameplay';
-import { GameBoard, type BoardClientProps } from '../../strategy-game-factory';
+import { GameBoard, type BoardClientProps } from 'strategy-game-factory';
 
 // Tailwind scans for whole class names, so the grid width cannot be built by
 // interpolation even though the side length is on the board.

--- a/src/components/games/shark-chase/board-client.tsx
+++ b/src/components/games/shark-chase/board-client.tsx
@@ -3,7 +3,7 @@ import { range } from 'lodash';
 
 import { SharkSvg } from './assets/shark-chase-shark-svg';
 import { SubmarineSvg } from './assets/shark-chase-submarine-svg';
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 import { type Board, RESEARCHERS, SHARK, sideLength } from './gameplay';
 import { GameBoard, type BoardClientProps } from 'strategy-game-factory';
 

--- a/src/components/games/shark-chase/shark-4-by-4/bot-strategy.ts
+++ b/src/components/games/shark-chase/shark-4-by-4/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { sample } from 'lodash';
-import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
+import type { BotMove, BotStrategy } from 'strategy-game-factory';
 import type { Board } from '../gameplay';
 import { makeGeometry } from '../bot-geometry';
 import type { Moves } from './gameplay';

--- a/src/components/games/shark-chase/shark-4-by-4/gameplay.spec.ts
+++ b/src/components/games/shark-chase/shark-4-by-4/gameplay.spec.ts
@@ -1,6 +1,6 @@
 import { isGameEnd, moves } from './gameplay';
 import { RESEARCHERS, SHARK, type Board } from '../gameplay';
-import { makeCtx } from '../../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 // The researchers win by moving a submarine onto the shark (or steering the
 // shark into one); the shark wins by surviving the turn limit.

--- a/src/components/games/shark-chase/shark-4-by-4/gameplay.ts
+++ b/src/components/games/shark-chase/shark-4-by-4/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { cloneDeep } from 'lodash';
 import { RESEARCHERS, SHARK, isSharkMoveAllowed, isSubmarineMoveAllowed, type Board } from '../gameplay';
 

--- a/src/components/games/shark-chase/shark-4-by-4/shark-chase.tsx
+++ b/src/components/games/shark-chase/shark-4-by-4/shark-chase.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory, type Ctx } from '../../../strategy-game-factory';
+import { strategyGameFactory, type Ctx } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { makeBoardClient } from '../board-client';
 import { type Board } from '../gameplay';

--- a/src/components/games/shark-chase/shark-5-by-5/bot-strategy.ts
+++ b/src/components/games/shark-chase/shark-5-by-5/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { sample } from 'lodash';
-import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
+import type { BotMove, BotStrategy } from 'strategy-game-factory';
 import type { Board } from '../gameplay';
 import { makeGeometry } from '../bot-geometry';
 import type { Moves } from './gameplay';

--- a/src/components/games/shark-chase/shark-5-by-5/gameplay.spec.ts
+++ b/src/components/games/shark-chase/shark-5-by-5/gameplay.spec.ts
@@ -1,6 +1,6 @@
 import { isGameEnd, moves } from './gameplay';
 import { RESEARCHERS, SHARK, type Board } from '../gameplay';
-import { makeCtx } from '../../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 // The researchers win by moving a submarine onto the shark (or steering the
 // shark into one); the shark wins by surviving the turn limit.

--- a/src/components/games/shark-chase/shark-5-by-5/gameplay.ts
+++ b/src/components/games/shark-chase/shark-5-by-5/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { cloneDeep } from 'lodash';
 import { RESEARCHERS, SHARK, isSharkMoveAllowed, isSubmarineMoveAllowed, type Board } from '../gameplay';
 

--- a/src/components/games/shark-chase/shark-5-by-5/shark-chase.tsx
+++ b/src/components/games/shark-chase/shark-5-by-5/shark-chase.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory, type Ctx } from '../../../strategy-game-factory';
+import { strategyGameFactory, type Ctx } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { makeBoardClient } from '../board-client';
 import { type Board } from '../gameplay';

--- a/src/components/games/single-number-increase/increment-or-double/bot-strategy.ts
+++ b/src/components/games/single-number-increase/increment-or-double/bot-strategy.ts
@@ -1,4 +1,4 @@
-import type { BotStrategy } from '../../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import { sample } from 'lodash';
 import { type Board, type Moves } from './gameplay';
 

--- a/src/components/games/single-number-increase/increment-or-double/gameplay.spec.ts
+++ b/src/components/games/single-number-increase/increment-or-double/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { moves } from './gameplay';
-import { makeCtx } from '../../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 // The player who passes 99 *loses*, so every ending credits the mover's
 // opponent — the opposite of most games in the repo.

--- a/src/components/games/single-number-increase/increment-or-double/gameplay.ts
+++ b/src/components/games/single-number-increase/increment-or-double/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
 // `board` is the last number said. 0 means nothing has been said yet, so the
 // starting player must open with 1 (their only legal move from 0).

--- a/src/components/games/single-number-increase/increment-or-double/increment-or-double.tsx
+++ b/src/components/games/single-number-increase/increment-or-double/increment-or-double.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { isLosing, moves, target, type Board } from './gameplay';
 import { smartBotStrategy } from './bot-strategy';
 

--- a/src/components/games/single-number-increase/plus-one-two-three/bot-strategy.ts
+++ b/src/components/games/single-number-increase/plus-one-two-three/bot-strategy.ts
@@ -1,4 +1,4 @@
-import type { BotStrategy } from '../../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import { random } from 'lodash';
 import { maxStep, type Board, type Moves } from './gameplay';
 

--- a/src/components/games/single-number-increase/plus-one-two-three/gameplay.spec.ts
+++ b/src/components/games/single-number-increase/plus-one-two-three/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { moves, type Board } from './gameplay';
-import { makeCtx } from '../../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 const isIncreaseValid = ({ board, number }: { board: Board; number: number }) =>
   moves.increaseTo.validate(board, { ctx: makeCtx() }, number);

--- a/src/components/games/single-number-increase/plus-one-two-three/gameplay.ts
+++ b/src/components/games/single-number-increase/plus-one-two-three/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
 export type Board = number
 

--- a/src/components/games/single-number-increase/plus-one-two-three/plus-one-two-three.tsx
+++ b/src/components/games/single-number-increase/plus-one-two-three/plus-one-two-three.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { range } from 'lodash';
 import { maxStep, moves, target, type Board } from './gameplay';
 import { smartBotStrategy } from './bot-strategy';

--- a/src/components/games/single-number-increase/superstitious-counting/bot-strategy.spec.ts
+++ b/src/components/games/single-number-increase/superstitious-counting/bot-strategy.spec.ts
@@ -1,5 +1,5 @@
 import { smartBotStrategy } from './bot-strategy';
-import { botNextMoveArgs, makeCtx } from '../../../../test-utils';
+import { botNextMoveArgs, makeCtx } from 'test-utils';
 import type { Board } from './gameplay';
 
 const smartBotStep = (board: Board): number =>

--- a/src/components/games/single-number-increase/superstitious-counting/bot-strategy.ts
+++ b/src/components/games/single-number-increase/superstitious-counting/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { random } from 'lodash';
-import type { BotStrategy } from '../../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import type { Board, Moves } from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>

--- a/src/components/games/single-number-increase/superstitious-counting/gameplay.spec.ts
+++ b/src/components/games/single-number-increase/superstitious-counting/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { moves, type Board } from './gameplay';
-import { makeCtx, moveValidator } from '../../../../test-utils';
+import { makeCtx, moveValidator } from 'test-utils';
 
 const isStepAllowed = moveValidator(moves.step);
 

--- a/src/components/games/single-number-increase/superstitious-counting/gameplay.ts
+++ b/src/components/games/single-number-increase/superstitious-counting/gameplay.ts
@@ -1,5 +1,5 @@
 import { range, sample, difference } from 'lodash';
-import type { Ctx, MoveOutcome } from '../../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
 export type Board = { current: number, target: number, restricted: number | null }
 

--- a/src/components/games/single-number-increase/superstitious-counting/superstitious-counting.tsx
+++ b/src/components/games/single-number-increase/superstitious-counting/superstitious-counting.tsx
@@ -1,5 +1,5 @@
 import { range } from 'lodash';
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { useTranslation } from '../../../../language';
 import { generateStartBoard, generateTestStartBoard, moves, type Board } from './gameplay';

--- a/src/components/games/single-number-increase/superstitious-counting/superstitious-counting.tsx
+++ b/src/components/games/single-number-increase/superstitious-counting/superstitious-counting.tsx
@@ -1,7 +1,7 @@
 import { range } from 'lodash';
 import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
-import { useTranslation } from '../../../../language';
+import { useTranslation } from 'language';
 import { generateStartBoard, generateTestStartBoard, moves, type Board } from './gameplay';
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {

--- a/src/components/games/single-pile-removal/doubling-reduction/bot-strategy.ts
+++ b/src/components/games/single-pile-removal/doubling-reduction/bot-strategy.ts
@@ -1,4 +1,4 @@
-import type { BotStrategy } from '../../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import { range, random, minBy } from 'lodash';
 import { type Board, cap } from '../gameplay';
 import { type Moves } from './gameplay';

--- a/src/components/games/single-pile-removal/doubling-reduction/doubling-reduction.tsx
+++ b/src/components/games/single-pile-removal/doubling-reduction/doubling-reduction.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory } from '../../../strategy-game-factory';
+import { strategyGameFactory } from 'strategy-game-factory';
 import { BoardClient, getPlayerStepDescription } from '../pebble-pile';
 import {  } from '../gameplay';
 import { generateStartBoard, generateTestStartBoard, moves } from './gameplay';

--- a/src/components/games/single-pile-removal/doubling-reduction/gameplay.spec.ts
+++ b/src/components/games/single-pile-removal/doubling-reduction/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { moves } from './gameplay';
-import { makeCtx } from '../../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
 

--- a/src/components/games/single-pile-removal/doubling-reduction/gameplay.ts
+++ b/src/components/games/single-pile-removal/doubling-reduction/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { random, sample } from 'lodash';
 import { type Board, validateTake } from '../gameplay';
 

--- a/src/components/games/single-pile-removal/pebble-pile.tsx
+++ b/src/components/games/single-pile-removal/pebble-pile.tsx
@@ -1,6 +1,6 @@
 import { range } from 'lodash';
 import { GameBoard, useHoverPreview, type BoardClientProps } from 'strategy-game-factory';
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 import { cap, type Board } from './gameplay';
 
 // The pile UI shared by the pebble take-away games.

--- a/src/components/games/single-pile-removal/pebble-pile.tsx
+++ b/src/components/games/single-pile-removal/pebble-pile.tsx
@@ -1,5 +1,5 @@
 import { range } from 'lodash';
-import { GameBoard, useHoverPreview, type BoardClientProps } from '../../strategy-game-factory';
+import { GameBoard, useHoverPreview, type BoardClientProps } from 'strategy-game-factory';
 import { useTranslation } from '../../../language';
 import { cap, type Board } from './gameplay';
 

--- a/src/components/games/single-pile-removal/prime-exponentials/bot-strategy.ts
+++ b/src/components/games/single-pile-removal/prime-exponentials/bot-strategy.ts
@@ -1,4 +1,4 @@
-import type { BotStrategy } from '../../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import { sample } from 'lodash';
 import { allPrimePowers, type Board, type Moves } from './gameplay';
 

--- a/src/components/games/single-pile-removal/prime-exponentials/gameplay.spec.ts
+++ b/src/components/games/single-pile-removal/prime-exponentials/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { moves } from './gameplay';
-import { makeCtx, moveValidator } from '../../../../test-utils';
+import { makeCtx, moveValidator } from 'test-utils';
 
 const isSubtractionAllowed = moveValidator(moves.subtractPrimeExponent);
 

--- a/src/components/games/single-pile-removal/prime-exponentials/gameplay.ts
+++ b/src/components/games/single-pile-removal/prime-exponentials/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { random } from 'lodash';
 
 export type Board = number

--- a/src/components/games/single-pile-removal/prime-exponentials/prime-exponentials.tsx
+++ b/src/components/games/single-pile-removal/prime-exponentials/prime-exponentials.tsx
@@ -5,7 +5,7 @@ import {
   GameBoard,
   useHoverPreview
 } from 'strategy-game-factory';
-import { useTranslation } from '../../../../language';
+import { useTranslation } from 'language';
 import { allPrimePowers, generateSmallStartBoard, generateStartBoard, moves, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 

--- a/src/components/games/single-pile-removal/prime-exponentials/prime-exponentials.tsx
+++ b/src/components/games/single-pile-removal/prime-exponentials/prime-exponentials.tsx
@@ -4,7 +4,7 @@ import {
   type BoardClientProps,
   GameBoard,
   useHoverPreview
-} from '../../../strategy-game-factory';
+} from 'strategy-game-factory';
 import { useTranslation } from '../../../../language';
 import { allPrimePowers, generateSmallStartBoard, generateStartBoard, moves, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';

--- a/src/components/games/single-pile-removal/primely-to-zero/bot-strategy.ts
+++ b/src/components/games/single-pile-removal/primely-to-zero/bot-strategy.ts
@@ -1,4 +1,4 @@
-import type { BotStrategy } from '../../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import { sample } from 'lodash';
 import { isValidStep, validSteps, type Board, type Moves } from './gameplay';
 

--- a/src/components/games/single-pile-removal/primely-to-zero/gameplay.spec.ts
+++ b/src/components/games/single-pile-removal/primely-to-zero/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { moves } from './gameplay';
-import { makeCtx, moveValidator } from '../../../../test-utils';
+import { makeCtx, moveValidator } from 'test-utils';
 
 const isMoveValid = moveValidator(moves.moveTo);
 

--- a/src/components/games/single-pile-removal/primely-to-zero/gameplay.ts
+++ b/src/components/games/single-pile-removal/primely-to-zero/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { range, sample } from 'lodash';
 
 export type Board = number

--- a/src/components/games/single-pile-removal/primely-to-zero/primely-to-zero.tsx
+++ b/src/components/games/single-pile-removal/primely-to-zero/primely-to-zero.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { range } from 'lodash';
 import { generateStartBoard, maxStart, moves, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';

--- a/src/components/games/single-pile-removal/take-1-or-halve/bot-strategy.ts
+++ b/src/components/games/single-pile-removal/take-1-or-halve/bot-strategy.ts
@@ -1,4 +1,4 @@
-import type { BotStrategy } from '../../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import { random } from 'lodash';
 import { type Board, type Moves } from './gameplay';
 

--- a/src/components/games/single-pile-removal/take-1-or-halve/gameplay.spec.ts
+++ b/src/components/games/single-pile-removal/take-1-or-halve/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { moves } from './gameplay';
-import { makeCtx } from '../../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
 

--- a/src/components/games/single-pile-removal/take-1-or-halve/gameplay.ts
+++ b/src/components/games/single-pile-removal/take-1-or-halve/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
 export type Board = number
 export type HoveredAction = 'take1' | 'halve' | null

--- a/src/components/games/single-pile-removal/take-1-or-halve/take-1-or-halve.tsx
+++ b/src/components/games/single-pile-removal/take-1-or-halve/take-1-or-halve.tsx
@@ -5,7 +5,7 @@ import {
   useHoverPreview
 } from 'strategy-game-factory';
 import { random, range } from 'lodash';
-import { useTranslation } from '../../../../language';
+import { useTranslation } from 'language';
 import { moves, type Board, type HoveredAction } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 

--- a/src/components/games/single-pile-removal/take-1-or-halve/take-1-or-halve.tsx
+++ b/src/components/games/single-pile-removal/take-1-or-halve/take-1-or-halve.tsx
@@ -3,7 +3,7 @@ import {
   type BoardClientProps,
   GameBoard,
   useHoverPreview
-} from '../../../strategy-game-factory';
+} from 'strategy-game-factory';
 import { random, range } from 'lodash';
 import { useTranslation } from '../../../../language';
 import { moves, type Board, type HoveredAction } from './gameplay';

--- a/src/components/games/single-pile-removal/take-power-of-two/bot-strategy.ts
+++ b/src/components/games/single-pile-removal/take-power-of-two/bot-strategy.ts
@@ -1,4 +1,4 @@
-import type { BotStrategy } from '../../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import { reverse, sample } from 'lodash';
 import { getAvailableExponents, type Board, type Moves } from './gameplay';
 

--- a/src/components/games/single-pile-removal/take-power-of-two/gameplay.spec.ts
+++ b/src/components/games/single-pile-removal/take-power-of-two/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { moves } from './gameplay';
-import { makeCtx } from '../../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
 

--- a/src/components/games/single-pile-removal/take-power-of-two/gameplay.ts
+++ b/src/components/games/single-pile-removal/take-power-of-two/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { range, random } from 'lodash';
 
 export const generateStartBoard = () => {

--- a/src/components/games/single-pile-removal/take-power-of-two/take-power-of-two.tsx
+++ b/src/components/games/single-pile-removal/take-power-of-two/take-power-of-two.tsx
@@ -3,7 +3,7 @@ import {
   type BoardClientProps,
   GameBoard,
   useHoverPreview
-} from '../../../strategy-game-factory';
+} from 'strategy-game-factory';
 import { useTranslation } from '../../../../language';
 import { generateStartBoard, generateTestStartBoard, getAvailableExponents, moves, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';

--- a/src/components/games/single-pile-removal/take-power-of-two/take-power-of-two.tsx
+++ b/src/components/games/single-pile-removal/take-power-of-two/take-power-of-two.tsx
@@ -4,7 +4,7 @@ import {
   GameBoard,
   useHoverPreview
 } from 'strategy-game-factory';
-import { useTranslation } from '../../../../language';
+import { useTranslation } from 'language';
 import { generateStartBoard, generateTestStartBoard, getAvailableExponents, moves, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 

--- a/src/components/games/single-pile-removal/three-more/bot-strategy.ts
+++ b/src/components/games/single-pile-removal/three-more/bot-strategy.ts
@@ -1,4 +1,4 @@
-import type { BotStrategy } from '../../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import { range, minBy } from 'lodash';
 import { type Board, cap } from '../gameplay';
 import { INCREMENT, type Moves } from './gameplay';

--- a/src/components/games/single-pile-removal/three-more/gameplay.spec.ts
+++ b/src/components/games/single-pile-removal/three-more/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { moves } from './gameplay';
-import { makeCtx } from '../../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
 

--- a/src/components/games/single-pile-removal/three-more/gameplay.ts
+++ b/src/components/games/single-pile-removal/three-more/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { range, random, sample } from 'lodash';
 import { type Board, validateTake } from '../gameplay';
 

--- a/src/components/games/single-pile-removal/three-more/three-more.tsx
+++ b/src/components/games/single-pile-removal/three-more/three-more.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory } from '../../../strategy-game-factory';
+import { strategyGameFactory } from 'strategy-game-factory';
 import { BoardClient, getPlayerStepDescription } from '../pebble-pile';
 import {  } from '../gameplay';
 import { generateStartBoard, moves } from './gameplay';

--- a/src/components/games/single-pile-removal/waning-stones/bot-strategy.ts
+++ b/src/components/games/single-pile-removal/waning-stones/bot-strategy.ts
@@ -1,4 +1,4 @@
-import type { BotStrategy } from '../../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import { range, random, minBy } from 'lodash';
 import { type Board, cap } from '../gameplay';
 import { type Moves } from './gameplay';

--- a/src/components/games/single-pile-removal/waning-stones/gameplay.spec.ts
+++ b/src/components/games/single-pile-removal/waning-stones/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { moves } from './gameplay';
-import { makeCtx } from '../../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
 

--- a/src/components/games/single-pile-removal/waning-stones/gameplay.ts
+++ b/src/components/games/single-pile-removal/waning-stones/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { range, random, sample } from 'lodash';
 import { type Board, validateTake } from '../gameplay';
 

--- a/src/components/games/single-pile-removal/waning-stones/waning-stones.tsx
+++ b/src/components/games/single-pile-removal/waning-stones/waning-stones.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory } from '../../../strategy-game-factory';
+import { strategyGameFactory } from 'strategy-game-factory';
 import { BoardClient, getPlayerStepDescription } from '../pebble-pile';
 import {  } from '../gameplay';
 import { generateStartBoard, generateTestStartBoard, moves } from './gameplay';

--- a/src/components/games/six-fields-circle/board-client.tsx
+++ b/src/components/games/six-fields-circle/board-client.tsx
@@ -1,5 +1,5 @@
 import { range } from 'lodash';
-import { GameBoard, type BoardClientProps } from '../../strategy-game-factory';
+import { GameBoard, type BoardClientProps } from 'strategy-game-factory';
 import { type Board, FIELD_COUNT, OPPOSITE_PAIRS } from './gameplay';
 
 type TurnState = { first: number } | null

--- a/src/components/games/six-fields-circle/bot-strategy.ts
+++ b/src/components/games/six-fields-circle/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { sample } from 'lodash';
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import {
   OPPOSITE_PAIRS,
   getLegalMoves,

--- a/src/components/games/six-fields-circle/gameplay.spec.ts
+++ b/src/components/games/six-fields-circle/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { getLegalMoves, hasLegalMove, isOpposite, isRemovalAllowed, moves, type Board } from './gameplay';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 describe('isRemovalAllowed', () => {
   const board: Board = [2, 1, 0, 3, 1, 1];

--- a/src/components/games/six-fields-circle/gameplay.ts
+++ b/src/components/games/six-fields-circle/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { random, sample } from 'lodash';
 
 // Six fields sit on a circle, indices 0..5 clockwise. Each field holds some

--- a/src/components/games/six-fields-circle/six-fields-circle.tsx
+++ b/src/components/games/six-fields-circle/six-fields-circle.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory, type Ctx } from '../../strategy-game-factory';
+import { strategyGameFactory, type Ctx } from 'strategy-game-factory';
 import { generateStartBoard, moves, type Board } from './gameplay';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { BoardClient } from './board-client';

--- a/src/components/games/stones-remove-one-not-twice-from-left/bot-strategy.ts
+++ b/src/components/games/stones-remove-one-not-twice-from-left/bot-strategy.ts
@@ -1,4 +1,4 @@
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import { random } from 'lodash';
 import { type Board, type Moves } from './gameplay';
 

--- a/src/components/games/stones-remove-one-not-twice-from-left/gameplay.spec.ts
+++ b/src/components/games/stones-remove-one-not-twice-from-left/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { isRemovalAllowed, moves } from './gameplay';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
 

--- a/src/components/games/stones-remove-one-not-twice-from-left/gameplay.ts
+++ b/src/components/games/stones-remove-one-not-twice-from-left/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { cloneDeep, isEqual, sample } from 'lodash';
 
 export type Board = { piles: [number, number], leftRestriction: [boolean, boolean] }

--- a/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
+++ b/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory, type BoardClientProps, GameBoard, useHoverPreview } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard, useHoverPreview } from 'strategy-game-factory';
 import { range } from 'lodash';
 import { useTranslation } from '../../../language';
 import { generateStartBoard, generateTestStartBoard, moves, type Board } from './gameplay';

--- a/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
+++ b/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
@@ -1,6 +1,6 @@
 import { strategyGameFactory, type BoardClientProps, GameBoard, useHoverPreview } from 'strategy-game-factory';
 import { range } from 'lodash';
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 import { generateStartBoard, generateTestStartBoard, moves, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 

--- a/src/components/games/sum-fifteen/bot-strategy.ts
+++ b/src/components/games/sum-fifteen/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { sample } from 'lodash';
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import {
   currentPlayerFromOwner,
   freeNumbers,

--- a/src/components/games/sum-fifteen/gameplay.spec.ts
+++ b/src/components/games/sum-fifteen/gameplay.spec.ts
@@ -7,7 +7,7 @@ import {
   type Board,
   type Owner
 } from './gameplay';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 describe('hasSum15', () => {
   it('detects a triple summing to 15', () => {

--- a/src/components/games/sum-fifteen/gameplay.ts
+++ b/src/components/games/sum-fifteen/gameplay.ts
@@ -1,4 +1,4 @@
-import type { MoveOutcome, Ctx } from '../../strategy-game-factory';
+import type { MoveOutcome, Ctx } from 'strategy-game-factory';
 
 // owner[i] holds who owns the number (i + 1): 0 = first player, 1 = second
 // player, null = still available.

--- a/src/components/games/sum-fifteen/sum-fifteen.tsx
+++ b/src/components/games/sum-fifteen/sum-fifteen.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { useTranslation } from '../../../language';
 import { allNumbers, findWinningTriple, generateStartBoard, moves, numbersOwnedBy, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';

--- a/src/components/games/sum-fifteen/sum-fifteen.tsx
+++ b/src/components/games/sum-fifteen/sum-fifteen.tsx
@@ -1,5 +1,5 @@
 import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 import { allNumbers, findWinningTriple, generateStartBoard, moves, numbersOwnedBy, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 

--- a/src/components/games/take-and-point/board-client.tsx
+++ b/src/components/games/take-and-point/board-client.tsx
@@ -1,5 +1,5 @@
 import { range } from 'lodash';
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 import { GameBoard, type BoardClientProps, useMoveScopedState } from 'strategy-game-factory';
 import { type Board, requiredPointCount } from './gameplay';
 

--- a/src/components/games/take-and-point/board-client.tsx
+++ b/src/components/games/take-and-point/board-client.tsx
@@ -1,6 +1,6 @@
 import { range } from 'lodash';
 import { useTranslation } from '../../../language';
-import { GameBoard, type BoardClientProps, useMoveScopedState } from '../../strategy-game-factory';
+import { GameBoard, type BoardClientProps, useMoveScopedState } from 'strategy-game-factory';
 import { type Board, requiredPointCount } from './gameplay';
 
 const Chips = ({ count, removeCount = 0 }: { count: number; removeCount?: number }) => (

--- a/src/components/games/take-and-point/bot-strategy.spec.ts
+++ b/src/components/games/take-and-point/bot-strategy.spec.ts
@@ -10,7 +10,7 @@ import {
   nonEmptyIndices,
   removerWins
 } from './gameplay';
-import { moveValidator } from '../../../test-utils';
+import { moveValidator } from 'test-utils';
 
 const isPointingAllowed = moveValidator(moves.pointPiles);
 

--- a/src/components/games/take-and-point/bot-strategy.ts
+++ b/src/components/games/take-and-point/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { sample, shuffle } from 'lodash';
-import type { BotMove, BotStrategy } from '../../strategy-game-factory';
+import type { BotMove, BotStrategy } from 'strategy-game-factory';
 import {
   type Board,
   applyRemoval,

--- a/src/components/games/take-and-point/gameplay.spec.ts
+++ b/src/components/games/take-and-point/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { makeCtx, moveValidator } from '../../../test-utils';
+import { makeCtx, moveValidator } from 'test-utils';
 import {
   applyRemoval,
   countMinPiles,

--- a/src/components/games/take-and-point/gameplay.ts
+++ b/src/components/games/take-and-point/gameplay.ts
@@ -1,5 +1,5 @@
 import { random, range, shuffle, uniq } from 'lodash';
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
 // piles: sizes of the piles; a value of 0 means that pile is empty (kept in the
 // array so pile indices stay stable across a game). pointed: indices of the

--- a/src/components/games/take-and-point/take-and-point.tsx
+++ b/src/components/games/take-and-point/take-and-point.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory } from '../../strategy-game-factory';
+import { strategyGameFactory } from 'strategy-game-factory';
 import { BoardClient } from './board-client';
 import { generateStartBoard, moves, nonEmptyIndices } from './gameplay';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';

--- a/src/components/games/ten-coins/bot-strategy.spec.ts
+++ b/src/components/games/ten-coins/bot-strategy.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { uniq, range } from 'lodash';
-import { playBotMove } from '../../../test-utils';
+import { playBotMove } from 'test-utils';
 import { smartBotStrategy } from './bot-strategy';
 import { moves as gameMoves } from './gameplay';
 

--- a/src/components/games/ten-coins/bot-strategy.ts
+++ b/src/components/games/ten-coins/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { uniq, sample } from 'lodash';
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import { type Board, type Moves } from './gameplay';
 
 type Move = { k: number, l: number, resultSet: number[] }

--- a/src/components/games/ten-coins/gameplay.spec.ts
+++ b/src/components/games/ten-coins/gameplay.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { moves, type Board } from './gameplay';
-import { makeCtx, moveValidator } from '../../../test-utils';
+import { makeCtx, moveValidator } from 'test-utils';
 
 const isConversionAllowed = moveValidator(moves.convert);
 

--- a/src/components/games/ten-coins/gameplay.ts
+++ b/src/components/games/ten-coins/gameplay.ts
@@ -1,5 +1,5 @@
 import { uniq, sample, random } from 'lodash';
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
 // The board is the multiset of coin values. Only which distinct values are
 // present matters for the game logic; the counts are pure flavour. The two

--- a/src/components/games/ten-coins/ten-coins.tsx
+++ b/src/components/games/ten-coins/ten-coins.tsx
@@ -1,6 +1,6 @@
 import { range } from 'lodash';
 import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 import { generateStartBoardC, generateStartBoardD, generateTestStartBoard, moves, type Board } from './gameplay';
 import { distinctValues, randomBotStrategy, smartBotStrategy } from './bot-strategy';
 

--- a/src/components/games/ten-coins/ten-coins.tsx
+++ b/src/components/games/ten-coins/ten-coins.tsx
@@ -1,5 +1,5 @@
 import { range } from 'lodash';
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { useTranslation } from '../../../language';
 import { generateStartBoardC, generateStartBoardD, generateTestStartBoard, moves, type Board } from './gameplay';
 import { distinctValues, randomBotStrategy, smartBotStrategy } from './bot-strategy';

--- a/src/components/games/ten-digit-number/bot-strategy.spec.ts
+++ b/src/components/games/ten-digit-number/bot-strategy.spec.ts
@@ -1,5 +1,5 @@
 import { sum } from 'lodash';
-import { runMatch, type MatchResult } from '../../strategy-game-factory';
+import { runMatch, type MatchResult } from 'strategy-game-factory';
 import { type Board, moves, availableDigits, totalDigits } from './gameplay';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 

--- a/src/components/games/ten-digit-number/bot-strategy.ts
+++ b/src/components/games/ten-digit-number/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { sample } from 'lodash';
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import { availableDigits, totalDigits, type Board, type Moves } from './gameplay';
 
 // Precompute winner(sumMod9, turnsLeft): 0 = Jenő wins, 1 = Béla wins, with optimal play.

--- a/src/components/games/ten-digit-number/gameplay.spec.ts
+++ b/src/components/games/ten-digit-number/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { moves } from './gameplay';
-import { makeCtx, moveValidator } from '../../../test-utils';
+import { makeCtx, moveValidator } from 'test-utils';
 
 const isDigitChoiceAllowed = moveValidator(moves.chooseDigit);
 

--- a/src/components/games/ten-digit-number/gameplay.ts
+++ b/src/components/games/ten-digit-number/gameplay.ts
@@ -1,4 +1,4 @@
-import type { MoveOutcome } from '../../strategy-game-factory';
+import type { MoveOutcome } from 'strategy-game-factory';
 
 export type Board = { digits: number[], sumMod9: number }
 

--- a/src/components/games/ten-digit-number/ten-digit-number.tsx
+++ b/src/components/games/ten-digit-number/ten-digit-number.tsx
@@ -1,5 +1,5 @@
 import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 import { availableDigits, moves, totalDigits, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 

--- a/src/components/games/ten-digit-number/ten-digit-number.tsx
+++ b/src/components/games/ten-digit-number/ten-digit-number.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { useTranslation } from '../../../language';
 import { availableDigits, moves, totalDigits, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';

--- a/src/components/games/thief-sheriff-mean/board-client.tsx
+++ b/src/components/games/thief-sheriff-mean/board-client.tsx
@@ -1,5 +1,5 @@
 import { range } from 'lodash';
-import { type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { Sheriff, Thief, type Board } from './gameplay';
 
 // Both variants deal the same row of numbered cards and take one per click; the

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/bot-strategy.ts
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/bot-strategy.ts
@@ -1,6 +1,6 @@
 import { sample } from 'lodash';
 import { Sheriff, Thief, hasWinningTriple, getUntakenCards, type Board } from '../gameplay';
-import { type BotStrategy } from '../../../strategy-game-factory';
+import { type BotStrategy } from 'strategy-game-factory';
 import { applyTakeCard, CARD_COUNT, type Moves } from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/gameplay.spec.ts
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/gameplay.spec.ts
@@ -1,6 +1,6 @@
 import { moves } from './gameplay';
 import { Sheriff, Thief, hasWinningTriple, type Board } from '../gameplay';
-import { makeCtx } from '../../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 // The thief wins by holding three cards in arithmetic progression; the sheriff
 // wins by preventing that until the cards run out.

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/gameplay.ts
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/gameplay.ts
@@ -1,6 +1,6 @@
 import { cloneDeep } from 'lodash';
 import { Sheriff, Thief, hasWinningTriple, getUntakenCards, isCardAvailable, type Board } from '../gameplay';
-import type { Ctx, MoveOutcome } from '../../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
 export const CARD_COUNT = 7;
 

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/thief-sheriff-mean-7.tsx
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/thief-sheriff-mean-7.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory } from '../../../strategy-game-factory';
+import { strategyGameFactory } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { generateStartBoard } from '../gameplay';
 import { makeBoardClient } from '../board-client';

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/bot-strategy.ts
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/bot-strategy.ts
@@ -1,6 +1,6 @@
 import { sample } from 'lodash';
 import { Sheriff, Thief, hasWinningTriple, getUntakenCards, type Board } from '../gameplay';
-import { type BotStrategy } from '../../../strategy-game-factory';
+import { type BotStrategy } from 'strategy-game-factory';
 import { applyTakeCard, CARD_COUNT, type Moves } from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/gameplay.spec.ts
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/gameplay.spec.ts
@@ -1,6 +1,6 @@
 import { moves } from './gameplay';
 import { Sheriff, Thief, hasWinningTriple, type Board } from '../gameplay';
-import { makeCtx } from '../../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 // The thief wins by holding three cards in arithmetic progression; the sheriff
 // wins by preventing that until the cards run out.

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/gameplay.ts
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/gameplay.ts
@@ -1,6 +1,6 @@
 import { cloneDeep } from 'lodash';
 import { Sheriff, Thief, hasWinningTriple, getUntakenCards, isCardAvailable, type Board } from '../gameplay';
-import type { Ctx, MoveOutcome } from '../../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
 export const CARD_COUNT = 9;
 

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/thief-sheriff-mean-9.tsx
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/thief-sheriff-mean-9.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory } from '../../../strategy-game-factory';
+import { strategyGameFactory } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { generateStartBoard } from '../gameplay';
 import { makeBoardClient } from '../board-client';

--- a/src/components/games/three-piles-rebuild/bot-strategy.ts
+++ b/src/components/games/three-piles-rebuild/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { random, sample } from 'lodash';
-import type { BotMove, BotStrategy } from '../../strategy-game-factory';
+import type { BotMove, BotStrategy } from 'strategy-game-factory';
 import {
   canSplit,
   isWinningNumber,

--- a/src/components/games/three-piles-rebuild/gameplay.spec.ts
+++ b/src/components/games/three-piles-rebuild/gameplay.spec.ts
@@ -9,7 +9,7 @@ import {
   keptPileId,
   moves
 } from './gameplay';
-import { makeCtx, moveValidator } from '../../../test-utils';
+import { makeCtx, moveValidator } from 'test-utils';
 
 const isKeepAllowed = moveValidator(moves.keepPile);
 

--- a/src/components/games/three-piles-rebuild/gameplay.ts
+++ b/src/components/games/three-piles-rebuild/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { random, range, sample } from 'lodash';
 
 export type Board = number[]; // always length 3

--- a/src/components/games/three-piles-rebuild/three-piles-rebuild.tsx
+++ b/src/components/games/three-piles-rebuild/three-piles-rebuild.tsx
@@ -1,7 +1,7 @@
 import {
   strategyGameFactory, type BoardClientProps, GameBoard, useDeferredMove, useMoveScopedState
 } from 'strategy-game-factory';
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 import {
   canSplit,
   generateStartBoard,

--- a/src/components/games/three-piles-rebuild/three-piles-rebuild.tsx
+++ b/src/components/games/three-piles-rebuild/three-piles-rebuild.tsx
@@ -1,6 +1,6 @@
 import {
   strategyGameFactory, type BoardClientProps, GameBoard, useDeferredMove, useMoveScopedState
-} from '../../strategy-game-factory';
+} from 'strategy-game-factory';
 import { useTranslation } from '../../../language';
 import {
   canSplit,

--- a/src/components/games/tictactoe-alikes/anti-tictactoe/anti-tictactoe.tsx
+++ b/src/components/games/tictactoe-alikes/anti-tictactoe/anti-tictactoe.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory } from '../../../strategy-game-factory';
+import { strategyGameFactory } from 'strategy-game-factory';
 import { generateEmptyTicTacToeBoard } from '../gameplay';
 import { BoardClient } from '../board-client';
 import { moves } from './gameplay';

--- a/src/components/games/tictactoe-alikes/anti-tictactoe/bot-strategy.spec.ts
+++ b/src/components/games/tictactoe-alikes/anti-tictactoe/bot-strategy.spec.ts
@@ -1,5 +1,5 @@
 import { smartBotStrategy } from './bot-strategy';
-import { botNextMoveArgs, makeCtx } from '../../../../test-utils';
+import { botNextMoveArgs, makeCtx } from 'test-utils';
 
 describe('smartBotStrategy', () => {
   it('should place to middle place as a starting move', () => {

--- a/src/components/games/tictactoe-alikes/anti-tictactoe/bot-strategy.ts
+++ b/src/components/games/tictactoe-alikes/anti-tictactoe/bot-strategy.ts
@@ -1,7 +1,7 @@
 import { range, isNull, sample, cloneDeep } from 'lodash';
 import { hasWinningSubset } from '../gameplay';
 import { hasFirstPlayerWon, isGameEnd, roleColors, type Board, type Moves } from './gameplay';
-import type { BotStrategy } from '../../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 
 type Bot = BotStrategy<Board, Moves>
 

--- a/src/components/games/tictactoe-alikes/anti-tictactoe/gameplay.spec.ts
+++ b/src/components/games/tictactoe-alikes/anti-tictactoe/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { hasFirstPlayerWon, isGameEnd, moves } from './gameplay';
-import { makeCtx } from '../../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 describe('isGameEnd', () => {
   it('should end game if there are 3 in a row', () => {

--- a/src/components/games/tictactoe-alikes/anti-tictactoe/gameplay.ts
+++ b/src/components/games/tictactoe-alikes/anti-tictactoe/gameplay.ts
@@ -1,4 +1,4 @@
-import type { MoveOutcome, Ctx } from '../../../strategy-game-factory';
+import type { MoveOutcome, Ctx } from 'strategy-game-factory';
 import { some, range, groupBy, cloneDeep } from 'lodash';
 import { hasWinningSubset, type Board, validatePlacement } from '../gameplay';
 

--- a/src/components/games/tictactoe-alikes/board-client.tsx
+++ b/src/components/games/tictactoe-alikes/board-client.tsx
@@ -1,5 +1,5 @@
 import { range } from 'lodash';
-import { type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { type Board } from './gameplay';
 
 // Shared by anti-tictactoe and tictactoe-doublestart, whose boards are the same

--- a/src/components/games/tictactoe-alikes/tictactoe-doublestart/bot-strategy.spec.ts
+++ b/src/components/games/tictactoe-alikes/tictactoe-doublestart/bot-strategy.spec.ts
@@ -1,5 +1,5 @@
 import { smartBotStrategy } from './bot-strategy';
-import { botNextMoveArgs, makeCtx } from '../../../../test-utils';
+import { botNextMoveArgs, makeCtx } from 'test-utils';
 
 describe('Double starter TicTacToe strategy', () => {
   describe('AI is the first to move', () => {

--- a/src/components/games/tictactoe-alikes/tictactoe-doublestart/bot-strategy.ts
+++ b/src/components/games/tictactoe-alikes/tictactoe-doublestart/bot-strategy.ts
@@ -1,7 +1,7 @@
 import { range, isNull, sample, sampleSize, cloneDeep } from 'lodash';
 import { hasWinningSubset } from '../gameplay';
 import { hasFirstPlayerWon, isGameEnd, roleColors, type Board, type Moves } from './gameplay';
-import type { BotMove, BotStrategy } from '../../../strategy-game-factory';
+import type { BotMove, BotStrategy } from 'strategy-game-factory';
 
 type Bot = BotStrategy<Board, Moves>
 

--- a/src/components/games/tictactoe-alikes/tictactoe-doublestart/gameplay.spec.ts
+++ b/src/components/games/tictactoe-alikes/tictactoe-doublestart/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { hasFirstPlayerWon, isGameEnd, moves } from './gameplay';
-import { makeCtx } from '../../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 describe('isGameEnd, hasFirstPlayerWon', () => {
   it('should end the game if there are 3 pieces in a row for the second player', () => {

--- a/src/components/games/tictactoe-alikes/tictactoe-doublestart/gameplay.ts
+++ b/src/components/games/tictactoe-alikes/tictactoe-doublestart/gameplay.ts
@@ -1,4 +1,4 @@
-import type { MoveOutcome, Ctx } from '../../../strategy-game-factory';
+import type { MoveOutcome, Ctx } from 'strategy-game-factory';
 import { range, cloneDeep } from 'lodash';
 import { hasWinningSubset, type Board, validatePlacement } from '../gameplay';
 

--- a/src/components/games/tictactoe-alikes/tictactoe-doublestart/tictactoe-doublestart.tsx
+++ b/src/components/games/tictactoe-alikes/tictactoe-doublestart/tictactoe-doublestart.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory } from '../../../strategy-game-factory';
+import { strategyGameFactory } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { generateEmptyTicTacToeBoard } from '../gameplay';
 import { BoardClient } from '../board-client';

--- a/src/components/games/tictactoe-alikes/tictactoe/bot-strategy.spec.ts
+++ b/src/components/games/tictactoe-alikes/tictactoe/bot-strategy.spec.ts
@@ -1,5 +1,5 @@
 import { smartBotStrategy } from './bot-strategy';
-import { botNextMoveArgs, makeCtx } from '../../../../test-utils';
+import { botNextMoveArgs, makeCtx } from 'test-utils';
 
 describe('smartBotStrategy', () => {
   describe('new piece placing phase', () => {

--- a/src/components/games/tictactoe-alikes/tictactoe/bot-strategy.ts
+++ b/src/components/games/tictactoe-alikes/tictactoe/bot-strategy.ts
@@ -1,6 +1,6 @@
 import { isNull, range, sample } from 'lodash';
 import { botColor, inPlacingPhase, isGameEnd, pColor, type Board, type Moves } from './gameplay';
-import type { BotStrategy } from '../../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 
 type Bot = BotStrategy<Board, Moves>
 

--- a/src/components/games/tictactoe-alikes/tictactoe/gameplay.spec.ts
+++ b/src/components/games/tictactoe-alikes/tictactoe/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { makeCtx } from 'test-utils';
-import type { Ctx } from '../../../strategy-game-factory';
+import type { Ctx } from 'strategy-game-factory';
 import { inPlacingPhase, moves, type Board } from './gameplay';
 
 // vsHuman keeps the colours independent of role choice: player 0 is blue, so the

--- a/src/components/games/tictactoe-alikes/tictactoe/gameplay.spec.ts
+++ b/src/components/games/tictactoe-alikes/tictactoe/gameplay.spec.ts
@@ -1,4 +1,4 @@
-import { makeCtx } from '../../../../test-utils';
+import { makeCtx } from 'test-utils';
 import type { Ctx } from '../../../strategy-game-factory';
 import { inPlacingPhase, moves, type Board } from './gameplay';
 

--- a/src/components/games/tictactoe-alikes/tictactoe/gameplay.ts
+++ b/src/components/games/tictactoe-alikes/tictactoe/gameplay.ts
@@ -1,4 +1,4 @@
-import type { MoveOutcome, Ctx } from '../../../strategy-game-factory';
+import type { MoveOutcome, Ctx } from 'strategy-game-factory';
 import { isNull, some, groupBy, range, cloneDeep } from 'lodash';
 import { hasWinningSubset, type Board, validatePlacement } from '../gameplay';
 

--- a/src/components/games/tictactoe-alikes/tictactoe/tictactoe.tsx
+++ b/src/components/games/tictactoe-alikes/tictactoe/tictactoe.tsx
@@ -1,5 +1,5 @@
 import { range } from 'lodash';
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { generateEmptyTicTacToeBoard } from '../gameplay';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { inPlacingPhase, moves, otherPlayerColor, type Board } from './gameplay';

--- a/src/components/games/totem-poles/triangular-grid-ropes-10/bot-strategy.spec.ts
+++ b/src/components/games/totem-poles/triangular-grid-ropes-10/bot-strategy.spec.ts
@@ -4,7 +4,7 @@ import {
   getAllowedMoves, isAllowed, edgeDirection, mirrorNodes, moves, type Board, type Edge
 } from './gameplay';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
-import { botNextMoveArgs, makeCtx } from '../../../../test-utils';
+import { botNextMoveArgs, makeCtx } from 'test-utils';
 
 // Play a real game through the engine: the same moves, validator and win
 // detection the site runs on.

--- a/src/components/games/totem-poles/triangular-grid-ropes-10/bot-strategy.spec.ts
+++ b/src/components/games/totem-poles/triangular-grid-ropes-10/bot-strategy.spec.ts
@@ -1,5 +1,5 @@
 import { isEqual } from 'lodash';
-import { runMatch, type MatchResult } from '../../../strategy-game-factory';
+import { runMatch, type MatchResult } from 'strategy-game-factory';
 import {
   getAllowedMoves, isAllowed, edgeDirection, mirrorNodes, moves, type Board, type Edge
 } from './gameplay';

--- a/src/components/games/totem-poles/triangular-grid-ropes-10/bot-strategy.ts
+++ b/src/components/games/totem-poles/triangular-grid-ropes-10/bot-strategy.ts
@@ -10,7 +10,7 @@ import {
   type Edge,
   type Moves
 } from './gameplay';
-import type { BotStrategy } from '../../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 
 type Bot = BotStrategy<Board, Moves>
 

--- a/src/components/games/totem-poles/triangular-grid-ropes-10/gameplay.spec.ts
+++ b/src/components/games/totem-poles/triangular-grid-ropes-10/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { isAllowed, moves, type Board } from './gameplay';
-import { makeCtx } from '../../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 //    0
 //   1 2

--- a/src/components/games/totem-poles/triangular-grid-ropes-10/gameplay.ts
+++ b/src/components/games/totem-poles/triangular-grid-ropes-10/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { every, range, last, uniqWith, isEqual, cloneDeep } from 'lodash';
 
 //    0

--- a/src/components/games/totem-poles/triangular-grid-ropes-10/triangular-grid-ropes-10.tsx
+++ b/src/components/games/totem-poles/triangular-grid-ropes-10/triangular-grid-ropes-10.tsx
@@ -4,7 +4,7 @@ import {
   type BoardClientProps,
   GameBoard,
   useHoverPreview
-} from '../../../strategy-game-factory';
+} from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { getAllowedSuperset, moves, vertices, type Board } from './gameplay';
 

--- a/src/components/games/totem-poles/triangular-grid-ropes-15/bot-strategy.spec.ts
+++ b/src/components/games/totem-poles/triangular-grid-ropes-15/bot-strategy.spec.ts
@@ -2,7 +2,7 @@ import { sample } from 'lodash';
 import { getAllowedMoves, getAllowedSuperset, type Board, type Edge } from './gameplay';
 import { findWinningMove } from './solver';
 import { smartBotStrategy } from './bot-strategy';
-import { botNextMoveArgs, makeCtx } from '../../../../test-utils';
+import { botNextMoveArgs, makeCtx } from 'test-utils';
 
 // Play a full game. Player 0 is the opponent, player 1 is the smart bot (the
 // second player, who has the winning strategy). Returns the index of the player

--- a/src/components/games/totem-poles/triangular-grid-ropes-15/bot-strategy.ts
+++ b/src/components/games/totem-poles/triangular-grid-ropes-15/bot-strategy.ts
@@ -1,7 +1,7 @@
 import { sample } from 'lodash';
 import { getAllowedMoves, type Board, type Moves } from './gameplay';
 import { findWinningMove } from './solver';
-import type { BotStrategy } from '../../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 
 type Bot = BotStrategy<Board, Moves>
 

--- a/src/components/games/totem-poles/triangular-grid-ropes-15/gameplay.spec.ts
+++ b/src/components/games/totem-poles/triangular-grid-ropes-15/gameplay.spec.ts
@@ -7,7 +7,7 @@ import {
   moves,
   vertices
 } from './gameplay';
-import { makeCtx } from '../../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 describe('15 totem poles geometry', () => {
   it('has 15 poles arranged in 5 rows', () => {

--- a/src/components/games/totem-poles/triangular-grid-ropes-15/gameplay.ts
+++ b/src/components/games/totem-poles/triangular-grid-ropes-15/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { every, range, last, uniqWith, isEqual, cloneDeep } from 'lodash';
 
 // 15 totem poles: same game as `triangular-grid-ropes` (10 poles) but on a

--- a/src/components/games/totem-poles/triangular-grid-ropes-15/triangular-grid-ropes-15.tsx
+++ b/src/components/games/totem-poles/triangular-grid-ropes-15/triangular-grid-ropes-15.tsx
@@ -4,7 +4,7 @@ import {
   type BoardClientProps,
   GameBoard,
   useHoverPreview
-} from '../../../strategy-game-factory';
+} from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { getAllowedSuperset, moves, vertices, type Board } from './gameplay';
 

--- a/src/components/games/triangle-circle-game/board-client.tsx
+++ b/src/components/games/triangle-circle-game/board-client.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 import { GameBoard, type BoardClientProps, useHoverPreview } from 'strategy-game-factory';
 import { BOARD_OUTLINE, EDGES, TRIANGLES, type Edge } from './geometry';
 import { type Board } from './gameplay';

--- a/src/components/games/triangle-circle-game/board-client.tsx
+++ b/src/components/games/triangle-circle-game/board-client.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from '../../../language';
-import { GameBoard, type BoardClientProps, useHoverPreview } from '../../strategy-game-factory';
+import { GameBoard, type BoardClientProps, useHoverPreview } from 'strategy-game-factory';
 import { BOARD_OUTLINE, EDGES, TRIANGLES, type Edge } from './geometry';
 import { type Board } from './gameplay';
 

--- a/src/components/games/triangle-circle-game/gameplay.spec.ts
+++ b/src/components/games/triangle-circle-game/gameplay.spec.ts
@@ -16,7 +16,7 @@ import {
   shadedCount,
   type Board
 } from './gameplay';
-import { makeCtx, moveValidator } from '../../../test-utils';
+import { makeCtx, moveValidator } from 'test-utils';
 
 const isShadeAllowed = moveValidator(moves.shadeEdge, makeCtx({ currentPlayer: LINE }));
 const isCirclePlacementAllowed = moveValidator(moves.placeCircle, makeCtx({ currentPlayer: CIRCLE }));

--- a/src/components/games/triangle-circle-game/gameplay.ts
+++ b/src/components/games/triangle-circle-game/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { EDGES, TRIANGLES, TRIANGLE_COUNT, EDGE_COUNT } from './geometry';
 
 // Board state. `edges[e]` is true once the line player has shaded edge e;

--- a/src/components/games/triangle-circle-game/strategy/bot-strategy.ts
+++ b/src/components/games/triangle-circle-game/strategy/bot-strategy.ts
@@ -15,7 +15,7 @@ import {
 } from '../gameplay';
 import { OPENING_EDGES, isLineTurnWon, marchEdges, winningPairHeatEdges } from './forced-win';
 import { makeMoveEvaluator } from './search';
-import type { BotStrategy } from '../../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 
 type Bot = BotStrategy<Board, Moves>
 

--- a/src/components/games/triangle-circle-game/strategy/spec-helpers.ts
+++ b/src/components/games/triangle-circle-game/strategy/spec-helpers.ts
@@ -1,6 +1,6 @@
 import { type Board, applyShade, applyCircle } from '../gameplay';
 import { botNextMove, makeCtx } from 'test-utils';
-import type { BotStrategy } from '../../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 
 // Ask a bot for one turn and report what it named, applying the move so tests
 // can inspect the resulting board too.

--- a/src/components/games/triangle-circle-game/strategy/spec-helpers.ts
+++ b/src/components/games/triangle-circle-game/strategy/spec-helpers.ts
@@ -1,5 +1,5 @@
 import { type Board, applyShade, applyCircle } from '../gameplay';
-import { botNextMove, makeCtx } from '../../../../test-utils';
+import { botNextMove, makeCtx } from 'test-utils';
 import type { BotStrategy } from '../../../strategy-game-factory';
 
 // Ask a bot for one turn and report what it named, applying the move so tests

--- a/src/components/games/triangle-circle-game/triangle-circle-game.tsx
+++ b/src/components/games/triangle-circle-game/triangle-circle-game.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory } from '../../strategy-game-factory';
+import { strategyGameFactory } from 'strategy-game-factory';
 import { BoardClient } from './board-client';
 import { LINE, generateStartBoard, moves } from './gameplay';
 import { smartBotStrategy, randomBotStrategy } from './strategy/bot-strategy';

--- a/src/components/games/triangle-coloring/bot-strategy.ts
+++ b/src/components/games/triangle-coloring/bot-strategy.ts
@@ -1,4 +1,4 @@
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import { sample, shuffle } from 'lodash';
 import { getAllowedMoves, withTriangleColored, type Board, type Moves } from './gameplay';
 

--- a/src/components/games/triangle-coloring/gameplay.spec.ts
+++ b/src/components/games/triangle-coloring/gameplay.spec.ts
@@ -1,6 +1,6 @@
 import { range } from 'lodash';
 import { moves, isColoringAllowed } from './gameplay';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
 

--- a/src/components/games/triangle-coloring/gameplay.ts
+++ b/src/components/games/triangle-coloring/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { range, cloneDeep } from 'lodash';
 
 export const [ALLOWED, COLORED, FORBIDDEN] = [1 as const, 2 as const, 3 as const];

--- a/src/components/games/triangle-coloring/triangle-coloring.tsx
+++ b/src/components/games/triangle-coloring/triangle-coloring.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { range } from 'lodash';
 import { ALLOWED, COLORED, FORBIDDEN, moves, triangles, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';

--- a/src/components/games/twelve-squares/bot-strategy.ts
+++ b/src/components/games/twelve-squares/bot-strategy.ts
@@ -1,4 +1,4 @@
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import { random, sample } from 'lodash';
 import { isValidStep, type Board, type Moves } from './gameplay';
 

--- a/src/components/games/twelve-squares/gameplay.spec.ts
+++ b/src/components/games/twelve-squares/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { isValidStep, moves } from './gameplay';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
 

--- a/src/components/games/twelve-squares/gameplay.ts
+++ b/src/components/games/twelve-squares/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
 export type Board = { left: number, right: number }
 

--- a/src/components/games/twelve-squares/twelve-squares.tsx
+++ b/src/components/games/twelve-squares/twelve-squares.tsx
@@ -1,4 +1,4 @@
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { range } from 'lodash';
 import { ChessBishopSvg } from '../chess-bishops/chess-bishop-svg';
 import { generateStartBoard, moves, type Board } from './gameplay';

--- a/src/components/games/two-of-three-takeaway/bot-strategy.ts
+++ b/src/components/games/two-of-three-takeaway/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { sample } from 'lodash';
-import type { BotStrategy } from '../../strategy-game-factory';
+import type { BotStrategy } from 'strategy-game-factory';
 import { applyMove, getLegalMoves, isTerminal, type Board, type Move, type Moves } from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>

--- a/src/components/games/two-of-three-takeaway/gameplay.spec.ts
+++ b/src/components/games/two-of-three-takeaway/gameplay.spec.ts
@@ -8,7 +8,7 @@ import {
   moves,
   type Board
 } from './gameplay';
-import { makeCtx } from '../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 describe('two-of-three-takeaway gameplay', () => {
   describe('move mechanics', () => {

--- a/src/components/games/two-of-three-takeaway/gameplay.ts
+++ b/src/components/games/two-of-three-takeaway/gameplay.ts
@@ -1,4 +1,4 @@
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 import { random } from 'lodash';
 
 // Chips in each of the three piles. The total is always even (it starts even

--- a/src/components/games/two-of-three-takeaway/two-of-three-takeaway.tsx
+++ b/src/components/games/two-of-three-takeaway/two-of-three-takeaway.tsx
@@ -1,7 +1,7 @@
 import { range } from 'lodash';
 import {
   strategyGameFactory, useMoveScopedState, type BoardClientProps, GameBoard
-} from '../../strategy-game-factory';
+} from 'strategy-game-factory';
 import { useTranslation } from '../../../language';
 import { generateStartBoard, moves, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';

--- a/src/components/games/two-of-three-takeaway/two-of-three-takeaway.tsx
+++ b/src/components/games/two-of-three-takeaway/two-of-three-takeaway.tsx
@@ -2,7 +2,7 @@ import { range } from 'lodash';
 import {
   strategyGameFactory, useMoveScopedState, type BoardClientProps, GameBoard
 } from 'strategy-game-factory';
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 import { generateStartBoard, moves, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 

--- a/src/components/overview/filters/filters.tsx
+++ b/src/components/overview/filters/filters.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode } from 'react';
 import { every } from 'lodash';
 import { gameList, categories, iconKeys, type Category, type GameList, type IconKey } from '../../games/gameList';
-import { useTranslation, type I18nString } from '../../../language';
+import { useTranslation, type I18nString } from 'language';
 import { GameIcon, iconLabels } from '../game-icons';
 
 // Keep only games matching at least one of the selected categories. An empty

--- a/src/components/overview/game-icons.tsx
+++ b/src/components/overview/game-icons.tsx
@@ -1,6 +1,6 @@
 import type { FC, SVGProps } from 'react';
 import type { IconKey } from '../games/gameList';
-import type { I18nString } from '../../language';
+import type { I18nString } from 'language';
 import { ScissorSvg } from '../games/shared/scissor-svg';
 
 // Small, self-contained, monochrome icons for the overview cards. Everything is

--- a/src/components/overview/game-list/collapsible-section.tsx
+++ b/src/components/overview/game-list/collapsible-section.tsx
@@ -1,5 +1,5 @@
 import { useId, useState, type ReactNode } from 'react';
-import { useTranslation, type I18nNode } from '../../../language';
+import { useTranslation, type I18nNode } from 'language';
 
 // Persist each section's open/closed state for the tab session, so it survives
 // navigating to a game page and back (which unmounts the overview). sessionStorage

--- a/src/components/overview/game-list/game-card.tsx
+++ b/src/components/overview/game-list/game-card.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router';
 import type { GameEntry, Category } from '../../games/gameList';
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 import { GameIcon } from '../game-icons';
 
 const chipBase = 'rounded-full drop-shadow-sm px-2 py-0.5 whitespace-nowrap bg-surface-elevated';

--- a/src/components/overview/game-list/sections.tsx
+++ b/src/components/overview/game-list/sections.tsx
@@ -1,6 +1,6 @@
 import { orderBy } from 'lodash';
 import { gameList, type Category, type GameList } from '../../games/gameList';
-import type { I18nNode } from '../../../language';
+import type { I18nNode } from 'language';
 import { CollapsibleSection } from './collapsible-section';
 import { GameCard } from './game-card';
 

--- a/src/components/overview/overview.tsx
+++ b/src/components/overview/overview.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { gameList, type Category, type IconKey } from '../games/gameList';
-import { useTranslation, LanguageSelector, type I18nNode } from '../../language';
+import { useTranslation, LanguageSelector, type I18nNode } from 'language';
 import { ThemeSwitcher } from '../../theme';
 import {
   FilterToggle, CategoryFilter, IconFilter, filterByCategories, filterByIcons

--- a/src/components/strategy-game-factory/game-parts/common/cta-text.spec.ts
+++ b/src/components/strategy-game-factory/game-parts/common/cta-text.spec.ts
@@ -1,5 +1,5 @@
 import { getCtaText } from './cta-text';
-import { makeCtx } from '../../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 describe('getCtaText', () => {
   describe('vsHuman mode', () => {

--- a/src/components/strategy-game-factory/game-parts/common/cta-text.ts
+++ b/src/components/strategy-game-factory/game-parts/common/cta-text.ts
@@ -1,4 +1,4 @@
-import type { I18nString } from '../../../../language';
+import type { I18nString } from 'language';
 import type { Ctx } from '../../types';
 
 export const getCtaText = ({

--- a/src/components/strategy-game-factory/game-parts/common/game-controls.tsx
+++ b/src/components/strategy-game-factory/game-parts/common/game-controls.tsx
@@ -1,5 +1,5 @@
 import { useId } from 'react';
-import { useTranslation } from '../../../../language';
+import { useTranslation } from 'language';
 import type { Variant, Mode } from '../../types';
 
 // Radios sharing a `name` form one native group, and the browser keeps exactly

--- a/src/components/strategy-game-factory/game-parts/game-end-dialog.tsx
+++ b/src/components/strategy-game-factory/game-parts/game-end-dialog.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Dialog, DialogPanel, DialogTitle, Description } from '@headlessui/react';
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 import { ModeSelector, DifficultySelector } from './common/game-controls';
 import { getCtaText } from './common/cta-text';
 import type { Ctx, Variant, Mode } from '../types';

--- a/src/components/strategy-game-factory/game-parts/game-footer.tsx
+++ b/src/components/strategy-game-factory/game-parts/game-footer.tsx
@@ -1,5 +1,5 @@
 import { useLocation } from 'react-router';
-import { useTranslation, LanguageSelector } from '../../../language';
+import { useTranslation, LanguageSelector } from 'language';
 import { ThemeSwitcher } from '../../../theme';
 import { gameList } from '../../games/gameList';
 

--- a/src/components/strategy-game-factory/game-parts/game-header.tsx
+++ b/src/components/strategy-game-factory/game-parts/game-header.tsx
@@ -1,5 +1,5 @@
 import { Link, useLocation } from 'react-router';
-import { useTranslation, LanguageSelector } from '../../../language';
+import { useTranslation, LanguageSelector } from 'language';
 import { ThemeSwitcher } from '../../../theme';
 import { gameList } from '../../games/gameList';
 

--- a/src/components/strategy-game-factory/game-parts/game-rule.tsx
+++ b/src/components/strategy-game-factory/game-parts/game-rule.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/react';
-import { useTranslation } from '../../../language';
+import { useTranslation } from 'language';
 
 export const GameRule = ({ ruleDescription }: { ruleDescription: React.ReactNode }) => {
   const { t } = useTranslation();

--- a/src/components/strategy-game-factory/game-parts/game-sidebar/game-sidebar.spec.tsx
+++ b/src/components/strategy-game-factory/game-parts/game-sidebar/game-sidebar.spec.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { GameSidebar, type SidebarMoves } from './game-sidebar';
 import type { Ctx } from '../../types';
-import { makeCtx } from '../../../../test-utils';
+import { makeCtx } from 'test-utils';
 
 beforeAll(() => {
   const { unmount } = renderSidebar();

--- a/src/components/strategy-game-factory/game-parts/game-sidebar/game-sidebar.tsx
+++ b/src/components/strategy-game-factory/game-parts/game-sidebar/game-sidebar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Input } from '@headlessui/react';
-import { useTranslation, type I18nString } from '../../../../language';
+import { useTranslation, type I18nString } from 'language';
 import { ModeSelector, DifficultySelector } from '../common/game-controls';
 import { getCtaText } from '../common/cta-text';
 import type { Ctx, Mode, Variant } from '../../types';

--- a/src/components/strategy-game-factory/strategy-game-factory.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.tsx
@@ -5,7 +5,7 @@ import { GameRule } from './game-parts/game-rule';
 import { GameSidebar } from './game-parts/game-sidebar/game-sidebar';
 import { GameEndDialog } from './game-parts/game-end-dialog';
 import { mapValues, isEqual } from 'lodash';
-import { useTranslation, type TranslatableNode, type I18nString } from '../../language';
+import { useTranslation, type TranslatableNode, type I18nString } from 'language';
 import { useLocation } from 'react-router';
 import { useGameStats } from './hooks/use-game-stats';
 import { trackEvent } from '../../tracking';

--- a/src/components/strategy-game-factory/types.ts
+++ b/src/components/strategy-game-factory/types.ts
@@ -1,4 +1,4 @@
-import type { I18nString, TranslatableNode } from '../../language';
+import type { I18nString, TranslatableNode } from 'language';
 
 export type Phase = 'roleSelection' | 'play' | 'gameEnd'
 export type Mode = 'vsComputer' | 'vsHuman'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,9 @@
     "noEmit": true,
     "resolveJsonModule": true,
     "paths": {
-      // Mirrors the alias in vite.config.js — keep the two in sync.
-      "test-utils": ["./src/test-utils.ts"]
+      // Mirrors the aliases in vite.config.js — keep the two in sync.
+      "test-utils": ["./src/test-utils.ts"],
+      "strategy-game-factory": ["./src/components/strategy-game-factory/index.ts"]
     },
     "skipLibCheck": true,
     "types": ["vitest/globals", "vite/client"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,10 @@
     "noImplicitAny": false,
     "noEmit": true,
     "resolveJsonModule": true,
+    "paths": {
+      // Mirrors the alias in vite.config.js — keep the two in sync.
+      "test-utils": ["./src/test-utils.ts"]
+    },
     "skipLibCheck": true,
     "types": ["vitest/globals", "vite/client"]
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "paths": {
       // Mirrors the aliases in vite.config.js — keep the two in sync.
       "test-utils": ["./src/test-utils.ts"],
-      "strategy-game-factory": ["./src/components/strategy-game-factory/index.ts"]
+      "strategy-game-factory": ["./src/components/strategy-game-factory/index.ts"],
+      "language": ["./src/language/index.ts"]
     },
     "skipLibCheck": true,
     "types": ["vitest/globals", "vite/client"]

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,12 +9,22 @@ export default defineConfig(() => ({
     // visualizer({ open: true })
   ],
   resolve: {
-    alias: {
-      // Specs sit three or four folders deep under src/, so without this every
-      // one of them reaches its shared helpers through a wall of `../`.
-      // Mirrored in tsconfig.json's `paths` — keep the two in sync.
-      'test-utils': fileURLToPath(new URL('./src/test-utils.ts', import.meta.url))
-    }
+    // Games and their specs sit two to four folders deep under src/, so without
+    // these every one of them reaches a shared module through a wall of `../` —
+    // a depth that shifts whenever a game grows a variant subfolder.
+    // Mirrored in tsconfig.json's `paths` — keep the two in sync.
+    // The patterns are anchored: `strategy-game-factory/engine/…` deliberately
+    // does not resolve, since games import through the barrel only.
+    alias: [
+      {
+        find: /^test-utils$/,
+        replacement: fileURLToPath(new URL('./src/test-utils.ts', import.meta.url))
+      },
+      {
+        find: /^strategy-game-factory$/,
+        replacement: fileURLToPath(new URL('./src/components/strategy-game-factory/index.ts', import.meta.url))
+      }
+    ]
   },
   base: '/',
   build: {

--- a/vite.config.js
+++ b/vite.config.js
@@ -23,6 +23,10 @@ export default defineConfig(() => ({
       {
         find: /^strategy-game-factory$/,
         replacement: fileURLToPath(new URL('./src/components/strategy-game-factory/index.ts', import.meta.url))
+      },
+      {
+        find: /^language$/,
+        replacement: fileURLToPath(new URL('./src/language/index.ts', import.meta.url))
       }
     ]
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 // import { visualizer } from 'rollup-plugin-visualizer';
@@ -7,6 +8,14 @@ export default defineConfig(() => ({
     react()
     // visualizer({ open: true })
   ],
+  resolve: {
+    alias: {
+      // Specs sit three or four folders deep under src/, so without this every
+      // one of them reaches its shared helpers through a wall of `../`.
+      // Mirrored in tsconfig.json's `paths` — keep the two in sync.
+      'test-utils': fileURLToPath(new URL('./src/test-utils.ts', import.meta.url))
+    }
+  },
   base: '/',
   build: {
     rollupOptions: {


### PR DESCRIPTION
Closes the §7 review item "No path alias for `test-utils`", and applies the same treatment to the other two shared modules reached across folders.

421 imports named a shared module by a wall of `../` whose depth was nothing but how deep the importing file happens to sit — `../../strategy-game-factory` from a game folder, `../../../` from a variant subfolder, and the same split on `test-utils` and `language`. Adding a variant subfolder to a game silently changes every one of them.

```diff
-import { makeCtx } from '../../../test-utils';
-import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
-import { useTranslation } from '../../../language';
+import { makeCtx } from 'test-utils';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
+import { useTranslation } from 'language';
```

One commit per alias, so an unwanted one can be dropped without unpicking the others: `test-utils` (107 imports), `strategy-game-factory` (262), `language` (52).

## What changed

- `vite.config.js` — `resolve.alias` maps each name to its entry point, as absolute paths via `fileURLToPath` (Vite requires absolute paths for filesystem aliases).
- `tsconfig.json` — the mirroring `paths` entries so `tsc` resolves them too. Each side carries a comment pointing at the other.
- 421 imports rewritten. The review counted 97 `test-utils` imports; the real figure is 107 — 66 at three levels, 41 at four.
- `AGENTS.md` / `README.md` — the barrel, testing and i18n sections name the import form so new games and specs follow it.
- `docs/project-review-2026-08.md` — item struck through with ✅, matching the other resolved bullets.

**Every pattern is anchored** (`/^strategy-game-factory$/`, and `paths` keys with no `*`), so `strategy-game-factory/engine/…` does not resolve at all. The no-deep-imports rule AGENTS.md already states is now enforced by resolution instead of by convention. Verified both ways: a deep import fails under `tsc` (`TS2307`) and under Vite (`Cannot find package`).

What stays relative is what is genuinely local: imports within `src/language/`, imports of `strategy-game-factory.tsx` from *inside* the factory folder (they name the module, not the barrel — aliasing them would silently redirect five files to a different target), and `src/test-utils.ts`'s own `./components/…` imports, one of which is a deep import of `engine/bot-turn` that the anchored alias intentionally cannot express.

## Verification

`tsc --noEmit` clean · `eslint` clean · `vitest run` 1709 tests / 181 files pass · `vite build` succeeds, emitting **byte-identical chunks** (same content hashes as before the change), so `manualChunks` still splits on resolved paths exactly as it did.

Also probed directly, since the alias could plausibly have defeated it: the `no-restricted-imports` guard that keeps `gameplay.ts` framework-free still fires on the bare specifier — `**/strategy-game-factory` matches `strategy-game-factory` — and still lets `import type` through. (No React-free module imports the `language` barrel, so the same question does not arise there.)

## Rebased on the two commits that landed meanwhile

`main` moved to #436 (`resolveVariants`) and #439 (`reportUnexpectedState`) while this was open, and both touched import blocks rewritten here — four conflicts, all in the same import lines, plus `docs/project-review-2026-08.md` where #439 struck through the bullet next to this one. Merged and resolved by taking main's content and re-applying the alias; the new `games/shared/unexpected-state.ts` needed no rewrite of its own.

## Note on the environment, not this diff

`npm ci` fails locally on this container: `package-lock.json` reports out of sync with `package.json` (`Missing: @emnapi/core@1.11.3`, `@emnapi/runtime@1.11.3`). This turned out to be a local artifact — the container runs Node 22 / npm 10 against an `engines` field pinning Node 24, and CI's `node:24.11.1` installs cleanly. Nothing to fix here, noted only in case it bites someone else on an older npm.