### PR TITLE
Put whose turn it is in both magic-box memo keys

### DIFF
--- a/src/components/games/magic-box/magic-box-a/bot-strategy.spec.ts
+++ b/src/components/games/magic-box/magic-box-a/bot-strategy.spec.ts
@@ -35,6 +35,32 @@ describe('smartBotStrategy', () => {
     expect([0, 4, 8]).toContain(smartBotPlacement(board, 0));
   });
 
+  // The search memoises by position, and the same position is asked about for
+  // both roles — vitest runs with `isolate: false`, so another spec that played
+  // this game has already filled that cache by the time this file runs. If whose
+  // turn it is is left out of the memo key, the answers below come back for the
+  // wrong player.
+  it('should force the same win after the cache has been filled for the other role', () => {
+    for (let firstMove = 0; firstMove < 9; firstMove++) {
+      let board = placeStone(generateEmptyBoard(), firstMove);
+      let mover = 0;
+      while (!isGameEnd(board)) {
+        board = placeStone(board, smartBotPlacement(board, mover));
+        mover = 1 - mover;
+      }
+    }
+
+    for (let firstMove = 0; firstMove < 9; firstMove++) {
+      let board = placeStone(generateEmptyBoard(), firstMove);
+      let mover = 1;
+      while (!isGameEnd(board)) {
+        board = placeStone(board, smartBotPlacement(board, mover));
+        mover = 1 - mover;
+      }
+      expect(mover).toBe(1);
+    }
+  });
+
   it('should let the second player always force a win with optimal play from an empty board', () => {
     for (let firstMove = 0; firstMove < 9; firstMove++) {
       let board = placeStone(generateEmptyBoard(), firstMove);

--- a/src/components/games/magic-box/magic-box-a/bot-strategy.ts
+++ b/src/components/games/magic-box/magic-box-a/bot-strategy.ts
@@ -12,8 +12,11 @@ const emptyCells = (board: Board) => range(0, 9).filter(i => !board[i]);
 const winnerCache = new Map<string, number>();
 
 // given it is someone's turn at this board (no full line yet), which player wins with optimal play?
+// The winner depends on whose turn it is as well as on the board, so both go in
+// the key: the same board is evaluated for either player, and a stale entry from
+// the other player's search would answer the wrong question.
 const winner = (board: Board, toMove: number): number => {
-  const key = board.join('');
+  const key = `${board.join('')}|${toMove}`;
   const cached = winnerCache.get(key);
   if (cached !== undefined) return cached;
 

--- a/src/components/games/magic-box/magic-box-b/bot-strategy.ts
+++ b/src/components/games/magic-box/magic-box-b/bot-strategy.ts
@@ -27,11 +27,15 @@ export const smartBotStrategy: Bot = ({ board, ctx }) => {
 
 const winnerCache = new Map<string, number>();
 
-const cacheKey = (stones: boolean[], pendingLine: number | null) => `${stones.join('')}|${pendingLine}`;
+// The winner depends on whose turn it is as well as on the position, so both go
+// in the key. A designation passes the turn without placing a stone, so the
+// stone count does not determine the mover and cannot stand in for it.
+const cacheKey = (stones: boolean[], pendingLine: number | null, toMove: number) =>
+  `${stones.join('')}|${pendingLine}|${toMove}`;
 
 // given it is toMove's turn at this state, who wins the rest of the game with optimal play?
 const winner = (stones: boolean[], pendingLine: number | null, toMove: number): number => {
-  const key = cacheKey(stones, pendingLine);
+  const key = cacheKey(stones, pendingLine, toMove);
   const cached = winnerCache.get(key);
   if (cached !== undefined) return cached;
 


### PR DESCRIPTION
magic-box-b/bot-strategy.spec.ts's "role 1 always wins" test fails about half the time, and magic-box-a's "second player always forces a win" fails every time, but only when plays-to-an-end.spec.ts happens to run first in the same worker. Alone, both files pass.

Both bots memoise who wins from a position, in a module-level Map. The result depends on whose turn it is — `winner` returns `toMove` or `1 - toMove` — but neither key included it. Within one game that is survivable, since the stone count tracks the mover; across callers it is not. plays-to-an-end plays both games from the real start with the bot in either seat, so it fills the cache with answers to the opposite question. vitest runs with `isolate: false`, so that cache is still there when the bot spec runs, and the bot then plays a losing move believing it wins. magic-box-b breaks the stone-count fallback too: its opening turn designates a line without placing a stone, so the count does not determine the mover even within a single game.

Both keys now carry toMove.

magic-box-a gains a regression test that reproduces it in-file: fill the cache by playing as role 0, then assert the role 1 forced win still holds. It fails on the old key and passes on the new one.

magic-box-b has no such test. Its losing side plays a random fallback, so a comparison across two cache states is noisy, and every in-file guard I built either missed the bug or was itself flaky — which is no way to guard against flakiness. Its fix is verified by the pairing that reproduced it: 25 consecutive paired runs green, against 5 of 10 failing before.


Claude-Session: https://claude.ai/code/session_011Mgc4SutoECEcSE4bpShia