### PR TITLE
Refuse to start a two-player game with colliding names

### DIFF
--- a/src/components/strategy-game-factory/game-parts/common/player-names.spec.ts
+++ b/src/components/strategy-game-factory/game-parts/common/player-names.spec.ts
@@ -1,0 +1,47 @@
+import { translate, type I18nString } from 'language';
+import { DEFAULT_PLAYER_NAMES, resolvePlayerNames, havePlayerNameCollision } from './player-names';
+
+const t = (texts: I18nString) => translate(texts, 'hu');
+const [firstDefault, secondDefault] = DEFAULT_PLAYER_NAMES.map(t);
+
+describe('resolvePlayerNames', () => {
+  it('keeps the typed names', () => {
+    expect(resolvePlayerNames(['Alice', 'Bob'], t)).toEqual(['Alice', 'Bob']);
+  });
+
+  it('fills in the default name of the seat left empty', () => {
+    expect(resolvePlayerNames(['Alice', ''], t)).toEqual(['Alice', secondDefault]);
+    expect(resolvePlayerNames([], t)).toEqual([firstDefault, secondDefault]);
+  });
+
+  it('treats a blank name as empty', () => {
+    expect(resolvePlayerNames(['   ', 'Bob'], t)).toEqual([firstDefault, 'Bob']);
+  });
+});
+
+describe('havePlayerNameCollision', () => {
+  it('accepts two different names', () => {
+    expect(havePlayerNameCollision(['Alice', 'Bob'], t)).toBe(false);
+  });
+
+  it('accepts both names left empty, since the defaults differ', () => {
+    expect(havePlayerNameCollision(['', ''], t)).toBe(false);
+    expect(havePlayerNameCollision([], t)).toBe(false);
+  });
+
+  it('rejects the same name typed twice, however it is capitalised', () => {
+    expect(havePlayerNameCollision(['Alice', 'Alice'], t)).toBe(true);
+    expect(havePlayerNameCollision(['Alice', 'alice'], t)).toBe(true);
+  });
+
+  it('rejects a typed default name next to an empty field', () => {
+    expect(havePlayerNameCollision(['', firstDefault], t)).toBe(true);
+    expect(havePlayerNameCollision([firstDefault, ''], t)).toBe(true);
+    expect(havePlayerNameCollision(['', secondDefault], t)).toBe(true);
+    expect(havePlayerNameCollision([secondDefault, ''], t)).toBe(true);
+  });
+
+  it('accepts a typed default name when the other player typed one too', () => {
+    expect(havePlayerNameCollision([firstDefault, 'Bob'], t)).toBe(false);
+  });
+});

--- a/src/components/strategy-game-factory/game-parts/common/player-names.ts
+++ b/src/components/strategy-game-factory/game-parts/common/player-names.ts
@@ -1,0 +1,27 @@
+import type { I18nString } from 'language';
+
+type Translate = (texts: I18nString) => string;
+
+export const DEFAULT_PLAYER_NAMES: [I18nString, I18nString] = [
+  { hu: '1. játékos', en: '1st player' },
+  { hu: '2. játékos', en: '2nd player' }
+];
+
+/** The names the game's messages actually use: what was typed, or the default. */
+export const resolvePlayerNames = (names: string[], t: Translate): [string, string] => [
+  names[0]?.trim() || t(DEFAULT_PLAYER_NAMES[0]),
+  names[1]?.trim() || t(DEFAULT_PLAYER_NAMES[1])
+];
+
+// Two players reading the same name in "Következik: …" cannot tell whose turn it
+// is, so the setup refuses to start such a game. Checked under both seatings
+// because a name only takes its seat when its owner presses "I start": leaving
+// one field empty while the other says "1st player" is a collision if the empty
+// one goes first, and typing it into the first field collides the other way
+// round. Rejecting both keeps the rule a property of what was typed rather than
+// of which button is about to be pressed.
+export const havePlayerNameCollision = (names: string[], t: Translate): boolean =>
+  [[names[0], names[1]], [names[1], names[0]]].some(seating => {
+    const [first, second] = resolvePlayerNames(seating, t);
+    return first.toLowerCase() === second.toLowerCase();
+  });

--- a/src/components/strategy-game-factory/game-parts/game-sidebar/game-sidebar.spec.tsx
+++ b/src/components/strategy-game-factory/game-parts/game-sidebar/game-sidebar.spec.tsx
@@ -21,14 +21,14 @@ const defaultMoves: SidebarMoves = {
   canUndo: false
 };
 
