### PR TITLE
Pin the turn state with a generic parameter, drop the opaque display botStrategy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,6 +281,35 @@ the name; a game that has not been converted yet keeps compiling.
   remembered during a turn if needed, i.e. to expose it from BoardClient to
   getPlayerStepDescription
 
+**Pinning the turn state.** Left unpinned, `ctx.turnState` is `unknown`, and
+every reader casts. A multi-stage game names the shape instead, next to the
+moves that produce it:
+
+```ts
+// gameplay.ts — the payload only; the engine adds the `| null` every turn
+// starts and ends in
+export type TurnState = { firstSelectedPile: number };
+```
+
+```tsx
+// board-client.tsx — annotating the props is what pins the whole game
+const BoardClient = ({ ctx, setTurnState }: BoardClientProps<Board, TurnState>) => {
+  const { turnState } = ctx;   // TurnState | null, no cast
+```
+
+The factory infers `TTurnState` from the config, so the game file's
+`getPlayerStepDescription` takes `StrategyArgs<Board, TurnState>`, each move's
+meta takes `{ ctx: Ctx<TurnState> }` and its `apply` returns
+`MoveOutcome<Board, TurnState>` — annotate all of them, since inference reads
+every one of those sites and a leftover bare `Ctx` contradicts the rest. A spec
+that builds a ctx names it too: `makeCtx<TurnState>({ … })`. Games with no
+mid-turn state say nothing and keep compiling.
+
+Bots are deliberately left out: a bot is asked again with a fresh `ctx` for
+every move it still owes, so it plans a whole turn rather than reading its own
+half-made selection back. `BotStrategy` therefore stays
+`BotStrategy<Board, Moves>` and sees `turnState` as `unknown`.
+
 **`setTurnState(stage)`** — a `BoardClient`-only prop, for components that keep
 mid-turn UI state in `ctx.turnState`. It is the one path that writes engine
 state without going through a move, deliberately: a selection is not a move, so

--- a/README.md
+++ b/README.md
@@ -260,6 +260,12 @@ by the framework in `ctx`: `currentPlayer`, `isClientMoveAllowed` (guard every
 player interaction with it), `isHumanVsHumanGame`, `chosenRoleIndex`, and
 `turnState` for multi-stage turns. Never modify either in place.
 
