### PR TITLE
Solve policeman-thief-ab's chase instead of walking it greedily

### DIFF
--- a/src/components/games/policeman-thief/policeman-thief-ab/bot-strategy.spec.ts
+++ b/src/components/games/policeman-thief/policeman-thief-ab/bot-strategy.spec.ts
@@ -1,0 +1,222 @@
+import { runMatch, type BotStrategy } from 'strategy-game-factory';
+import { botNextMove, botNextMoveArgs, makeCtx } from 'test-utils';
+import {
+  POLICE, THIEF, THIEF_MOVE_LIMIT, VERTEX_COUNT, generateStartBoardA, generateStartBoardB,
+  moves, neighbours, type Board
+} from './gameplay';
+import { policeWin, smartBotStrategy } from './bot-strategy';
+
+// ---------------------------------------------------------------------------
+// Independent reference, written straight from the rules: no memoisation and no
+// code shared with the module under test, so the search is graded against
+// something other than itself. `movesLeft` is how many of the thief's moves are
+// still to come.
+// ---------------------------------------------------------------------------
+const refPoliceWinAfterPoliceTurn = (
+  p0: number, p1: number, thief: number, movesLeft: number
+): boolean => {
+  if (p0 === thief || p1 === thief) return true;
+  return neighbours[thief].every((vertex: number) => {
+    if (vertex === p0 || vertex === p1) return true;
+    if (movesLeft === 1) return false;
+    return refPoliceWin(p0, p1, vertex, movesLeft - 1);
+  });
+};
+
+const refPoliceWin = (p0: number, p1: number, thief: number, movesLeft: number): boolean =>
+  neighbours[p0].some((a: number) =>
+    neighbours[p1].some((b: number) => refPoliceWinAfterPoliceTurn(a, b, thief, movesLeft)));
+
+const board = (
+  policemen: [number, number], thief: number, turnCount = 0
+): Board => ({ policemen, thief, turnCount, firstPolicemanMoved: false });
+
+const movesLeftIn = (b: Board) => THIEF_MOVE_LIMIT - b.turnCount;
+
+// Every position either side can be asked about: a capture has not happened yet
+// and the thief still has a move to make.
+const positions = (): Board[] => {
+  const all: Board[] = [];
+  for (let p0 = 0; p0 < VERTEX_COUNT; p0++) {
+    for (let p1 = 0; p1 < VERTEX_COUNT; p1++) {
+      for (let thief = 0; thief < VERTEX_COUNT; thief++) {
+        if (thief === p0 || thief === p1) continue;
+        for (let turnCount = 0; turnCount < THIEF_MOVE_LIMIT; turnCount++) {
+          all.push(board([p0, p1], thief, turnCount));
+        }
+      }
+    }
+  }
+  return all;
+};
+
+const startBoards = (generate: () => Board, samples = 600): Board[] => {
+  const seen = new Map<string, Board>();
+  for (let i = 0; i < samples; i++) {
+    const b = generate();
+    seen.set(`${b.policemen[0]},${b.policemen[1]},${b.thief}`, b);
+  }
+  return [...seen.values()];
+};
+
+const askBot = (b: Board, player: number) =>
+  smartBotStrategy({ board: b, ctx: makeCtx({ currentPlayer: player }) });
+
+// A police turn is named as two moves; read both destinations off it.
+const namedPoliceTurn = (b: Board): [number, number] => {
+  const named = askBot(b, POLICE) as { move: string, args?: unknown[] }[];
+  expect(named.map(m => m.move)).toEqual(['moveFirstPoliceman', 'moveSecondPoliceman']);
+  return [named[0]!.args![0] as number, named[1]!.args![0] as number];
+};
+
+const namedThiefVertex = (b: Board): number => botNextMoveArgs(askBot(b, THIEF))[0];
+
+// A bot that just moves legally, to stand in for an opponent that does anything.
+const randomBot: BotStrategy<Board> = ({ board: b, ctx }) => {
+  const pick = (from: number) => neighbours[from][Math.floor(Math.random() * 3)];
+  if (ctx.currentPlayer === THIEF) return { move: 'moveThief', args: [pick(b.thief)] };
+  return [
+    { move: 'moveFirstPoliceman', args: [pick(b.policemen[0]!)] },
+    { move: 'moveSecondPoliceman', args: [pick(b.policemen[1]!)] }
+  ];
+};
+
+const play = (startBoard: Board, strategies: [BotStrategy<Board>, BotStrategy<Board>]) =>
+  runMatch({ gameplay: { moves }, strategies, startBoard });
+
+describe('policeWin', () => {
+  it('agrees with the independent reference on every position', () => {
+    for (const b of positions()) {
+      expect({ ...b, win: policeWin(b) }).toEqual({
+        ...b,
+        win: refPoliceWin(b.policemen[0]!, b.policemen[1]!, b.thief, movesLeftIn(b))
+      });
+    }
+  });
+
+  // The eight intersections are the corners of a cube, and `7 - v` is the corner
+  // opposite v. With both policemen starting together (variant A) that is the
+  // one place the thief cannot get away from: three roads lead out of it and the
+  // two policemen, splitting up, cover them all.
+  it('catches a thief at the opposite corner, and only there, when the police start together', () => {
+    for (let police = 0; police < VERTEX_COUNT; police++) {
+      for (let thief = 0; thief < VERTEX_COUNT; thief++) {
+        if (thief === police || neighbours[police].includes(thief)) continue;
+        expect({ police, thief, caught: policeWin(board([police, police], thief)) })
+          .toEqual({ police, thief, caught: thief === VERTEX_COUNT - 1 - police });
+      }
+    }
+  });
+
+  it('catches a thief the two policemen already have surrounded', () => {
+    expect(policeWin(board([1, 2], 0, 2))).toBe(true);
+  });
+});
+
+describe('smartBotStrategy as the police', () => {
+  it('names two legal steps, one per policeman', () => {
+    for (const b of positions()) {
+      const [first, second] = namedPoliceTurn(b);
+      expect(neighbours[b.policemen[0]!]).toContain(first);
+      expect(neighbours[b.policemen[1]!]).toContain(second);
+    }
+  });
+
+  it('keeps the win from every position the police can win', () => {
+    for (const b of positions()) {
+      if (!refPoliceWin(b.policemen[0]!, b.policemen[1]!, b.thief, movesLeftIn(b))) continue;
+      const [first, second] = namedPoliceTurn(b);
+      const wins = refPoliceWinAfterPoliceTurn(first, second, b.thief, movesLeftIn(b));
+      expect({ ...b, first, second, wins }).toEqual({ ...b, first, second, wins: true });
+    }
+  });
+});
+
+describe('smartBotStrategy as the thief', () => {
+  it('names a legal step', () => {
+    for (const b of positions()) {
+      expect(neighbours[b.thief]).toContain(namedThiefVertex(b));
+    }
+  });
+
+  it('keeps the escape from every position the thief can survive', () => {
+    for (const b of positions()) {
+      const movesLeft = movesLeftIn(b);
+      // the police have just moved; the thief replies
+      if (refPoliceWinAfterPoliceTurn(b.policemen[0]!, b.policemen[1]!, b.thief, movesLeft)) continue;
+      const vertex = namedThiefVertex(b);
+      const escapes = vertex !== b.policemen[0] && vertex !== b.policemen[1]
+        && (movesLeft === 1 || !refPoliceWin(b.policemen[0]!, b.policemen[1]!, vertex, movesLeft - 1));
+      expect({ ...b, vertex, escapes: true }).toEqual({ ...b, vertex, escapes });
+    }
+  });
+
+  // The old greedy thief asked only whether a step was free right now and
+  // whether it had any free neighbour, so it walked onto squares the police
+  // could reach next turn — here, straight next to both of them.
+  it('does not step next to the policemen when a safe road exists', () => {
+    const b = board([5, 5], 3, 1);
+    expect(namedThiefVertex(b)).not.toBe(7);
+  });
+
+  it('never walks into a policeman while any other road is open', () => {
+    for (const b of positions()) {
+      const vertex = namedThiefVertex(b);
+      const openRoads = neighbours[b.thief]
+        .filter((v: number) => v !== b.policemen[0] && v !== b.policemen[1]);
+      if (openRoads.length) expect(openRoads).toContain(vertex);
+    }
+  });
+});
+
+describe('played out through the engine', () => {
+  it('hands the win to the side the search names, in optimal-vs-optimal play', () => {
+    for (const b of positions().filter(p => p.turnCount === 0)) {
+      const { winnerIndex } = play(b, [smartBotStrategy, smartBotStrategy]);
+      expect({ ...b, policeWins: policeWin(b) })
+        .toEqual({ ...b, policeWins: winnerIndex === POLICE });
+    }
+  });
+
+  it('wins against a bot moving at random, from every position it should', () => {
+    for (const b of positions().filter(p => p.turnCount === 0)) {
+      const winner = policeWin(b) ? POLICE : THIEF;
+      const strategies: [BotStrategy<Board>, BotStrategy<Board>] = winner === POLICE
+        ? [smartBotStrategy, randomBot]
+        : [randomBot, smartBotStrategy];
+      for (let trial = 0; trial < 6; trial++) {
+        expect({ ...b, winner: play(b, strategies).winnerIndex }).toEqual({ ...b, winner });
+      }
+    }
+  });
+});
+
+describe.each([
+  ['A (together)', generateStartBoardA],
+  ['B (apart)', generateStartBoardB]
+])('start boards of variant %s', (_label, generate) => {
+  const boards = startBoards(generate);
+
+  it('never starts with the thief already caught or cornered', () => {
+    for (const b of boards) {
+      expect(b.turnCount).toBe(0);
+      expect(b.policemen).not.toContain(b.thief);
+      // the police must not be able to take them on the very first step
+      expect(neighbours[b.policemen[0]!]).not.toContain(b.thief);
+      expect(neighbours[b.policemen[1]!]).not.toContain(b.thief);
+    }
+  });
+
+  it('gives both sides positions they can win', () => {
+    const policeWinnable = boards.filter(policeWin).length;
+    expect(policeWinnable).toBeGreaterThan(0);
+    expect(policeWinnable).toBeLessThan(boards.length);
+  });
+});
+
+describe('the bot names its whole turn', () => {
+  it('gives the police both half-moves at once, and the thief a single move', () => {
+    expect(askBot(board([0, 0], 7), POLICE)).toHaveLength(2);
+    expect(botNextMove(askBot(board([0, 0], 7), THIEF)).move).toBe('moveThief');
+  });
+});