-const renderSidebar = (ctxOverrides: Partial<Ctx> = {}) => {
+const renderSidebar = (ctxOverrides: Partial<Ctx> = {}, playerNames: string[] = ['', '']) => {
   const ctx = makeCtx({ currentPlayer: 0, ...ctxOverrides });
   return render(
     <MemoryRouter>
       <GameSidebar
         stepDescription=""
         ctx={ctx}
-        playerNames={[]}
+        playerNames={playerNames}
         moves={defaultMoves}
         variants={[{ hasBotStrategy: true, originalIndex: 0, disabled: false }]}
         selectedVariantIndex={0}
@@ -41,6 +41,31 @@ describe('GameSidebar', () => {
   it('shows name inputs in vsHuman roleSelection', () => {
     renderSidebar({ isHumanVsHumanGame: true, phase: 'roleSelection' });
     expect(screen.getAllByRole('textbox')).toHaveLength(2);
+  });
+
+  describe('colliding player names', () => {
+    const nameSetup = (playerNames: string[]) =>
+      renderSidebar({ isHumanVsHumanGame: true, phase: 'roleSelection' }, playerNames);
+    const startButtons = () => [0, 1].map(i => screen.getByTestId(`start-hh-game-${i}`));
+
+    it('lets the game start with two different names', () => {
+      nameSetup(['Alice', 'Bob']);
+      expect(startButtons().every(button => (button as HTMLButtonElement).disabled)).toBe(false);
+      expect(screen.queryByRole('alert')).toBeNull();
+    });
+
+    it('blocks both starts when the same name is typed twice', () => {
+      nameSetup(['Alice', 'Alice']);
+      expect(startButtons().every(button => (button as HTMLButtonElement).disabled)).toBe(true);
+      expect(screen.getByRole('alert').textContent).toContain('nem lehet azonos');
+    });
+
+    it('blocks the start when a name matches the default of the empty field', () => {
+      nameSetup(['', '1. játékos']);
+      expect(startButtons().every(button => (button as HTMLButtonElement).disabled)).toBe(true);
+      // the empty field is the confusing part, so the message spells out what fills it in
+      expect(screen.getByRole('alert').textContent).toContain('Az üresen hagyott mező');
+    });
   });
 
   it('does not show name inputs in vsComputer roleSelection', () => {

--- a/src/components/strategy-game-factory/game-parts/game-sidebar/game-sidebar.tsx
+++ b/src/components/strategy-game-factory/game-parts/game-sidebar/game-sidebar.tsx
@@ -3,6 +3,7 @@ import { Input } from '@headlessui/react';
 import { useTranslation, type I18nString } from 'language';
 import { ModeSelector, DifficultySelector } from '../common/game-controls';
 import { getCtaText } from '../common/cta-text';
+import { DEFAULT_PLAYER_NAMES, havePlayerNameCollision } from '../common/player-names';
 import type { Ctx, Mode, Variant } from '../../types';
 
 import type { Stats } from '../../hooks/use-game-stats';
@@ -202,6 +203,8 @@ const PlayerNameSetup = ({ roleLabels, playerNames, setPlayerNames, onStart }: {
   onStart: () => void
 }) => {
   const { t } = useTranslation();
+  const hasCollision = havePlayerNameCollision(playerNames, t);
+  const hasEmptyName = !playerNames[0] || !playerNames[1];
   return (
   <div className="flex flex-col gap-2 sm:gap-3">
     {([0, 1] as const).map(i => (
@@ -216,6 +219,7 @@ const PlayerNameSetup = ({ roleLabels, playerNames, setPlayerNames, onStart }: {
             { hu: 'Neved (Teknős)', en: 'Your name (Dot)' }
           ][i])}
           value={playerNames[i]}
+          aria-invalid={hasCollision}
           onChange={e => {
             const updated: [string, string] = [playerNames[0], playerNames[1]];
             updated[i] = e.target.value.trim();
@@ -225,7 +229,8 @@ const PlayerNameSetup = ({ roleLabels, playerNames, setPlayerNames, onStart }: {
         <button
           data-testid={`start-hh-game-${i}`}
           className="shrink-0 px-2 py-1 text-sm font-semibold rounded-md
-            bg-blue-500 text-white hocus:bg-blue-600"
+            bg-blue-500 text-white enabled:hocus:bg-blue-600 disabled:opacity-50"
+          disabled={hasCollision}
           onClick={() => {
             setPlayerNames([playerNames[i], playerNames[1 - i]]);
             onStart();
@@ -236,6 +241,20 @@ const PlayerNameSetup = ({ roleLabels, playerNames, setPlayerNames, onStart }: {
         </button>
       </div>
     ))}
+    {hasCollision && (
+      <p role="alert" className="text-sm text-red-500">
+        {t({
+          hu: 'A két játékos neve nem lehet azonos.',
+          en: 'The two players must have different names.'
+        })}
+        {hasEmptyName && ' ' + t({
+          hu: `Az üresen hagyott mező helyére „${t(DEFAULT_PLAYER_NAMES[0])}", `
+            + `illetve „${t(DEFAULT_PLAYER_NAMES[1])}" kerül.`,
+          en: `An empty field is filled in as "${t(DEFAULT_PLAYER_NAMES[0])}" `
+            + `or "${t(DEFAULT_PLAYER_NAMES[1])}".`
+        })}
+      </p>
+    )}
   </div>
   );
 };

--- a/src/components/strategy-game-factory/strategy-game-factory.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.tsx
@@ -19,11 +19,7 @@ import { buildCtx } from './engine/build-ctx';
 import { asBotMoves, isBotTurnUnfinished, unknownMoveMessage } from './engine/bot-turn';
 import { reduceMove } from './engine/reducer';
 import { stepDelay } from './engine/timing';
-
-const DEFAULT_PLAYER_NAMES: I18nString[] = [
-  { hu: '1. játékos', en: '1st player' },
-  { hu: '2. játékos', en: '2nd player' }
-];
+import { resolvePlayerNames } from './game-parts/common/player-names';
 
 export interface Presentation<TBoard, TTurnState = unknown> {
   rule: TranslatableNode
@@ -109,10 +105,7 @@ export const strategyGameFactory = <TBoard, TTurnState = unknown>({
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [currentPlayer, isHumanVsHumanGame, phase, chosenRoleIndex]);
 
-    const resolvedPlayerNames: [string, string] = [
-      playerNames[0] || t(DEFAULT_PLAYER_NAMES[0]),
-      playerNames[1] || t(DEFAULT_PLAYER_NAMES[1])
-    ];
+    const resolvedPlayerNames = resolvePlayerNames(playerNames, t);
 
     let wrappedGameMoves: GameMoves<TBoard, TTurnState> = {} as GameMoves<TBoard, TTurnState>;
 


### PR DESCRIPTION
Fixes #446.

In two-player mode the sidebar's messages (`Következik: …`, `A játékot nyerte: …`) and the turn panel all read `ctx.resolvedPlayerNames` — the typed name, or the default `1. játékos` / `2. játékos`. Nothing stopped both seats from resolving to the same string, so both players could read the same name and not know whose turn it was.

## What changed

- New `game-parts/common/player-names.ts` holds `DEFAULT_PLAYER_NAMES` (moved out of `strategy-game-factory.tsx`, which now calls the shared `resolvePlayerNames`) plus `havePlayerNameCollision`.
- A pair is rejected under **either** seating, not just the one about to be played: a name only takes its seat when its owner presses "Kezdek", so `["", "1. játékos"]` and `["1. játékos", ""]` are both refused. That keeps the rule a property of what was typed rather than of which button is about to be pressed. The comparison is case-insensitive and blank-tolerant, so `Anna` / `anna` collides too.
- `PlayerNameSetup` disables both start buttons on a collision, marks the inputs `aria-invalid`, and shows a `role="alert"` message. The message gets a second sentence naming the fill-in defaults only when a field is actually empty, since that is the non-obvious half of the rule.

## Testing

- `player-names.spec.ts` covers name resolution and every collision case (same name, case differences, typed default next to an empty field in both orders, and the pairs that must stay allowed).
- `game-sidebar.spec.tsx` asserts the start buttons disable and the right message renders.
- Full suite (1784 tests), lint and typecheck pass.
- Driven in a real browser as well: same-name and empty-vs-default both block the start, clearing the collision re-enables it, and the game then starts and names the players normally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZbKxZ8WBbMYz6wEogqNAd)_