+A multi-stage game pins what its `turnState` holds — `export type TurnState` in
+`gameplay.ts`, `BoardClientProps<Board, TurnState>` on the component — and the
+factory infers the rest of the config from there, so nothing has to cast it
+back. See [AGENTS.md § Pinning the turn
+state](AGENTS.md#strategygamefactory-api).
+
 Always pass the current `board` as a move's first argument, including to
 subsequent moves within the same turn. The framework's own state is
 authoritative — it lives in a synchronous store outside React — so the argument

--- a/docs/project-review-2026-08.md
+++ b/docs/project-review-2026-08.md
@@ -152,9 +152,28 @@ rules specs relative to module size.
   render snapshot contrary to the file's own read-the-store doctrine; the
   single `botTimeoutRef` slot shared by bot pacing and `endOfTurnMove`
   (a load-bearing implicit invariant).
-- `types.ts`: `Variant.botStrategy?: unknown` forces `botStrategy!` at the
+- ~~`types.ts`: `Variant.botStrategy?: unknown` forces `botStrategy!` at the
   call site; `Ctx.turnState: unknown` pushes a cast into every multi-stage
-  `BoardClient` — worth a generic parameter.
+  `BoardClient` — worth a generic parameter.~~ ✅ Both done, differently.
+
+  `Ctx` (and with it `MoveOutcome`, `MoveDefinition`, `Gameplay`,
+  `StrategyArgs`, `BoardClientProps`, `CoreState`, the factory) took a
+  `TTurnState = unknown` parameter, naming the *payload* only — the engine adds
+  the `| null` every turn starts and ends in, so a game cannot forget it and
+  `createInitialCoreState` needs no cast. A game pins it by annotating its
+  `BoardClient`, and the factory infers the rest of the config from there; all
+  7 multi-stage games are converted and no longer cast, the other 69 compile
+  untouched. `BotStrategy` is deliberately left unparameterised: a bot is asked
+  again with a fresh `ctx` for each move it still owes, so it never reads its
+  own half-made selection back.
+
+  `Variant.botStrategy` was the display type holding a strategy it never calls,
+  opaque because the display knows no `TBoard`. It is now `hasBotStrategy:
+  boolean`, and `getVariantsForMode` builds the projection field by field
+  instead of spreading the whole variant. The `botStrategy!` at the call site
+  was optionality, not opacity: `runBotTurn` now takes the strategy as a
+  parameter, and `doBotTurn` — which already threw on a missing one — narrows
+  it once.
 - `strategy-game-factory.spec.tsx` is 1050 lines / 16 `describe`s — split by
   concern (undo, validate enforcement, outcome moves, staleness, …).
 - `plays-to-an-end.spec.ts` re-implements the default-variant logic instead of

--- a/src/components/games/coins-in-3-piles/board-client.tsx
+++ b/src/components/games/coins-in-3-piles/board-client.tsx
@@ -1,6 +1,6 @@
 import { range } from 'lodash';
 import { useTranslation } from '../../../language';
-import type { Board } from './gameplay';
+import type { Board, TurnState } from './gameplay';
 import { GameBoard, type BoardClientProps, useHoverPreview } from '../../strategy-game-factory';
 
 const getCoinBgColor = (coinValue) => {
@@ -14,9 +14,9 @@ const getCoinShadowColor = (coinValue) => {
   return 'shadow-yellow-400';
 };
 
-export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
+export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board, TurnState>) => {
   const { t } = useTranslation();
-  const valueOfRemovedCoin = (ctx.turnState as { removedCoinValue: number } | null)?.removedCoinValue ?? null;
+  const valueOfRemovedCoin = ctx.turnState?.removedCoinValue ?? null;
   const { value: validHoveredPile, hoverProps } = useHoverPreview<number>(ctx.moveCount);
 
   const wasCoinAlreadyRemovedInTurn = valueOfRemovedCoin !== null;

--- a/src/components/games/coins-in-3-piles/coins-in-3-piles.tsx
+++ b/src/components/games/coins-in-3-piles/coins-in-3-piles.tsx
@@ -1,11 +1,12 @@
-import { strategyGameFactory } from '../../strategy-game-factory';
+import { strategyGameFactory, type StrategyArgs } from '../../strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { BoardClient } from './board-client';
 import {
-  generateArbitraryStartBoard, generateFixedStartBoard, generateTestStartBoard, moves
+  generateArbitraryStartBoard, generateFixedStartBoard, generateTestStartBoard, moves,
+  type Board, type TurnState
 } from './gameplay';
 
-const getPlayerStepDescription = ({ ctx: { turnState } }) => {
+const getPlayerStepDescription = ({ ctx: { turnState } }: StrategyArgs<Board, TurnState>) => {
   if (turnState !== null) {
     return {
       hu: 'Válassz a visszarakási lehetőségek közül.',

--- a/src/components/games/coins-in-3-piles/gameplay.spec.ts
+++ b/src/components/games/coins-in-3-piles/gameplay.spec.ts
@@ -1,13 +1,12 @@
-import { moves, type Board } from './gameplay';
+import { moves, type Board, type TurnState } from './gameplay';
 import { makeCtx } from '../../../test-utils';
 
 describe('coins-in-3-piles move validators', () => {
-  type TurnState = { removedCoinValue: number } | null;
-  const isRemovalAllowed = (board: Board, turnState: TurnState, value: number) =>
+  const isRemovalAllowed = (board: Board, turnState: TurnState | null, value: number) =>
     moves.removeCoin.validate(board, { ctx: makeCtx({ turnState }) }, value);
-  const isAddAllowed = (board: Board, turnState: TurnState, value: number) =>
+  const isAddAllowed = (board: Board, turnState: TurnState | null, value: number) =>
     moves.addCoin.validate(board, { ctx: makeCtx({ turnState }) }, value);
-  const isPassAllowed = (board: Board, turnState: TurnState) =>
+  const isPassAllowed = (board: Board, turnState: TurnState | null) =>
     moves.passAddition.validate(board, { ctx: makeCtx({ turnState }) });
 
   describe('removeCoin', () => {
@@ -59,7 +58,7 @@ describe('coins-in-3-piles move validators', () => {
 });
 
 describe('coins-in-3-piles move outcomes', () => {
-  const ctx = makeCtx({ currentPlayer: 0 });
+  const ctx = makeCtx<TurnState>({ currentPlayer: 0 });
 
   it('removing a 1-coin ends the turn without a place-back phase', () => {
     expect(moves.removeCoin.apply([2, 5, 7], { ctx }, 1))

--- a/src/components/games/coins-in-3-piles/gameplay.ts
+++ b/src/components/games/coins-in-3-piles/gameplay.ts
@@ -2,6 +2,9 @@ import { cloneDeep, isEqual, random, sample, sum } from 'lodash';
 import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
 
 export type Board = number[]
+// The coin taken in the first half of the turn, while the player decides what
+// (if anything) to place back.
+export type TurnState = { removedCoinValue: number }
 
 // Is the player to move lost against optimal play? Closed-form parity
 // predicate: a turn changes the parity of one pile, or of two when a coin is
@@ -42,9 +45,9 @@ export const generateTestStartBoard = (): Board =>
 
 export const moves = {
   removeCoin: {
-    validate: (board: Board, { ctx }: { ctx: Ctx }, value: number) =>
+    validate: (board: Board, { ctx }: { ctx: Ctx<TurnState> }, value: number) =>
       ctx.turnState === null && value >= 1 && value <= 3 && board[value - 1] > 0,
-    apply: (board: Board, { ctx }: { ctx: Ctx }, value: number): MoveOutcome<Board> => {
+    apply: (board: Board, { ctx }: { ctx: Ctx<TurnState> }, value: number): MoveOutcome<Board, TurnState> => {
       const nextBoard = cloneDeep(board);
       nextBoard[value - 1] -= 1;
       if (value === 1) {
@@ -57,19 +60,19 @@ export const moves = {
     }
   },
   addCoin: {
-    validate: (board: Board, { ctx }: { ctx: Ctx }, value: number) => {
-      const removed = (ctx.turnState as { removedCoinValue: number } | null)?.removedCoinValue;
+    validate: (board: Board, { ctx }: { ctx: Ctx<TurnState> }, value: number) => {
+      const removed = ctx.turnState?.removedCoinValue;
       return removed != null && value >= 1 && value < removed;
     },
-    apply: (board: Board, { ctx }: { ctx: Ctx }, value: number) => {
+    apply: (board: Board, { ctx }: { ctx: Ctx<TurnState> }, value: number) => {
       const nextBoard = cloneDeep(board);
       nextBoard[value - 1] += 1;
       return finishPlaceBack(nextBoard, ctx);
     }
   },
   passAddition: {
-    validate: (board: Board, { ctx }: { ctx: Ctx }) => ctx.turnState !== null,
-    apply: (board: Board, { ctx }: { ctx: Ctx }) => finishPlaceBack(board, ctx)
+    validate: (board: Board, { ctx }: { ctx: Ctx<TurnState> }) => ctx.turnState !== null,
+    apply: (board: Board, { ctx }: { ctx: Ctx<TurnState> }) => finishPlaceBack(board, ctx)
   }
 }
 
@@ -77,7 +80,7 @@ export type Moves = typeof moves
 
 // Shared second half of the place-back phase: whether a coin was added or the
 // player passed, the turn ends the same way.
-function finishPlaceBack(nextBoard: Board, ctx: Ctx): MoveOutcome<Board> {
+function finishPlaceBack(nextBoard: Board, ctx: Ctx<TurnState>): MoveOutcome<Board, TurnState> {
   if (isEqual(nextBoard, [0, 0, 0])) {
     return { nextBoard, nextTurnState: null, gameEnd: { winnerIndex: ctx.currentPlayer! } };
   }

--- a/src/components/games/distinct-squares/five-squares/five-squares.tsx
+++ b/src/components/games/distinct-squares/five-squares/five-squares.tsx
@@ -1,11 +1,12 @@
 import { range } from 'lodash';
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../../strategy-game-factory';
+import {
+  strategyGameFactory, type BoardClientProps, type StrategyArgs, GameBoard
+} from '../../../strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { generateStartBoard, moves, type Board, type TurnState } from './gameplay';
 
-const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
-  const turnState = ctx.turnState as TurnState;
-  const firstPlacedSquareIndex = turnState?.firstPlacedSquareIndex ?? null;
+const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board, TurnState>) => {
+  const firstPlacedSquareIndex = ctx.turnState?.firstPlacedSquareIndex ?? null;
   const showDimmedDisc = ctx.isClientMoveAllowed && firstPlacedSquareIndex !== null;
 
   return (
@@ -36,7 +37,7 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   );
 };
 
-const getPlayerStepDescription = ({ ctx }) => {
+const getPlayerStepDescription = ({ ctx }: StrategyArgs<Board, TurnState>) => {
   if (ctx.currentPlayer === 1 && ctx.turnState === null) {
     return {
       hu: 'Kattints arra a mezőre, ahova az első korongot szeretnéd rakni. (1/2)',

--- a/src/components/games/distinct-squares/five-squares/gameplay.spec.ts
+++ b/src/components/games/distinct-squares/five-squares/gameplay.spec.ts
@@ -1,9 +1,9 @@
-import { moves } from './gameplay';
+import { moves, type TurnState } from './gameplay';
 import { makeCtx } from '../../../../test-utils';
 
 // The game always ends on the tenth square; the second player wins only if the
 // five counts are all distinct by then.
-const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
+const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx<TurnState>({ currentPlayer }) });
 
 describe('five-squares end of game', () => {
   it('gives the game to the second player when the five counts are all distinct', () => {

--- a/src/components/games/distinct-squares/five-squares/gameplay.ts
+++ b/src/components/games/distinct-squares/five-squares/gameplay.ts
@@ -3,7 +3,9 @@ import type { Ctx, MoveOutcome } from '../../../strategy-game-factory';
 import { isPlacementAllowed } from '../gameplay';
 
 export type Board = number[]
-export type TurnState = { firstPlacedSquareIndex: number } | null
+// Where the second player put the first of their two pieces, so the
+// BoardClient can dim it for the rest of the turn.
+export type TurnState = { firstPlacedSquareIndex: number }
 
 export const generateStartBoard = (): Board => {
   const board = Array(5).fill(0);
@@ -14,8 +16,10 @@ export const generateStartBoard = (): Board => {
 
 export const moves = {
   addPiece: {
-    validate: (board: Board, _, pileId: number) => isPlacementAllowed(board, pileId),
-    apply: (board: Board, { ctx }: { ctx: Ctx }, pileId: number): MoveOutcome<Board> => {
+    validate: (board: Board, _: { ctx: Ctx<TurnState> }, pileId: number) => isPlacementAllowed(board, pileId),
+    apply: (
+      board: Board, { ctx }: { ctx: Ctx<TurnState> }, pileId: number
+    ): MoveOutcome<Board, TurnState> => {
       const nextBoard = cloneDeep(board);
       nextBoard[pileId] += 1;
       // The second player places two squares at a time, so on the first half of

--- a/src/components/games/number-pyramid/board-client.tsx
+++ b/src/components/games/number-pyramid/board-client.tsx
@@ -1,9 +1,7 @@
 import { isEqual } from 'lodash';
 import { useTranslation } from '../../../language';
-import { hasActivePair, type Board } from './gameplay';
+import { hasActivePair, type Board, type TurnState } from './gameplay';
 import { GameBoard, type BoardClientProps } from '../../strategy-game-factory';
-
-export type TurnState = { levelIdx: number; slotIdx: number } | null;
 
 const chipBase = 'rounded-lg border-2 py-2 font-bold min-w-10';
 
@@ -29,9 +27,9 @@ const ActiveSlot = ({ value, isSelected, isDisabled, onClick }) => (
   </button>
 );
 
-export const BoardClient = ({ board, ctx, setTurnState, moves }: BoardClientProps<Board>) => {
+export const BoardClient = ({ board, ctx, setTurnState, moves }: BoardClientProps<Board, TurnState>) => {
   const { t } = useTranslation();
-  const turnState = ctx.turnState as TurnState;
+  const { turnState } = ctx;
 
   const handleClick = ({ levelIdx, slotIdx }) => {
     if (!ctx.isClientMoveAllowed) return;

--- a/src/components/games/number-pyramid/gameplay.ts
+++ b/src/components/games/number-pyramid/gameplay.ts
@@ -8,6 +8,8 @@ export type Board = {
   target: number;
   sortedInitial: number[];
 };
+// The first of the two slots a turn combines, while the player picks the second.
+export type TurnState = { levelIdx: number; slotIdx: number };
 
 export const generateStartBoard = (tries = 0): Board => {
   if (tries >= 100) throw new Error('generateStartBoard: too many retries');
@@ -41,12 +43,16 @@ export const generateStartBoard = (tries = 0): Board => {
 
 export const moves = {
   combineTwo: {
-    validate: (board: Board, _, move: { levelIdx: number; indices: number[] }) => isCombineAllowed(board, move),
+    validate: (
+      board: Board,
+      _: { ctx: Ctx<TurnState> },
+      move: { levelIdx: number; indices: number[] }
+    ) => isCombineAllowed(board, move),
     apply: (
       board: Board,
-      { ctx }: { ctx: Ctx },
+      { ctx }: { ctx: Ctx<TurnState> },
       { levelIdx, indices }: { levelIdx: number; indices: number[] }
-    ): MoveOutcome<Board> => {
+    ): MoveOutcome<Board, TurnState> => {
       const { nextBoard, combinedValue } = applyMoveToBoard(board, levelIdx, indices);
 
       // nextTurnState clears the half-made selection the BoardClient parked in

--- a/src/components/games/number-pyramid/number-pyramid.tsx
+++ b/src/components/games/number-pyramid/number-pyramid.tsx
@@ -1,7 +1,7 @@
-import { strategyGameFactory, type Ctx } from '../../strategy-game-factory';
+import { strategyGameFactory, type StrategyArgs } from '../../strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
-import { generateStartBoard, moves } from './gameplay';
-import { BoardClient, type TurnState } from './board-client';
+import { generateStartBoard, moves, type Board, type TurnState } from './gameplay';
+import { BoardClient } from './board-client';
 
 const rule = {
   hu: <>
@@ -18,8 +18,7 @@ const rule = {
   </>
 };
 
-const getPlayerStepDescription = ({ ctx }: { ctx: Ctx }) => {
-  const turnState = ctx.turnState as TurnState;
+const getPlayerStepDescription = ({ ctx: { turnState } }: StrategyArgs<Board, TurnState>) => {
   if (turnState) {
     const level = turnState.levelIdx + 1;
     return {

--- a/src/components/games/pile-union/gameplay.spec.ts
+++ b/src/components/games/pile-union/gameplay.spec.ts
@@ -1,9 +1,9 @@
-import { isPile, moves } from './gameplay';
+import { isPile, moves, type TurnState } from './gameplay';
 import { makeCtx, moveValidator } from '../../../test-utils';
 
 const isMergeAllowed = moveValidator(moves.mergePiles);
 
-const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
+const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx<TurnState>({ currentPlayer }) });
 
 describe('isPile', () => {
   const board = [3, 2, 5];

--- a/src/components/games/pile-union/gameplay.ts
+++ b/src/components/games/pile-union/gameplay.ts
@@ -2,7 +2,8 @@ import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
 
 export type Board = number[]
 export type MoveType = 'remove' | 'merge'
-export type TurnState = { firstSelectedPile: number } | null
+// The pile clicked first, while the player picks the one to merge it with.
+export type TurnState = { firstSelectedPile: number }
 
 // Empty piles never survive a move (removeOne drops a pile it empties), so any
 // pile still on the table has a match to take.
@@ -16,8 +17,10 @@ const isMergeAllowed = (board: Board, piles: number[]): boolean =>
 
 export const moves = {
   removeOne: {
-    validate: (board: Board, _, pileIndex: number) => isPile(board, pileIndex),
-    apply: (board: Board, { ctx }: { ctx: Ctx }, pileIndex: number): MoveOutcome<Board> => {
+    validate: (board: Board, _: { ctx: Ctx<TurnState> }, pileIndex: number) => isPile(board, pileIndex),
+    apply: (
+      board: Board, { ctx }: { ctx: Ctx<TurnState> }, pileIndex: number
+    ): MoveOutcome<Board, TurnState> => {
       const newSize = board[pileIndex] - 1;
       const nextBoard = [
         ...board.slice(0, pileIndex),
@@ -32,8 +35,10 @@ export const moves = {
     }
   },
   mergePiles: {
-    validate: (board: Board, _, piles: number[]) => isMergeAllowed(board, piles),
-    apply: (board: Board, _, [pileIndex1, pileIndex2]: number[]): MoveOutcome<Board> => {
+    validate: (board: Board, _: { ctx: Ctx<TurnState> }, piles: number[]) => isMergeAllowed(board, piles),
+    apply: (
+      board: Board, _: { ctx: Ctx<TurnState> }, [pileIndex1, pileIndex2]: number[]
+    ): MoveOutcome<Board, TurnState> => {
       const [firstIdx, secondIdx] = [pileIndex1, pileIndex2].sort((a, b) => a - b);
       const merged = board[firstIdx] + board[secondIdx];
       const nextBoard = board.filter((_, i) => i !== firstIdx && i !== secondIdx);

--- a/src/components/games/pile-union/pile-union.tsx
+++ b/src/components/games/pile-union/pile-union.tsx
@@ -1,14 +1,16 @@
 import { useState, type ComponentProps } from 'react';
 import { range, random } from 'lodash';
-import { strategyGameFactory, type BoardClientProps, GameBoard, useHoverPreview } from '../../strategy-game-factory';
+import {
+  strategyGameFactory, type BoardClientProps, type StrategyArgs, GameBoard, useHoverPreview
+} from '../../strategy-game-factory';
 import { useTranslation } from '../../../language';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { moves, type Board, type MoveType, type TurnState } from './gameplay';
 
-const BoardClient = ({ board, ctx, setTurnState, moves }: BoardClientProps<Board>) => {
+const BoardClient = ({ board, ctx, setTurnState, moves }: BoardClientProps<Board, TurnState>) => {
   const [moveType, setMoveType] = useState<MoveType>('remove');
   const { value: hoveredPile, hoverProps } = useHoverPreview<number>(ctx.moveCount);
-  const turnState = ctx.turnState as TurnState;
+  const { turnState } = ctx;
 
   // The merge branch is a two-click sequence held in turn state, so this one
   // keeps its guard: without it a click during the bot's turn would still move
@@ -174,7 +176,7 @@ const Matchstick = ({ dimmed }: { dimmed: boolean }) => (
   </div>
 );
 
-const getPlayerStepDescription = ({ board, ctx }) => {
+const getPlayerStepDescription = ({ board, ctx }: StrategyArgs<Board, TurnState>) => {
   if (ctx.turnState !== null) {
     return {
       hu: 'Kattints egy másik kupacra az egyesítéshez, vagy ugyanerre a kupacra a kijelölés visszavonásához.',

--- a/src/components/games/remove-row-or-column/board-client.tsx
+++ b/src/components/games/remove-row-or-column/board-client.tsx
@@ -1,16 +1,14 @@
 import { range } from 'lodash';
 import {
-  type BoardClientProps, type Ctx, GameBoard, useHoverPreview
+  type BoardClientProps, type StrategyArgs, GameBoard, useHoverPreview
 } from '../../strategy-game-factory';
 import { useTranslation } from '../../../language';
-import { type Board, type Orientation, getRectangleAt } from './gameplay';
+import { type Board, type Orientation, type TurnState, getRectangleAt } from './gameplay';
 
-type Selected = { r: number; c: number } | null
-
-export const BoardClient = ({ board, ctx, setTurnState, moves }: BoardClientProps<Board>) => {
+export const BoardClient = ({ board, ctx, setTurnState, moves }: BoardClientProps<Board, TurnState>) => {
   const { t } = useTranslation();
   const { grid } = board;
-  const selected = ctx.turnState as Selected;
+  const selected = ctx.turnState;
   const { value: hoverOrientation, hoverProps, clear: clearHover } = useHoverPreview<Orientation>(ctx.moveCount);
   const rect = selected ? getRectangleAt(grid, selected.r, selected.c) : null;
 
@@ -104,7 +102,7 @@ export const BoardClient = ({ board, ctx, setTurnState, moves }: BoardClientProp
   );
 };
 
-export const getPlayerStepDescription = ({ ctx }: { board: Board; ctx: Ctx }) => {
+export const getPlayerStepDescription = ({ ctx }: StrategyArgs<Board, TurnState>) => {
   return ctx.turnState
     ? {
       hu: 'Vedd le a kijelölt korong sorát vagy oszlopát a gombokkal, vagy válassz másik korongot.',

--- a/src/components/games/remove-row-or-column/gameplay.spec.ts
+++ b/src/components/games/remove-row-or-column/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import {
-  type Board, type Grid, type Move,
+  type Board, type Grid, type Move, type TurnState,
   getRectangleAt, getRectangles, applyMove, isEmpty, getAllMoves, isRemovalAllowed, moves
 } from './gameplay';
 import { makeCtx } from '../../../test-utils';
@@ -116,7 +116,7 @@ describe('isRemovalAllowed', () => {
 // Whoever takes the last disc off the board wins; the selected disc parked in
 // ctx.turnState is cleared either way.
 describe('end of game', () => {
-  const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
+  const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx<TurnState>({ currentPlayer }) });
   const board = (grid: boolean[][]): Board => ({ grid });
 
   it.each([0, 1])('ends for the mover (player %i) when the last discs come off', p => {

--- a/src/components/games/remove-row-or-column/gameplay.ts
+++ b/src/components/games/remove-row-or-column/gameplay.ts
@@ -3,6 +3,8 @@ import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
 export type Grid = boolean[][]
 export type Board = { grid: Grid }
 export type Orientation = 'row' | 'col'
+// The disc the player picked first, while choosing between its row and its column.
+export type TurnState = { r: number; c: number }
 interface Rect { minR: number; maxR: number; minC: number; maxC: number }
 export interface Move { r: number; c: number; orientation: Orientation }
 
@@ -75,8 +77,8 @@ export const isEmpty = (grid: Grid): boolean => grid.every(row => row.every(cell
 
 export const moves = {
   removeLine: {
-    validate: (board: Board, _: { ctx: Ctx }, move: Move) => isRemovalAllowed(board.grid, move),
-    apply: (board: Board, { ctx }: { ctx: Ctx }, move: Move): MoveOutcome<Board> => {
+    validate: (board: Board, _: { ctx: Ctx<TurnState> }, move: Move) => isRemovalAllowed(board.grid, move),
+    apply: (board: Board, { ctx }: { ctx: Ctx<TurnState> }, move: Move): MoveOutcome<Board, TurnState> => {
       const nextBoard = { grid: applyMove(board.grid, move) };
       // nextTurnState clears the disc the BoardClient parked in ctx.turnState
       // while the player was choosing between its row and its column.

--- a/src/components/games/six-fields-circle/board-client.tsx
+++ b/src/components/games/six-fields-circle/board-client.tsx
@@ -1,8 +1,6 @@
 import { range } from 'lodash';
 import { GameBoard, type BoardClientProps } from '../../strategy-game-factory';
-import { type Board, FIELD_COUNT, OPPOSITE_PAIRS } from './gameplay';
-
-type TurnState = { first: number } | null
+import { type Board, type TurnState, FIELD_COUNT, OPPOSITE_PAIRS } from './gameplay';
 
 // Six fields evenly spaced on a circle, index 0 at the top going clockwise.
 const coords: { cx: number; cy: number }[] = range(FIELD_COUNT).map((i) => {
@@ -13,9 +11,8 @@ const coords: { cx: number; cy: number }[] = range(FIELD_COUNT).map((i) => {
   };
 });
 
-export const BoardClient = ({ board, ctx, setTurnState, moves }: BoardClientProps<Board>) => {
-  const turnState = ctx.turnState as TurnState;
-  const first = turnState?.first ?? null;
+export const BoardClient = ({ board, ctx, setTurnState, moves }: BoardClientProps<Board, TurnState>) => {
+  const first = ctx.turnState?.first ?? null;
 
   const isClickable = (node: number) => {
     if (!ctx.isClientMoveAllowed) return false;

--- a/src/components/games/six-fields-circle/gameplay.spec.ts
+++ b/src/components/games/six-fields-circle/gameplay.spec.ts
@@ -1,4 +1,6 @@
-import { getLegalMoves, hasLegalMove, isOpposite, isRemovalAllowed, moves, type Board } from './gameplay';
+import {
+  getLegalMoves, hasLegalMove, isOpposite, isRemovalAllowed, moves, type Board, type TurnState
+} from './gameplay';
 import { makeCtx } from '../../../test-utils';
 
 describe('isRemovalAllowed', () => {
@@ -53,7 +55,7 @@ describe('isRemovalAllowed', () => {
 
 // A move needs two non-empty fields that are not opposite each other, so two
 // survivors facing each other across the circle is a dead position.
-const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
+const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx<TurnState>({ currentPlayer }) });
 
 describe('end of game', () => {
   it.each([0, 1])('ends for the mover (player %i) when only opposite fields remain', p => {

--- a/src/components/games/six-fields-circle/gameplay.ts
+++ b/src/components/games/six-fields-circle/gameplay.ts
@@ -8,6 +8,8 @@ import { random, sample } from 'lodash';
 // forbidden. The player who cannot move loses.
 export type Board = number[]
 export type Move = [number, number]
+// The field clicked first, while the player picks the second one of the pair.
+export type TurnState = { first: number }
 
 export const FIELD_COUNT = 6;
 
@@ -78,8 +80,8 @@ export const sampleNonEmptyField = (board: Board, [a, b]: Move): number => {
 
 export const moves = {
   removeFromTwo: {
-    validate: (board: Board, _, move: Move) => isRemovalAllowed(board, move),
-    apply: (board: Board, { ctx }: { ctx: Ctx }, [i, j]: Move): MoveOutcome<Board> => {
+    validate: (board: Board, _: { ctx: Ctx<TurnState> }, move: Move) => isRemovalAllowed(board, move),
+    apply: (board: Board, { ctx }: { ctx: Ctx<TurnState> }, [i, j]: Move): MoveOutcome<Board, TurnState> => {
       const nextBoard = board.slice();
       nextBoard[i] -= 1;
       nextBoard[j] -= 1;

--- a/src/components/games/six-fields-circle/six-fields-circle.tsx
+++ b/src/components/games/six-fields-circle/six-fields-circle.tsx
@@ -1,12 +1,12 @@
-import { strategyGameFactory, type Ctx } from '../../strategy-game-factory';
-import { generateStartBoard, moves, type Board } from './gameplay';
+import { strategyGameFactory, type StrategyArgs } from '../../strategy-game-factory';
+import { generateStartBoard, moves, type Board, type TurnState } from './gameplay';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { BoardClient } from './board-client';
 
 export type { Board };
 
-const getPlayerStepDescription = ({ ctx }: { ctx: Ctx }) => {
-  if ((ctx.turnState as { first: number } | null) !== null) {
+const getPlayerStepDescription = ({ ctx }: StrategyArgs<Board, TurnState>) => {
+  if (ctx.turnState !== null) {
     return {
       hu: 'Kattints egy másik, nem üres és a kijelölttel nem szemközti mezőre a második korong ' +
         'elvételéhez, vagy a kijelölt mezőre a kijelölés visszavonásához.',

--- a/src/components/games/ten-coins/gameplay.spec.ts
+++ b/src/components/games/ten-coins/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { moves, type Board } from './gameplay';
+import { moves, type Board, type TurnState } from './gameplay';
 import { makeCtx, moveValidator } from '../../../test-utils';
 
 const isConversionAllowed = moveValidator(moves.convert);
@@ -37,7 +37,7 @@ describe('isConversionAllowed', () => {
 
 // A conversion turns *every* coin of the chosen value into the same smaller
 // one, and the player whose move leaves all ten coins equal wins.
-const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
+const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx<TurnState>({ currentPlayer }) });
 
 describe('end of game', () => {
   it('converts every coin of the chosen value at once', () => {

--- a/src/components/games/ten-coins/gameplay.ts
+++ b/src/components/games/ten-coins/gameplay.ts
@@ -7,6 +7,8 @@ import type { Ctx, MoveOutcome } from '../../strategy-game-factory';
 // 1..5 for the harder category D) — encoded purely in the start board, so the
 // solver, moves and board rendering are all shared and board-driven.
 export type Board = number[]
+// The coin value the player selected, while choosing what to change it to.
+export type TurnState = number
 
 const totalCoins = 10;
 
@@ -18,8 +20,11 @@ const isConversionAllowed = (board: Board, k: number, l: number): boolean =>
 
 export const moves = {
   convert: {
-    validate: (board: Board, _, k: number, l: number) => isConversionAllowed(board, k, l),
-    apply: (board: Board, { ctx }: { ctx: Ctx }, k: number, l: number): MoveOutcome<Board> => {
+    validate: (board: Board, _: { ctx: Ctx<TurnState> }, k: number, l: number) =>
+      isConversionAllowed(board, k, l),
+    apply: (
+      board: Board, { ctx }: { ctx: Ctx<TurnState> }, k: number, l: number
+    ): MoveOutcome<Board, TurnState> => {
       const nextBoard = board.map(v => (v === k ? l : v)).sort((a, b) => a - b);
       if (uniq(nextBoard).length === 1) {
         return { nextBoard, gameEnd: { winnerIndex: ctx.currentPlayer! } };

--- a/src/components/games/ten-coins/ten-coins.tsx
+++ b/src/components/games/ten-coins/ten-coins.tsx
@@ -1,7 +1,12 @@
 import { range } from 'lodash';
-import { strategyGameFactory, type BoardClientProps, GameBoard } from '../../strategy-game-factory';
+import {
+  strategyGameFactory, type BoardClientProps, type StrategyArgs, GameBoard
+} from '../../strategy-game-factory';
 import { useTranslation } from '../../../language';
-import { generateStartBoardC, generateStartBoardD, generateTestStartBoard, moves, type Board } from './gameplay';
+import {
+  generateStartBoardC, generateStartBoardD, generateTestStartBoard, moves,
+  type Board, type TurnState
+} from './gameplay';
 import { distinctValues, randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 // --- Exact solver over the non-empty subsets of the present values ------------
@@ -13,9 +18,9 @@ import { distinctValues, randomBotStrategy, smartBotStrategy } from './bot-strat
 // {1,2,3}, {1,4,5}, {2,3,4,5}, {1,2,3,4,5} for values 1..5. Everything else is a
 // first-player win, driven towards one of these (or merged to a single value).
 
-const BoardClient = ({ board, ctx, setTurnState, moves }: BoardClientProps<Board>) => {
+const BoardClient = ({ board, ctx, setTurnState, moves }: BoardClientProps<Board, TurnState>) => {
   const { t } = useTranslation();
-  const selectedValue = ctx.turnState as number | null;
+  const selectedValue = ctx.turnState;
   const presentValues = distinctValues(board);
 
   // Asking about L = 1 asks whether these coins can be changed at all: it is the
@@ -112,7 +117,7 @@ const Coin = ({ value }: { value: number }) => (
   </div>
 );
 
-const getPlayerStepDescription = ({ ctx }) => {
+const getPlayerStepDescription = ({ ctx }: StrategyArgs<Board, TurnState>) => {
   if (ctx.turnState !== null) {
     return {
       hu: `Válaszd ki, mi legyen a(z) ${ctx.turnState} értékű érmék új (kisebb) értéke.`,

--- a/src/components/strategy-game-factory/engine/build-ctx.ts
+++ b/src/components/strategy-game-factory/engine/build-ctx.ts
@@ -12,9 +12,9 @@ import type { CoreState } from './store';
 // `isHumanVsHumanGame`), and `undoSnapshot`/`currentTurnHasMoves` — engine
 // bookkeeping that would silently become public API, and that an authoritative
 // server must never ship to a client.
-export const buildCtx = <TBoard>(
-  state: CoreState<TBoard>, resolvedPlayerNames: [string, string]
-): Ctx => ({
+export const buildCtx = <TBoard, TTurnState>(
+  state: CoreState<TBoard, TTurnState>, resolvedPlayerNames: [string, string]
+): Ctx<TTurnState> => ({
   isHumanVsHumanGame: state.mode === 'vsHuman',
   resolvedPlayerNames,
   chosenRoleIndex: state.chosenRoleIndex,

--- a/src/components/strategy-game-factory/engine/reducer.ts
+++ b/src/components/strategy-game-factory/engine/reducer.ts
@@ -3,8 +3,8 @@ import type { MoveOutcome, MoveDefinition } from '../types';
 import { buildCtx } from './build-ctx';
 import type { CoreState } from './store';
 
-type MoveTransition<TBoard> = {
-  state: CoreState<TBoard>
+type MoveTransition<TBoard, TTurnState> = {
+  state: CoreState<TBoard, TTurnState>
   // validate rejected the dispatch; state is unchanged (same reference)
   illegal?: boolean
   // the shell should schedule gameplay.endOfTurnMove
@@ -12,24 +12,24 @@ type MoveTransition<TBoard> = {
   // the shell should run its game-end side effects (dialog, stats, analytics)
   gameJustEnded?: { winnerIndex: number }
   // what the dispatcher (bot / BoardClient) receives back
-  result: MoveOutcome<TBoard>
+  result: MoveOutcome<TBoard, TTurnState>
 }
 
 // Framework-free move interpreter: validate + apply + fold the consequences
 // into the next CoreState. Pure — the React shell decides what to do with the
 // returned transition (store write, dialog, timers).
-export const reduceMove = <TBoard>(
-  state: CoreState<TBoard>,
-  def: MoveDefinition<TBoard>,
+export const reduceMove = <TBoard, TTurnState>(
+  state: CoreState<TBoard, TTurnState>,
+  def: MoveDefinition<TBoard, TTurnState>,
   name: string,
   args: unknown[],
   resolvedPlayerNames: [string, string]
-): MoveTransition<TBoard> => {
+): MoveTransition<TBoard, TTurnState> => {
   const ctx = buildCtx(state, resolvedPlayerNames);
   if (def.validate && !def.validate(state.board, { ctx }, ...args)) {
     return { state, illegal: true, result: { nextBoard: state.board } };
   }
-  const next: CoreState<TBoard> = { ...state };
+  const next: CoreState<TBoard, TTurnState> = { ...state };
   if (!state.currentTurnHasMoves) {
     next.undoSnapshot = {
       board: cloneDeep(state.board),
@@ -39,7 +39,7 @@ export const reduceMove = <TBoard>(
     next.currentTurnHasMoves = true;
   }
   let gameJustEnded: { winnerIndex: number } | undefined;
-  const result: MoveOutcome<TBoard> = def.apply(state.board, { ctx }, ...args);
+  const result: MoveOutcome<TBoard, TTurnState> = def.apply(state.board, { ctx }, ...args);
   if (result.nextTurnState !== undefined) {
     next.turnState = result.nextTurnState;
   }

--- a/src/components/strategy-game-factory/engine/run-match.ts
+++ b/src/components/strategy-game-factory/engine/run-match.ts
@@ -33,20 +33,20 @@ const PLAYER_NAMES: [string, string] = ['0', '1'];
 // Everything that goes wrong throws: unlike the shell, which must keep a live
 // game playable, a headless match only ever runs in tests and CI, where a
 // silent no-op would hide the bug it exists to catch.
-export const runMatch = <TBoard>({
+export const runMatch = <TBoard, TTurnState = unknown>({
   gameplay: { moves, endOfTurnMove },
   strategies,
   startBoard,
   maxMoves = 500
 }: {
-  gameplay: Gameplay<TBoard>
+  gameplay: Gameplay<TBoard, TTurnState>
   // strategies[i] plays as player i
   strategies: [BotStrategy<TBoard>, BotStrategy<TBoard>]
   startBoard: TBoard
   maxMoves?: number
 }): MatchResult<TBoard> => {
-  let state: CoreState<TBoard> = {
-    ...createInitialCoreState(startBoard),
+  let state: CoreState<TBoard, TTurnState> = {
+    ...createInitialCoreState<TBoard, TTurnState>(startBoard),
     phase: 'play',
     currentPlayer: 0
   };

--- a/src/components/strategy-game-factory/engine/store.ts
+++ b/src/components/strategy-game-factory/engine/store.ts
@@ -7,13 +7,13 @@ import type { Mode, Phase } from '../types';
 // This module is framework-free (no React import): together with reducer.ts
 // and build-ctx.ts it is the seed of the headless engine a future
 // server-authoritative competition mode needs (issue #313).
-export type CoreState<TBoard> = {
+export type CoreState<TBoard, TTurnState = unknown> = {
   board: TBoard
   phase: Phase
   mode: Mode
   currentPlayer: number | null
   chosenRoleIndex: number | null
-  turnState: unknown
+  turnState: TTurnState | null
   moveCount: number
   winnerIndex: number | null
   undoSnapshot: { board: TBoard; currentPlayer: number; moveCount: number } | null
@@ -21,9 +21,9 @@ export type CoreState<TBoard> = {
   currentTurnHasMoves: boolean
 }
 
-export const createInitialCoreState = <TBoard>(
+export const createInitialCoreState = <TBoard, TTurnState = unknown>(
   board: TBoard, mode: Mode = 'vsComputer'
-): CoreState<TBoard> => ({
+): CoreState<TBoard, TTurnState> => ({
   board,
   phase: 'roleSelection',
   mode,
@@ -36,16 +36,18 @@ export const createInitialCoreState = <TBoard>(
   currentTurnHasMoves: false
 });
 
-type GameStore<TBoard> = {
-  getState: () => CoreState<TBoard>
-  setState: (patch: Partial<CoreState<TBoard>>) => void
+type GameStore<TBoard, TTurnState = unknown> = {
+  getState: () => CoreState<TBoard, TTurnState>
+  setState: (patch: Partial<CoreState<TBoard, TTurnState>>) => void
   subscribe: (listener: () => void) => () => void
 }
 
 // Minimal hand-rolled store: getState returns the same object between writes
 // (a requirement of useSyncExternalStore), setState merges a partial patch and
 // notifies subscribers synchronously.
-export const createGameStore = <TBoard>(initial: CoreState<TBoard>): GameStore<TBoard> => {
+export const createGameStore = <TBoard, TTurnState = unknown>(
+  initial: CoreState<TBoard, TTurnState>
+): GameStore<TBoard, TTurnState> => {
   let state = initial;
   const listeners = new Set<() => void>();
   return {

--- a/src/components/strategy-game-factory/game-parts/common/game-controls.spec.tsx
+++ b/src/components/strategy-game-factory/game-parts/common/game-controls.spec.tsx
@@ -11,8 +11,8 @@ import type { Variant } from '../../types';
 // highlight comes from the label's own class, so this is invisible on screen.)
 
 const variants: Variant[] = [
-  { originalIndex: 0, label: { hu: 'Könnyű', en: 'Easy' }, disabled: false } as Variant,
-  { originalIndex: 1, label: { hu: 'Nehéz', en: 'Hard' }, disabled: false } as Variant
+  { originalIndex: 0, label: { hu: 'Könnyű', en: 'Easy' }, disabled: false, hasBotStrategy: true },
+  { originalIndex: 1, label: { hu: 'Nehéz', en: 'Hard' }, disabled: false, hasBotStrategy: true }
 ];
 
 describe('ModeSelector', () => {
@@ -71,7 +71,7 @@ describe('DifficultySelector', () => {
   it('marks a variant whose bot is not always optimal', () => {
     const withMarker: Variant[] = [
       variants[0]!,
-      { ...variants[1]!, notAlwaysOptimal: true } as Variant
+      { ...variants[1]!, notAlwaysOptimal: true }
     ];
     const { getAllByTitle } = render(
       <DifficultySelector variants={withMarker} selectedIndex={0} onSelect={() => {}} disabled={false} />

--- a/src/components/strategy-game-factory/game-parts/game-end-dialog.spec.tsx
+++ b/src/components/strategy-game-factory/game-parts/game-end-dialog.spec.tsx
@@ -22,8 +22,8 @@ const ctxWith = (isHumanVsHumanGame: boolean): Ctx => ({
 });
 
 const variants: Variant[] = [
-  { originalIndex: 0, label: { hu: 'Könnyű', en: 'Easy' }, disabled: false } as Variant,
-  { originalIndex: 1, label: { hu: 'Nehéz', en: 'Hard' }, disabled: false } as Variant
+  { originalIndex: 0, label: { hu: 'Könnyű', en: 'Easy' }, disabled: false, hasBotStrategy: true },
+  { originalIndex: 1, label: { hu: 'Nehéz', en: 'Hard' }, disabled: false, hasBotStrategy: true }
 ];
 
 const Harness = ({ isHumanVsHumanGame = false }: { isHumanVsHumanGame?: boolean }) => {

--- a/src/components/strategy-game-factory/game-parts/game-sidebar/game-sidebar.spec.tsx
+++ b/src/components/strategy-game-factory/game-parts/game-sidebar/game-sidebar.spec.tsx
@@ -30,7 +30,7 @@ const renderSidebar = (ctxOverrides: Partial<Ctx> = {}) => {
         ctx={ctx}
         playerNames={[]}
         moves={defaultMoves}
-        variants={[{ botStrategy: () => {}, originalIndex: 0, disabled: false }]}
+        variants={[{ hasBotStrategy: true, originalIndex: 0, disabled: false }]}
         selectedVariantIndex={0}
       />
     </MemoryRouter>

--- a/src/components/strategy-game-factory/game-parts/game-sidebar/game-sidebar.tsx
+++ b/src/components/strategy-game-factory/game-parts/game-sidebar/game-sidebar.tsx
@@ -42,7 +42,8 @@ export const GameSidebar = ({
 }: GameSidebarProps) => {
   const { t } = useTranslation();
   const isNewGameAllowed = ctx.phase !== 'play' || ctx.isClientMoveAllowed;
-  const activeVariantHasBotStrategy = !!variants.find(v => v.originalIndex === selectedVariantIndex)?.botStrategy;
+  const activeVariantHasBotStrategy =
+    !!variants.find(v => v.originalIndex === selectedVariantIndex)?.hasBotStrategy;
 
   const selectedVariant = variants.find(v => v.originalIndex === selectedVariantIndex);
   const modeSummaryLabel = t(ctx.isHumanVsHumanGame

--- a/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
@@ -143,6 +143,22 @@ describe('variant availability by mode', () => {
     expect(variantRadio(view, 'Beta').disabled).toBe(true);
   });
 
+  // The variant radio is not the only thing a missing bot turns off: with nobody
+  // to play the other side there is no role to choose either.
+  it('blocks role selection in vsComputer mode when the game defines no bot', () => {
+    const view = renderGame(botlessVariants());
+
+    expect((view.getByTestId('role-btn-0') as HTMLButtonElement).disabled).toBe(true);
+    expect((view.getByTestId('role-btn-1') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('offers both roles when the selected variant does have a bot', () => {
+    const view = renderGame(mixedVariants());
+
+    expect((view.getByTestId('role-btn-0') as HTMLButtonElement).disabled).toBe(false);
+    expect((view.getByTestId('role-btn-1') as HTMLButtonElement).disabled).toBe(false);
+  });
+
   it('enables those same variants in vsHuman mode, which needs no bot', () => {
     const view = renderGame(botlessVariants());
     fireEvent.click(view.getByTestId('mode-vsHuman'));

--- a/src/components/strategy-game-factory/strategy-game-factory.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.tsx
@@ -11,7 +11,7 @@ import { useGameStats } from './hooks/use-game-stats';
 import { trackEvent } from '../../tracking';
 import type {
   Mode, Ctx, MoveOutcome, Gameplay, GameMoves, ClientGameMoves, BotStrategy, BotMove,
-  BoardClientProps, Variant as DisplayVariant, VariantInput
+  BoardClientProps, StrategyArgs, Variant as DisplayVariant, VariantInput
 } from './types';
 import { resolveVariants } from './helpers/resolve-variants';
 import { createGameStore, createInitialCoreState } from './engine/store';
@@ -25,16 +25,16 @@ const DEFAULT_PLAYER_NAMES: I18nString[] = [
   { hu: '2. játékos', en: '2nd player' }
 ];
 
-export interface Presentation<TBoard> {
+export interface Presentation<TBoard, TTurnState = unknown> {
   rule: TranslatableNode
   roleLabels?: [I18nString, I18nString]
-  getPlayerStepDescription: (args: { board: TBoard; ctx: Ctx }) => TranslatableNode
+  getPlayerStepDescription: (args: StrategyArgs<TBoard, TTurnState>) => TranslatableNode
 }
 
-export type StrategyGameConfig<TBoard> = {
-  presentation: Presentation<TBoard>
-  BoardClient: React.ComponentType<BoardClientProps<TBoard>>
-  gameplay: Gameplay<TBoard>
+export type StrategyGameConfig<TBoard, TTurnState = unknown> = {
+  presentation: Presentation<TBoard, TTurnState>
+  BoardClient: React.ComponentType<BoardClientProps<TBoard, TTurnState>>
+  gameplay: Gameplay<TBoard, TTurnState>
   variants: VariantInput<TBoard>[]
 }
 
@@ -43,17 +43,17 @@ export type StrategyGameConfig<TBoard> = {
 // conformance spec can reach every registered game without a second registry to
 // keep in step — and it is the shape a competition server would load a game by
 // (issue #313).
-export type StrategyGame<TBoard> = React.FC & {
-  gameplay: Gameplay<TBoard>
+export type StrategyGame<TBoard, TTurnState = unknown> = React.FC & {
+  gameplay: Gameplay<TBoard, TTurnState>
   variants: VariantInput<TBoard>[]
 }
 
-export const strategyGameFactory = <TBoard,>({
+export const strategyGameFactory = <TBoard, TTurnState = unknown>({
   presentation,
   BoardClient,
   gameplay,
   variants
-}: StrategyGameConfig<TBoard>): StrategyGame<TBoard> => {
+}: StrategyGameConfig<TBoard, TTurnState>): StrategyGame<TBoard, TTurnState> => {
   const { rule, roleLabels, getPlayerStepDescription } = presentation;
   const { moves, endOfTurnMove } = gameplay;
   const { defaultVariantIndex, defaultVariant, resolvedVariants } = resolveVariants(variants);
@@ -68,7 +68,9 @@ export const strategyGameFactory = <TBoard,>({
     // Authoritative game state lives in a synchronous store outside React (see
     // engine/store.ts); React renders a snapshot of it. Bots and chained
     // dispatches always read the store, so they can never see stale state.
-    const [store] = useState(() => createGameStore(createInitialCoreState(activeGenerateStartBoard())));
+    const [store] = useState(
+      () => createGameStore(createInitialCoreState<TBoard, TTurnState>(activeGenerateStartBoard()))
+    );
     const state = useSyncExternalStore(store.subscribe, store.getState);
     const { board, phase, mode, currentPlayer, chosenRoleIndex, undoSnapshot } = state;
 
@@ -112,7 +114,7 @@ export const strategyGameFactory = <TBoard,>({
       playerNames[1] || t(DEFAULT_PLAYER_NAMES[1])
     ];
 
-    let wrappedGameMoves: GameMoves<TBoard> = {} as GameMoves<TBoard>;
+    let wrappedGameMoves: GameMoves<TBoard, TTurnState> = {} as GameMoves<TBoard, TTurnState>;
 
     // An illegal move should never happen through the UI (buttons are disabled)
     // or a correct bot, so reaching here means a bug or tampering. In dev we
@@ -144,7 +146,9 @@ export const strategyGameFactory = <TBoard,>({
       });
     };
 
-    const dispatchMove = (name: string, moveBoard: TBoard, args: unknown[]): MoveOutcome<TBoard> => {
+    const dispatchMove = (
+      name: string, moveBoard: TBoard, args: unknown[]
+    ): MoveOutcome<TBoard, TTurnState> => {
       // The store board is authoritative; the board argument remains for API
       // compatibility. A mismatch means a chaining bug — a bot or BoardClient
       // passed a stale board to the second move of a turn — so fail loudly in
@@ -194,8 +198,15 @@ export const strategyGameFactory = <TBoard,>({
     const getVariantsForMode = (m: Mode): DisplayVariant[] => {
       const humanVsHuman = m === 'vsHuman';
       return resolvedVariants
-        .map((v, i) => ({ ...v, originalIndex: i, disabled: !humanVsHuman && !v.botStrategy }))
-        .filter(v => !humanVsHuman || !!v.generateStartBoard);
+        .map((variant, originalIndex) => ({ variant, originalIndex }))
+        .filter(({ variant }) => !humanVsHuman || !!variant.generateStartBoard)
+        .map(({ variant, originalIndex }) => ({
+          originalIndex,
+          label: variant.label,
+          notAlwaysOptimal: variant.notAlwaysOptimal,
+          hasBotStrategy: !!variant.botStrategy,
+          disabled: !humanVsHuman && !variant.botStrategy
+        }));
     };
 
     const canUndo = phase === 'play'
@@ -222,16 +233,16 @@ export const strategyGameFactory = <TBoard,>({
       store.setState({ phase: 'play', currentPlayer: 0, chosenRoleIndex: roleIndex });
     };
 
-    const ctx: Ctx = buildCtx(state, resolvedPlayerNames);
+    const ctx: Ctx<TTurnState> = buildCtx(state, resolvedPlayerNames);
 
     // For the BoardClient's mid-turn UI state. Moves never get this; they
     // return `nextTurnState` instead.
-    const setTurnState = (turnState: unknown) => {
+    const setTurnState = (turnState: TTurnState | null) => {
       store.setState({ turnState });
     };
 
     wrappedGameMoves = mapValues(moves, (_def, name) => {
-      const wrapped: GameMoves<TBoard>[string] = (moveBoard: TBoard, ...args: unknown[]) =>
+      const wrapped: GameMoves<TBoard, TTurnState>[string] = (moveBoard: TBoard, ...args: unknown[]) =>
         dispatchMove(name, moveBoard, args);
       return wrapped;
     });
@@ -244,13 +255,13 @@ export const strategyGameFactory = <TBoard,>({
     // Bots and the auto `endOfTurnMove` dispatch use `wrappedGameMoves` instead:
     // there an illegal move is a bug, and the validator fails loudly (see
     // `reportIllegalMove`).
-    const clientGameMoves: ClientGameMoves<TBoard> = mapValues(moves, ({ validate }, name) => {
+    const clientGameMoves: ClientGameMoves<TBoard, TTurnState> = mapValues(moves, ({ validate }, name) => {
       const isAllowed = (moveBoard: TBoard, ...args: unknown[]) => {
         const liveCtx = buildCtx(store.getState(), resolvedPlayerNames);
         return liveCtx.isClientMoveAllowed
           && (!validate || validate(moveBoard, { ctx: liveCtx }, ...args));
       };
-      const clientWrapped: ClientGameMoves<TBoard>[string] = Object.assign(
+      const clientWrapped: ClientGameMoves<TBoard, TTurnState>[string] = Object.assign(
         (moveBoard: TBoard, ...args: unknown[]) =>
           isAllowed(moveBoard, ...args)
             ? wrappedGameMoves[name]!(moveBoard, ...args)
@@ -281,12 +292,11 @@ export const strategyGameFactory = <TBoard,>({
     // makes the bot look like it is thinking; keeping it here rather than
     // inside the strategy is what lets the same strategy run headless
     // (engine/run-match.ts).
-    const runBotTurn = (queue: BotMove[], delay: number) => {
-      const { botStrategy } = activeVariant;
+    const runBotTurn = (queue: BotMove[], delay: number, botStrategy: BotStrategy<TBoard>) => {
       botTimeoutRef.current = setTimeout(() => {
         botTimeoutRef.current = null;
         const playerBefore = store.getState().currentPlayer!;
-        const named = queue.length ? queue : askBot(botStrategy!);
+        const named = queue.length ? queue : askBot(botStrategy);
         if (!named.length) return;
         const [{ move, args = [] }, ...rest] = named;
         if (!moves[move]) {
@@ -308,16 +318,17 @@ export const strategyGameFactory = <TBoard,>({
         // A pending auto endOfTurnMove occupies the same timeout slot and
         // already owns the rest of the turn, so only carry on without one.
         if (botTimeoutRef.current === null) {
-          runBotTurn(rest, stepDelay());
+          runBotTurn(rest, stepDelay(), botStrategy);
         }
       }, delay);
     };
 
     const doBotTurn = () => {
-      if (!activeVariant.botStrategy) {
+      const { botStrategy } = activeVariant;
+      if (!botStrategy) {
         throw new Error('strategyGameFactory: no botStrategy available for vsComputer mode');
       }
-      runBotTurn([], stepDelay());
+      runBotTurn([], stepDelay(), botStrategy);
     };
 
     const visibleVariants = getVariantsForMode(mode);

--- a/src/components/strategy-game-factory/types.ts
+++ b/src/components/strategy-game-factory/types.ts
@@ -3,12 +3,17 @@ import type { I18nString, TranslatableNode } from '../../language';
 export type Phase = 'roleSelection' | 'play' | 'gameEnd'
 export type Mode = 'vsComputer' | 'vsHuman'
 
-export interface Ctx {
+// TTurnState is the game's own mid-turn state — the half-made selection a
+// multi-stage turn carries between its moves. It names the payload only: the
+// engine adds the `| null` that every turn starts and ends in, so a game never
+// has to spell it out. Left unpinned it is `unknown`, and reading `turnState`
+// then needs a cast, exactly as it did before the parameter existed.
+export interface Ctx<TTurnState = unknown> {
   isHumanVsHumanGame: boolean
   resolvedPlayerNames: [string, string]
   chosenRoleIndex: number | null
   phase: Phase
-  turnState: unknown
+  turnState: TTurnState | null
   currentPlayer: number | null
   isClientMoveAllowed: boolean
   winnerIndex: number | null
@@ -17,13 +22,13 @@ export interface Ctx {
 
 // Everything a move can cause, expressed as data: the engine interprets what
 // the move returns, so a move never reaches out and changes anything itself.
-export type MoveOutcome<TBoard> = {
+export type MoveOutcome<TBoard, TTurnState = unknown> = {
   nextBoard: TBoard
   // Turn passes to the other player. Omitted/false = turn continues (mid-turn
   // move of a multi-phase turn). Ignored when `gameEnd` is present.
   isTurnEnd?: boolean
   // undefined = turnState unchanged; null = cleared; anything else = new value.
-  nextTurnState?: unknown
+  nextTurnState?: TTurnState | null
   // Terminal: the game is over, naming the winner explicitly (use
   // `ctx.currentPlayer!` when the mover wins).
   gameEnd?: { winnerIndex: number }
@@ -35,31 +40,31 @@ export type MoveOutcome<TBoard> = {
 // could cause an effect through, so purity is enforced by the type system
 // rather than by convention — which is what lets the same function run in a
 // future authoritative server.
-export type MoveFunction<TBoard> = (
-  board: TBoard, meta: { ctx: Ctx }, ...args: any[]
-) => MoveOutcome<TBoard>
+export type MoveFunction<TBoard, TTurnState = unknown> = (
+  board: TBoard, meta: { ctx: Ctx<TTurnState> }, ...args: any[]
+) => MoveOutcome<TBoard, TTurnState>
 // Pure, side-effect-free legality predicate for a single move, colocated with
 // its `apply`. Because it depends only on `board` + `ctx` (no React), the same
 // function drives the UI (button `disabled`), the engine (illegal-move
 // enforcement) and, in the future, an authoritative server-side check.
-type MoveValidator<TBoard> = (
-  board: TBoard, meta: { ctx: Ctx }, ...args: any[]
+type MoveValidator<TBoard, TTurnState = unknown> = (
+  board: TBoard, meta: { ctx: Ctx<TTurnState> }, ...args: any[]
 ) => boolean
-export type MoveDefinition<TBoard> = {
-  apply: MoveFunction<TBoard>
-  validate?: MoveValidator<TBoard>
+export type MoveDefinition<TBoard, TTurnState = unknown> = {
+  apply: MoveFunction<TBoard, TTurnState>
+  validate?: MoveValidator<TBoard, TTurnState>
 }
-export interface Gameplay<TBoard> {
-  moves: Record<string, MoveDefinition<TBoard>>
+export interface Gameplay<TBoard, TTurnState = unknown> {
+  moves: Record<string, MoveDefinition<TBoard, TTurnState>>
   // move name auto-executed (after a delay) following moves returning autoEndOfTurn: true
   endOfTurnMove?: string
 }
 // Engine-wrapped moves, callable to dispatch. This is the bot's view: a bot
 // enumerates legal moves through the raw `validate`/its own helpers, because
 // `isAllowed` would be false throughout its turn anyway (see below).
-export type GameMoves<TBoard> = Record<
+export type GameMoves<TBoard, TTurnState = unknown> = Record<
   string,
-  (board: TBoard, ...args: any[]) => MoveOutcome<TBoard>
+  (board: TBoard, ...args: any[]) => MoveOutcome<TBoard, TTurnState>
 >
 // The BoardClient's view: the same dispatchers, plus `isAllowed(board, ...args)`
 // on every move — `ctx.isClientMoveAllowed` (turn ownership) AND the move's
@@ -67,15 +72,18 @@ export type GameMoves<TBoard> = Record<
 // ask; the same check silently gates every client dispatch, so handlers need no
 // `if (!allowed) return` guards. Assignable to GameMoves, so helpers shared with
 // a bot keep taking the wider type.
-export type ClientGameMoves<TBoard> = Record<
+export type ClientGameMoves<TBoard, TTurnState = unknown> = Record<
   string,
-  ((board: TBoard, ...args: any[]) => MoveOutcome<TBoard>)
+  ((board: TBoard, ...args: any[]) => MoveOutcome<TBoard, TTurnState>)
     & { isAllowed: (board: TBoard, ...args: any[]) => boolean }
 >
-export type StrategyArgs<TBoard> = { board: TBoard; ctx: Ctx }
+export type StrategyArgs<TBoard, TTurnState = unknown> = {
+  board: TBoard
+  ctx: Ctx<TTurnState>
+}
 // A game's `moves` object seen as a type — what a game exports as `Moves` so
 // its bots can name moves out of it.
-type AnyMoves = Record<string, MoveDefinition<any>>
+type AnyMoves = Record<string, MoveDefinition<any, any>>
 // What a move takes beyond the board and the meta object: exactly the tail a
 // bot has to supply as `args`.
 type MoveArgs<TApply> =
@@ -97,23 +105,36 @@ export type BotMove<TMoves extends string | AnyMoves = string> =
 // board to thread, so the same function can run on an authoritative server.
 // If the turn is still the bot's once its moves are played, it is asked again
 // (see engine/bot-turn.ts), so naming one move at a time is equally fine.
+// Deliberately not parameterised over the turn state: a bot is asked again with
+// a fresh `ctx` for every move it owes, so it plans a whole turn rather than
+// reading its own half-made selection back — the one consumer `turnState` has
+// no client for. A bot that ever needs it reads `unknown` and casts.
 export type BotStrategy<TBoard, TMoves extends string | AnyMoves = string> =
   (args: StrategyArgs<TBoard>) => BotMove<TMoves> | BotMove<TMoves>[]
-export type BoardClientProps<TBoard> = Omit<StrategyArgs<TBoard>, 'moves'> & {
-  moves: ClientGameMoves<TBoard>
-  // Writes the mid-turn UI state a BoardClient needs to remember (which pile is
-  // selected, which slot is being edited), read back as `ctx.turnState`. The one
-  // path that writes engine state without going through a move: a selection is
-  // not a move, so it must not bump `moveCount` or take an undo snapshot. Moves
-  // never get this — they return `nextTurnState` in their MoveOutcome instead.
-  setTurnState: (state: unknown) => void
-}
+// A game pins TTurnState by annotating its BoardClient — `BoardClientProps<Board,
+// TurnState>` — and the factory infers the rest of the config from it, so
+// `ctx.turnState` and `setTurnState` are typed with no cast anywhere.
+export type BoardClientProps<TBoard, TTurnState = unknown> =
+  StrategyArgs<TBoard, TTurnState> & {
+    moves: ClientGameMoves<TBoard, TTurnState>
+    // Writes the mid-turn UI state a BoardClient needs to remember (which pile is
+    // selected, which slot is being edited), read back as `ctx.turnState`. The one
+    // path that writes engine state without going through a move: a selection is
+    // not a move, so it must not bump `moveCount` or take an undo snapshot. Moves
+    // never get this — they return `nextTurnState` in their MoveOutcome instead.
+    setTurnState: (state: TTurnState | null) => void
+  }
 
+// What the variant chooser and the game-end dialog render: a projection of the
+// configured variants, deliberately free of the game's own types. It carries
+// *whether* a variant has a bot rather than the bot itself — the display never
+// calls one, and an opaque `botStrategy?: unknown` field is what forced every
+// consumer to guess what it was holding.
 export interface Variant {
   originalIndex: number
   disabled?: boolean
   label?: I18nString
-  botStrategy?: unknown
+  hasBotStrategy: boolean
   notAlwaysOptimal?: boolean
 }
 

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,8 +1,12 @@
 import type { BotMove, BotStrategy, Ctx, MoveDefinition } from './components/strategy-game-factory';
 import { asBotMoves } from './components/strategy-game-factory/engine/bot-turn';
 
-// Mock `ctx` for testing move functions and bot strategies.
-export const makeCtx = (overrides: Partial<Ctx> = {}): Ctx => ({
+// Mock `ctx` for testing move functions and bot strategies. A game that pins
+// its mid-turn state names it — `makeCtx<TurnState>({ turnState: … })` — so the
+// spec type-checks the same shape the moves receive at runtime.
+export const makeCtx = <TTurnState = unknown>(
+  overrides: Partial<Ctx<TTurnState>> = {}
+): Ctx<TTurnState> => ({
   phase: 'roleSelection',
   isHumanVsHumanGame: false,
   resolvedPlayerNames: ['Player 1', 'Player 2'],
@@ -19,9 +23,9 @@ export const makeCtx = (overrides: Partial<Ctx> = {}): Ctx => ({
 // so a spec asserting a rule also pins that the rule is still wired to the move
 // it governs. A bare predicate imported from `gameplay.ts` keeps passing after
 // its `validate:` line is dropped; this does not.
-export const moveValidator = <TBoard, TArgs extends unknown[]>(
-  move: { validate?: (board: TBoard, meta: { ctx: Ctx }, ...args: TArgs) => boolean },
-  ctx: Ctx = makeCtx()
+export const moveValidator = <TBoard, TArgs extends unknown[], TTurnState = unknown>(
+  move: { validate?: (board: TBoard, meta: { ctx: Ctx<TTurnState> }, ...args: TArgs) => boolean },
+  ctx: Ctx<TTurnState> = makeCtx()
 ) => (board: TBoard, ...args: TArgs): boolean => move.validate!(board, { ctx }, ...args);
 
 // A bot names its moves rather than playing them, so a spec reads its decision
@@ -35,11 +39,11 @@ export const botNextMoveArgs = (named: BotMove | BotMove[]): any[] =>
 // Ask a strategy for its turn and play its next move through the game's own
 // move, as the engine would. Lets a spec step a position forward by one bot
 // move without standing up a whole match.
-export const playBotMove = <TBoard>(
+export const playBotMove = <TBoard, TTurnState = unknown>(
   strategy: BotStrategy<TBoard>,
-  moves: Record<string, MoveDefinition<TBoard>>,
+  moves: Record<string, MoveDefinition<TBoard, TTurnState>>,
   board: TBoard,
-  ctx: Ctx = makeCtx()
+  ctx: Ctx<TTurnState> = makeCtx()
 ): TBoard => {
   const { move, args = [] } = botNextMove(strategy({ board, ctx }));
   return moves[move]!.apply(board, { ctx }, ...args).nextBoard;


### PR DESCRIPTION
Resolves the `types.ts` bullet in `docs/project-review-2026-08.md`:

> `Variant.botStrategy?: unknown` forces `botStrategy!` at the call site; `Ctx.turnState: unknown` pushes a cast into every multi-stage `BoardClient` — worth a generic parameter.

## `Ctx.turnState: unknown` → `Ctx<TTurnState>`

`Ctx` gained a `TTurnState = unknown` parameter, threaded through `MoveOutcome`, `MoveFunction`, `MoveValidator`, `MoveDefinition`, `Gameplay`, `StrategyArgs`, `GameMoves`/`ClientGameMoves`, `BoardClientProps`, `Presentation`, `StrategyGameConfig`/`StrategyGame`, and the engine's `CoreState`, `buildCtx`, `reduceMove`, `runMatch`.

One design call worth a look: **`TTurnState` names the payload only** — `Ctx.turnState` is `TTurnState | null` and the engine supplies the `| null` every turn starts and ends in. The alternative (the game's type carrying its own `| null`, as `pile-union` and `five-squares` did) leaves `createInitialCoreState`'s `turnState: null` unassignable, so it would need an unsound cast. Side benefit: a game cannot pin a shape that forgets the empty state.

A game pins it by annotating its `BoardClient`:

```ts
// gameplay.ts
export type TurnState = { firstSelectedPile: number };
```
```tsx
// board-client.tsx — this is what the factory infers the rest of the config from
const BoardClient = ({ ctx, setTurnState }: BoardClientProps<Board, TurnState>) => {
  const { turnState } = ctx;   // TurnState | null, no cast
```

All 7 multi-stage games are converted and cast nothing — `remove-row-or-column`, `number-pyramid`, `coins-in-3-piles`, `six-fields-circle`, `ten-coins`, `pile-union`, `five-squares`. The other 69 compile untouched via the `= unknown` default. Two games kept `TurnState` in their React file; it moved to `gameplay.ts`, next to the moves that produce it. `makeCtx` / `moveValidator` / `playBotMove` in `test-utils` are generic to match, so a spec names the same shape the moves receive.

Inference reads every ctx-shaped site in the config, so a converted game has to annotate all of them (`getPlayerStepDescription`, each move's meta, each `apply`'s return) — a leftover bare `Ctx` contradicts the rest and fails the build. Noted in AGENTS.md.

**`BotStrategy` is deliberately left unparameterised.** A bot is asked again with a fresh `ctx` for every move it still owes, so it plans a whole turn rather than reading its own half-made selection back — no game bot reads `turnState` today. Parameterising it would also make `VariantInput.botStrategy` a competing contravariant inference site against the `BoardClient`, which is what actually pins the game. Documented at the type; can be added if a bot ever needs it.

## `Variant.botStrategy?: unknown` → `hasBotStrategy: boolean`

`Variant` is the display projection rendered by the variant chooser and the game-end dialog. It held a strategy those never call, opaque because the display knows no `TBoard` — and both consumers only ever asked it for truthiness. `getVariantsForMode` now builds the projection field by field instead of spreading the whole variant into it.

The `botStrategy!` at the call site turned out to be optionality rather than opacity (it comes from `VariantInput.botStrategy?`). Fixed at the root: `runBotTurn` takes the strategy as a parameter, and `doBotTurn` — which already threw on a missing one — narrows it once.

## Testing

Two new tests in `strategy-game-factory.spec.tsx` cover the half of that projection nothing pinned: role-selection buttons gated by whether the active variant has a bot (the variant radios' `disabled` half was already covered).

`npx tsc --noEmit`, `npm run lint` and all 1709 tests across 180 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MrHK7uv6p5XPNCP29q36xg

---
_Generated by [Claude Code](https://claude.ai/code/session_01MrHK7uv6p5XPNCP29q36xg)_