### PR TITLE
Throw in dev on a game bot's "unexpected state" instead of console.error

### DIFF
--- a/docs/project-review-2026-08.md
+++ b/docs/project-review-2026-08.md
@@ -299,9 +299,16 @@ rules specs relative to module size.
   no npm cache~~ ✅ (#401); the two workflows still duplicate their build block
   verbatim.
 - No path alias for `test-utils` — 97 specs import `../../../test-utils`.
-- 7 `console.*` calls in shipped game code (`triangular-grid-ropes-10`,
+- ~~7 `console.*` calls in shipped game code (`triangular-grid-ropes-10`,
   `stones-remove-one-not-twice-from-left`, `cube-coloring`) as "unexpected
-  state" fallbacks — arguably should throw in dev like the engine does.
+  state" fallbacks — arguably should throw in dev like the engine does.~~ ✅
+  Four of the seven were the game fallbacks (the other three are the engine's
+  own, which already throw in dev); they now go through
+  `games/shared/unexpected-state.ts`, which makes the engine's trade — throw in
+  dev, warn in prod and let the caller take its fallback. `cube-coloring`'s had
+  no fallback to take: it returned `undefined` into a `!`, so in prod it
+  crashed on the next line rather than degrading; the bot now names no move,
+  which the engine already handles.
 - ~~No SessionStart hook for web/agent sessions~~ ✅ (#399): `npm ci` now runs
   at session start, guarded by `CLAUDE_CODE_REMOTE` so local sessions are
   unaffected.

--- a/src/components/games/cube-coloring/bot-strategy.ts
+++ b/src/components/games/cube-coloring/bot-strategy.ts
@@ -1,6 +1,7 @@
 import { difference, range, shuffle, sample } from 'lodash';
 import { isAllowedStep, isColored, neighbours, colors, type Board, type Moves } from './gameplay';
 import type { BotStrategy } from '../../strategy-game-factory';
+import { reportUnexpectedState } from '../shared/unexpected-state';
 
 type Bot = BotStrategy<Board, Moves>
 
@@ -18,10 +19,14 @@ export const randomBotStrategy: Bot = ({ board }) => {
 };
 
 export const smartBotStrategy: Bot = ({ board, ctx }) => {
-  const { vertex, color } = ctx.chosenRoleIndex === 0
-    ? makeOptimalStepAsSecond(board)!
+  const step = ctx.chosenRoleIndex === 0
+    ? makeOptimalStepAsSecond(board)
     : makeOptimalStepAsFirst(board);
-  return { move: 'colorVertex', args: [{ vertex, color }] };
+  // Only reachable after the unexpected state below: with no colourable vertex
+  // left there is no move to name, and naming none stalls the bot rather than
+  // crashing on an undefined step.
+  if (!step) return [];
+  return { move: 'colorVertex', args: [step] };
 };
 
 const makeOptimalStepAsFirst = (board: Board) => {
@@ -75,7 +80,8 @@ const makeOptimalStepAsSecond = (board: Board) => {
     }
   }
   // if all vertices are banned we should have a game end
-  console.error('This state should not happen');
+  reportUnexpectedState('cube-coloring: no colourable vertex left but the game has not ended');
+  return undefined;
 };
 
 const getMissingColors = (board: Board, vertex) => {

--- a/src/components/games/shared/unexpected-state.spec.ts
+++ b/src/components/games/shared/unexpected-state.spec.ts
@@ -1,0 +1,20 @@
+import { reportUnexpectedState } from './unexpected-state';
+
+describe('reportUnexpectedState', () => {
+  it('throws in dev so the bug surfaces where it happened', () => {
+    expect(() => reportUnexpectedState('cube-coloring: every vertex is banned'))
+      .toThrow('cube-coloring: every vertex is banned');
+  });
+
+  describe('in production (import.meta.env.DEV = false)', () => {
+    beforeEach(() => { vi.stubEnv('DEV', false); });
+    afterEach(() => { vi.unstubAllEnvs(); });
+
+    it('warns and returns so the caller can take its fallback', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      expect(() => reportUnexpectedState('cube-coloring: every vertex is banned')).not.toThrow();
+      expect(warn).toHaveBeenCalledWith('cube-coloring: every vertex is banned');
+      warn.mockRestore();
+    });
+  });
+});

--- a/src/components/games/shared/unexpected-state.ts
+++ b/src/components/games/shared/unexpected-state.ts
@@ -1,0 +1,10 @@
+// A branch a game's strategy holds to be unreachable — every vertex banned
+// while the game has not ended, a mirror move the symmetry argument says must
+// be free. Reaching one is a bug in the strategy, not a position to handle, so
+// this makes the same trade the engine makes for an illegal move: throw in dev
+// so the bug is loud and located, warn in prod and let the caller take its
+// fallback, since a suboptimal or stalled bot beats a white-screened game.
+export const reportUnexpectedState = (message: string): void => {
+  if (import.meta.env.DEV) throw new Error(message);
+  console.warn(message);
+};

--- a/src/components/games/stones-remove-one-not-twice-from-left/bot-strategy.ts
+++ b/src/components/games/stones-remove-one-not-twice-from-left/bot-strategy.ts
@@ -1,6 +1,7 @@
 import type { BotStrategy } from '../../strategy-game-factory';
 import { random } from 'lodash';
 import { type Board, type Moves } from './gameplay';
+import { reportUnexpectedState } from '../shared/unexpected-state';
 
 type Bot = BotStrategy<Board, Moves>
 
@@ -18,6 +19,14 @@ export const smartBotStrategy: Bot = ({ board, ctx }) => {
   return { move: 'removeStone', args: [botMove] };
 };
 
+// smartBotStrategy answers a left-restricted mover before ever consulting the
+// search, and the one recursive call below hands the restriction to the mover
+// only in an odd-odd position, which neither branch guarded by this message
+// can reach. So a restricted mover here means the caller or the recursion is
+// wrong, not that the game produced the position.
+const restrictedMoverMessage =
+  'stones-remove-one-not-twice-from-left: the mover is left-restricted in getOptimalMove';
+
 // return undefined if there is no winning move
 const getOptimalMove = (board, ctx) => {
   const otherPlayer = 1 - ctx.currentPlayer;
@@ -27,7 +36,7 @@ const getOptimalMove = (board, ctx) => {
     if (!board.leftRestriction[otherPlayer]) {
       return undefined;
     } else if (board.leftRestriction[ctx.currentPlayer]) {
-      console.error('Unexpected internal state, please report.')
+      reportUnexpectedState(restrictedMoverMessage);
       return undefined;
     } else {
       /*
@@ -63,7 +72,7 @@ const getOptimalMove = (board, ctx) => {
       if (!board.leftRestriction[ctx.currentPlayer]) {
         return 0;
       } else {
-        console.error('Unexpected internal state, please report.')
+        reportUnexpectedState(restrictedMoverMessage);
         return undefined;
       }
     } else {

--- a/src/components/games/totem-poles/triangular-grid-ropes-10/bot-strategy.ts
+++ b/src/components/games/totem-poles/triangular-grid-ropes-10/bot-strategy.ts
@@ -11,6 +11,7 @@ import {
   type Moves
 } from './gameplay';
 import type { BotStrategy } from '../../../strategy-game-factory';
+import { reportUnexpectedState } from '../../shared/unexpected-state';
 
 type Bot = BotStrategy<Board, Moves>
 
@@ -41,7 +42,12 @@ export const smartBotStrategy: Bot = ({ board, ctx }) => {
           to: mirrorNodes[symDir][lastMove.to]
         };
         if (!isAllowed(board, mirrorOfLastMove)) {
-          console.error('Unexpected state, falling back');
+          // The position is symmetric before the opponent moves, so the mirror
+          // of their move is free by construction — a taken one means the
+          // mirroring bookkeeping is wrong, not that the game reached it.
+          reportUnexpectedState(
+            `triangular-grid-ropes-10: mirror of ${JSON.stringify(lastMove)} already taken`
+          );
           return { move: 'stretchRope', args: [sample(allowedMoves)!] };
         }
         return { move: 'stretchRope', args: [mirrorOfLastMove] };


### PR DESCRIPTION
Closes the §7 review item: *"7 `console.*` calls in shipped game code
(`triangular-grid-ropes-10`, `stones-remove-one-not-twice-from-left`,
`cube-coloring`) as 'unexpected state' fallbacks — arguably should throw in dev
like the engine does."*

Four of the seven were the game fallbacks. The other three are the engine's own
sites, which already throw in dev — so the review's count was of `console.*` in
`src/`, not of things to change.

## The change

Each of the four reported a state the strategy holds to be unreachable, then
carried on. That is exactly the engine's situation for an illegal move, and the
engine makes the opposite trade — throw in dev so the bug is loud and located,
warn in prod and fail safe. The bots now make it too, through one helper:

```ts
// src/components/games/shared/unexpected-state.ts
export const reportUnexpectedState = (message: string): void => {
  if (import.meta.env.DEV) throw new Error(message);
  console.warn(message);
};
```

**Why `games/shared/` and not the engine.** The barrel pulls in React, so a bot
value-importing from it would drag React into the half a competition server
ships (#313) — today every bot's barrel import is type-only. Deep-importing
`engine/` would break the no-deep-imports convention. `games/shared/**/*.ts` is
already lint-enforced framework-free and is where games' shared non-UI code
lives, so it fits without a new rule.

Each call site gets a message naming the game and the invariant, replacing
three variants of "this should not happen".

## `cube-coloring` needed more than a swap

Its fallback did not fall back. `makeOptimalStepAsSecond` fell off the end
returning `undefined`, into:

```ts
const { vertex, color } = ctx.chosenRoleIndex === 0
  ? makeOptimalStepAsSecond(board)!
  : makeOptimalStepAsFirst(board);
```

so in prod it logged and then crashed on the next line destructuring
`undefined` — the console.error bought nothing. The bot now names no move,
which the engine already handles ("botStrategy named no move to play"): a
stalled bot instead of a white screen.

## Verifying the branches are actually dead

A dev throw is only safe if nothing reaches it, so I checked before making them
throw, with a throwaway spec driving `runMatch`:

| game | matches | coverage |
|---|---|---|
| `cube-coloring` | 1500 | smart/random/smart-vs-smart, both seats |
| `triangular-grid-ropes-10` | 500 | bot in seat 0 — the only one of its two paths with such a branch; the other is the deep search |
| `stones-remove-one-not-twice-from-left` | 10000 | both variants' start boards, both seats |

None reached a branch. The sweep spec was not committed — it is slow and its
value was one-off; `plays-to-an-end.spec.ts` and the games' own bot specs keep
exercising the code from here.

## Tests

`unexpected-state.spec.ts` covers both modes, prod via `vi.stubEnv('DEV',
false)` — the pattern `strategy-game-factory.spec.tsx` already uses.

Full suite (181 files, 1709 tests), `eslint src` and `tsc --noEmit` all clean.

## Out of scope, but noticed

`stones-remove-one-not-twice-from-left/bot-strategy.ts:63` reads
`if (board.piles[0] <= (board.piles[0] + 1))` — a pile compared to itself, so
always true. `piles[1] + 1` looks like what was meant. I left it alone: it
changes which moves the bot picks and wants its own change with its own test.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJFVp3VM4z3SAzxiDnhww5)_