--- a/src/components/games/policeman-thief/policeman-thief-ab/bot-strategy.ts
+++ b/src/components/games/policeman-thief/policeman-thief-ab/bot-strategy.ts
@@ -1,83 +1,105 @@
-import { random } from 'lodash';
-import { POLICE, neighbours, type Board, type Moves } from './gameplay';
+import { sample } from 'lodash';
 import type { BotMove, BotStrategy } from 'strategy-game-factory';
+import { POLICE, THIEF_MOVE_LIMIT, isCaught, neighbours, type Board, type Moves } from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>
 
-export const smartBotStrategy: Bot = ({ board, ctx }) =>
-  ctx.chosenRoleIndex === POLICE ? thiefMove(board) : policemenMoves(board);
+// What the search works on. `firstPolicemanMoved` is not part of it: the bot
+// names a whole police turn at once, so it only ever searches from a fresh one.
+type Position = { policemen: [number, number], thief: number, turnCount: number }
 
-// Both policemen step in the same turn, planned together from the position they
-// start in, so the turn is named as a whole.
-const policemenMoves = (board: Board): BotMove<Moves>[] => {
-  let index0 = board.policemen[0];
-  // where it would catch the thief outright, which overrides any later choice
-  let catchIndex0: number | null = null;
-  for (let i = 0; i < 3; i++) {
-    if (neighbours[board.policemen[0]][i] === board.thief) {
-      index0 = neighbours[board.policemen[0]][i];
-      catchIndex0 = index0;
-    } else {
-      for (let j = 0; j < 3; j++) {
-        if (neighbours[neighbours[board.policemen[0]][i]][j] === board.thief) {
-          index0 = neighbours[board.policemen[0]][i];
-        }
-      }
-    }
-  }
-  if (index0 === board.policemen[0]) {
-    index0 = neighbours[board.policemen[0]][random(0, 2)];
-  }
+// A police turn is where each policeman goes — one decision, nine ways to make it.
+type PoliceTurn = [number, number]
 
-  let index1 = board.policemen[1];
-  let catchIndex1: number | null = null;
-  for (let i = 0; i < 3; i++) {
-    if (
-      neighbours[board.policemen[1]][i] === board.thief &&
-      index0 !== neighbours[board.policemen[1]][i]
-    ) {
-      index1 = neighbours[board.policemen[1]][i];
-      catchIndex1 = index1;
-    } else {
-      for (let j = 0; j < 3; j++) {
-        if (
-          neighbours[neighbours[board.policemen[1]][i]][j] === board.thief &&
-          index0 !== neighbours[board.policemen[1]][i]
-        ) {
-          index1 = neighbours[board.policemen[1]][i];
-        }
-      }
-    }
-  }
-  if (index1 === board.policemen[1]) {
-    while (index1 === index0 || index1 === board.policemen[1]) {
-      index1 = neighbours[board.policemen[1]][random(0, 2)];
-    }
-  }
+const positionOf = (board: Board): Position => ({
+  policemen: [board.policemen[0]!, board.policemen[1]!],
+  thief: board.thief,
+  turnCount: board.turnCount
+});
 
+const policeTurns = ({ policemen }: Position): PoliceTurn[] =>
+  neighbours[policemen[0]].flatMap((first: number) =>
+    neighbours[policemen[1]].map((second: number): PoliceTurn => [first, second]));
+
+const afterPoliceTurn = (position: Position, [first, second]: PoliceTurn): Position =>
+  ({ ...position, policemen: [first, second] });
+
+const afterThiefMove = (position: Position, vertex: number): Position =>
+  ({ ...position, thief: vertex, turnCount: position.turnCount + 1 });
+
+// Three rounds of nine police turns against three thief replies is a few
+// thousand positions, so the chase is solved outright rather than chased
+// greedily. Both sides read their move off the same search.
+const cache = new Map<string, boolean>();
+
+// Do the police win, with a police turn due?
+const policeWinMoving = (position: Position): boolean => {
+  const { policemen, thief, turnCount } = position;
+  const key = `${policemen[0]},${policemen[1]},${thief},${turnCount}`;
+  const cached = cache.get(key);
+  if (cached !== undefined) return cached;
+  const result = policeTurns(position)
+    .some(turn => policeWinAfterPoliceTurn(afterPoliceTurn(position, turn)));
+  cache.set(key, result);
+  return result;
+};
+
+// ... with the police turn just played, so the thief replies unless already caught.
+// The thief may step onto a policeman — never willingly, but it keeps the reply
+// list exactly the rules' one rather than a filtered version of it.
+const policeWinAfterPoliceTurn = (position: Position): boolean =>
+  isCaught(position)
+    || neighbours[position.thief]
+      .every((vertex: number) => policeWinAfterThiefMove(afterThiefMove(position, vertex)));
+
+// ... with the thief's move just played: caught, out of moves, or play on.
+const policeWinAfterThiefMove = (position: Position): boolean =>
+  isCaught(position)
+    || (position.turnCount < THIEF_MOVE_LIMIT && policeWinMoving(position));
+
+// Whether the police, to move, catch the thief with best play from both sides.
+export const policeWin = (board: Board): boolean => policeWinMoving(positionOf(board));
+
+// From a lost position every move loses to best play, so play the one leaving
+// the opponent fewest ways to keep the win — the best chance they pick wrong.
+const fewestBy = <T,>(options: T[], cost: (option: T) => number): T[] => {
+  const best = Math.min(...options.map(cost));
+  return options.filter(option => cost(option) === best);
+};
+
+const policemenTurn = (board: Board): BotMove<Moves>[] => {
+  const position = positionOf(board);
+  const turns = policeTurns(position);
+  const winning = turns.filter(
+    turn => policeWinAfterPoliceTurn(afterPoliceTurn(position, turn))
+  );
+  const [first, second] = sample(winning.length ? winning : fewestBy(turns, turn => {
+    const next = afterPoliceTurn(position, turn);
+    return neighbours[next.thief]
+      .filter((vertex: number) => !policeWinAfterThiefMove(afterThiefMove(next, vertex))).length;
+  }))!;
   return [
-    { move: 'moveFirstPoliceman', args: [catchIndex0 ?? index0] },
-    { move: 'moveSecondPoliceman', args: [catchIndex1 ?? index1] }
+    { move: 'moveFirstPoliceman', args: [first] },
+    { move: 'moveSecondPoliceman', args: [second] }
   ];
 };
 
 const thiefMove = (board: Board): BotMove<Moves> => {
-  let index = board.thief;
-  for (let i = 0; i < 3; i++) {
-    if (
-      neighbours[board.thief][i] !== board.policemen[0] &&
-      neighbours[board.thief][i] !== board.policemen[1]
-    ) {
-      for (let j = 0; j < 3; j++) {
-        const fieldToCheck = neighbours[neighbours[board.thief][i]][j];
-        if (fieldToCheck !== board.policemen[0] && fieldToCheck !== board.policemen[1]) {
-          index = neighbours[board.thief][i];
-        }
-      }
-    }
-  }
-  if (index === board.thief) {
-    index = neighbours[board.thief][random(0, 2)];
-  }
-  return { move: 'moveThief', args: [index] };
+  const position = positionOf(board);
+  const options: number[] = neighbours[position.thief];
+  const escaping = options.filter(
+    vertex => !policeWinAfterThiefMove(afterThiefMove(position, vertex))
+  );
+  const vertex = sample(escaping.length ? escaping : fewestBy(options, option => {
+    const next = afterThiefMove(position, option);
+    // Only two policemen chase three neighbours, so at least one step is never
+    // straight into their arms — walking into one is always the worst option.
+    if (isCaught(next)) return Infinity;
+    return policeTurns(next)
+      .filter(turn => policeWinAfterPoliceTurn(afterPoliceTurn(next, turn))).length;
+  }))!;
+  return { move: 'moveThief', args: [vertex] };
 };
+
+export const smartBotStrategy: Bot = ({ board, ctx }) =>
+  ctx.currentPlayer === POLICE ? policemenTurn(board) : thiefMove(board);

--- a/src/components/games/policeman-thief/policeman-thief-ab/gameplay.ts
+++ b/src/components/games/policeman-thief/policeman-thief-ab/gameplay.ts
@@ -79,7 +79,7 @@ export const moves = {
       if (isGameEnd(nextBoard)) {
         return {
           nextBoard,
-          gameEnd: { winnerIndex: hasFirstPlayerWon(nextBoard) ? POLICE : THIEF }
+          gameEnd: { winnerIndex: isCaught(nextBoard) ? POLICE : THIEF }
         };
       }
       return { nextBoard, isTurnEnd: true };
@@ -108,7 +108,7 @@ export const moves = {
       if (isGameEnd(nextBoard)) {
         return {
           nextBoard,
-          gameEnd: { winnerIndex: hasFirstPlayerWon(nextBoard) ? POLICE : THIEF }
+          gameEnd: { winnerIndex: isCaught(nextBoard) ? POLICE : THIEF }
         };
       }
       return { nextBoard, isTurnEnd: true };
@@ -118,15 +118,12 @@ export const moves = {
 
 export type Moves = typeof moves;
 
-const isGameEnd = (board: Board) => {
-  if (board.turnCount === 3) {
-    return true;
-  } else if (board.thief === board.policemen[0] || board.thief === board.policemen[1]) {
-    return true;
-  }
-  return false;
-};
+// The thief escapes by surviving this many moves; the police win by sharing an
+// intersection with them before that.
+export const THIEF_MOVE_LIMIT = 3;
 
-const hasFirstPlayerWon = (board: Board) => {
-  return board.turnCount < 4 && board.policemen.includes(board.thief);
-};
+export const isCaught = ({ policemen, thief }: Pick<Board, 'policemen' | 'thief'>): boolean =>
+  policemen.includes(thief);
+
+const isGameEnd = (board: Board) =>
+  isCaught(board) || board.turnCount === THIEF_MOVE_LIMIT;


### PR DESCRIPTION
Both halves of the bot were greedy one-step heuristics. This replaces them with one exact search over the real rules.

## What was wrong

The **thief's** rule asked only whether a road was free *right now* and whether the square beyond it had any free neighbour — never whether the police could reach it next turn. Its loop also kept the **last** qualifying road rather than a safe one, so the choice among candidates was arbitrary.

The **police** rule closed in when the thief was one or two roads away, and otherwise moved at random. That drops the wins where the second policeman has to cut the thief off rather than chase.

## How much it actually costs — and a correction

Solving the chase exactly (8 intersections forming a cube, two policemen, three thief moves) and comparing move by move finds **96 police and 96 thief blunders across all positions**.

That number is misleading on its own, and an earlier version of this description leaned on it. It counts positions *in the abstract*. It does not ask whether the bot ever **reaches** them while playing its own strategy from a legal start board. Restricted to positions the bot actually meets in a real game:

| variant | bot's side | starts it should win | reachable blunders |
|---|---|---|---|
| A (police together) | police | 8 | **0** |
| A (police together) | thief | 24 | **0** |
| B (police apart) | police | 56 | **48** |
| B (police apart) | thief | 72 | **0** |

So:

- **Variant A is unaffected in play**, on either side.
- **The thief half is a correctness fix with no observable symptom** — by the time its bad positions arise, the thief is already lost, so the wrong move costs nothing.
- **Variant B with the bot as police is the real defect**, and it is never *forced*: the losing move is always one of the guesses its random fallback makes. There is no fixed line that reproduces it every time.

What is measurable is variant B against a human thief playing well:

| | thief escapes |
|---|---|
| before | **72.6%** |
| after | **53.6%** |

53.6% is exactly the share of variant-B start boards the thief genuinely wins — i.e. the bot now wins when and only when it should. (Of the rest: 42.9% of games are police-wins where the old bot still lets the thief escape 44.4% of the time, 3.6% are police-wins it never loses.)

Concretely, from blue=0, green=1, thief=6: blue is forced to 4, but green picks among 0, 3 and 5 uniformly and only green→3 keeps the win — so two times in three the bot throws away a won game on move one.

## This is not a regression in the bot

Worth recording, because it changes where to look for others like it.

The strategy has **never been edited** since the game landed in `d50dcca9` "rendorok, tolvaj játék v1" (#110), 2024-07-11. The code replaced here is that original logic, only renamed — `blue1`/`blue2`/`red` → `policemen`/`thief`, `getRandomInt(3)` → `random(0, 2)`. Same two-level neighbour loops, same fallbacks, same spin loop. Every commit touching the file since was mechanical: the moves API (#131), TypeScript (#245), folder reorgs, the named-move refactors (#388/#389/#393), gameplay extraction (#395), quote style (#422), comments (#425), path aliases (#437).

What changed was the game. `35e54ab4` "Add 9kb policeman thief" (#199), 2026-01-24, added **variant B** — policemen may start on different intersections — and reused the existing bot unchanged; its diff touches only `app.js`, `gameList.js` and `policeman-thief.js`.

For its first eighteen months the heuristic was, in practice, unbeatable: "close in on the thief" happens to be exactly right when both policemen start stacked. Variant B invalidated the precondition the heuristic silently rested on. No review of #199 would have caught it, because #199 did not touch the strategy.

## The rewrite

Three rounds of nine police turns against three thief replies is a few thousand positions, so the game is solved outright rather than chased greedily. Both sides read their move off the same search; from a lost position either side plays the move leaving the opponent fewest ways to keep the win.

That also retires the strategy's **spin loop** — a `while` re-rolling a random neighbour until it differed — and its unreachable fallbacks.

In `gameplay.ts`, `hasFirstPlayerWon`'s `turnCount < 4` guard was always true, since the game ends at 3. It has been dead since the original commit, which already ended the game at `turnCount === 3`. The win condition is now just `isCaught`, shared with the search along with `THIEF_MOVE_LIMIT`.

## Tests

New `bot-strategy.spec.ts` grades the search against an **independent reference solver** written from the rules — no memoisation, no code shared with the module — over all 1536 positions, following the pattern `policeman-thief-c`'s spec already uses.

It also pins the characterisation that falls out: with both policemen starting together, the thief is caught **exactly at the opposite corner of the cube** — three roads lead out of it and two policemen, splitting up, cover them all.

Beyond that, both sides must keep a decided position from every position they hold it in, name only legal steps, and win a played-out match through the engine against an opponent moving at random. Control run: the old bot **fails 9 of these**, three of which depend only on the independent reference.