### PR TITLE
Enforce the leading-underscore convention for unused parameters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,6 +208,24 @@ This applies with particular force to moves on the outcome-returning `apply`
 contract: `gameEnd: { winnerIndex }` already names the winner, so prose
 narrating who won earns nothing.
 
+## Unused parameters
+
+A parameter that has to be written but is never read starts with `_`: the `meta`
+slot of a move whose `validate` only asks about the board, the value slot of an
+`(_, i) => …` callback. A bare `_` is fine when it is the only unused parameter
+in the signature; give it a name (`_board`, `_meta`) when a second one would
+collide with it, or when the name is worth reading.
+
+ESLint enforces this (`no-unused-vars` with `args: 'all'`), so an unused
+parameter left under its real name is an error rather than a silent
+inconsistency.
+
+The rule is about parameters you are *forced* to write. One that is merely
+unwanted should be dropped instead — trailing parameters can simply be left off
+(`apply: (board: Board) => …`), and an unwanted key is left out of the
+destructuring, which is why bots and `getPlayerStepDescription` write
+`({ board })` rather than underscoring `ctx`.
+
 ## Pull request size
 
 Reviewer time is the scarcest resource here, so plan the split **before**

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -41,7 +41,16 @@ export default [
     },
     rules: {
       'no-unused-vars': 'off',
-      '@typescript-eslint/no-unused-vars': 'error',
+      // A parameter whose slot is fixed by a contract has to be written even
+      // when unused — a move's `meta` sits before its game-specific args. `^_`
+      // is how such a parameter says it is ignored on purpose; `args: 'all'`
+      // is what stops an ordinary name from going unnoticed in that slot.
+      '@typescript-eslint/no-unused-vars': ['error', {
+        args: 'all',
+        argsIgnorePattern: '^_',
+        caughtErrors: 'all',
+        caughtErrorsIgnorePattern: '^_'
+      }],
       '@typescript-eslint/consistent-type-imports': 'error',
       'no-restricted-syntax': ['error', {
         selector: 'TSAsExpression > TSNeverKeyword.typeAnnotation',

--- a/src/components/CLAUDE.md
+++ b/src/components/CLAUDE.md
@@ -77,6 +77,12 @@ alone and fail loudly (dev: throw; prod: warn + `illegal-move` analytics event
 (two-phase turn) and `cube-coloring` (reuses the existing `isAllowedStep`
 helper) for examples.
 
+Both halves take `(board, { ctx }, ...args)`, and the meta slot sits *before* the
+game-specific args, so it has to be written even when the move ignores it. Write
+it `_` then — `validate: (board: Board, _, cell: number) => …` — and `_board`
+when it is the board that goes unread instead. This is the repo-wide rule for
+unused parameters (AGENTS.md § Unused parameters); ESLint enforces it.
+
 **`moves.<name>.isAllowed(board, ...args)`** — exposed on every move of the
 `BoardClient`'s wrapped `moves` object: `ctx.isClientMoveAllowed` (turn
 ownership) AND the move's `validate` (when defined), with `ctx` already bound.

--- a/src/components/games/coins-in-3-piles/gameplay.ts
+++ b/src/components/games/coins-in-3-piles/gameplay.ts
@@ -60,7 +60,7 @@ export const moves = {
     }
   },
   addCoin: {
-    validate: (board: Board, { ctx }: { ctx: Ctx<TurnState> }, value: number) => {
+    validate: (_board: Board, { ctx }: { ctx: Ctx<TurnState> }, value: number) => {
       const removed = ctx.turnState?.removedCoinValue;
       return removed != null && value >= 1 && value < removed;
     },
@@ -71,7 +71,7 @@ export const moves = {
     }
   },
   passAddition: {
-    validate: (board: Board, { ctx }: { ctx: Ctx<TurnState> }) => ctx.turnState !== null,
+    validate: (_board: Board, { ctx }: { ctx: Ctx<TurnState> }) => ctx.turnState !== null,
     apply: (board: Board, { ctx }: { ctx: Ctx<TurnState> }) => finishPlaceBack(board, ctx)
   }
 }

--- a/src/components/games/four-piles-two-grabs/gameplay.ts
+++ b/src/components/games/four-piles-two-grabs/gameplay.ts
@@ -30,7 +30,7 @@ const isMoveLegal = (board: Board, move: Move): boolean =>
 // Every legal move: pick two non-empty piles, remove between 1 and the whole
 // pile from each. Amounts removed from the two piles are independent.
 export const getLegalMoves = (board: Board): Move[] => {
-  const nonEmpty = board.map((v, i) => i).filter(i => board[i] > 0);
+  const nonEmpty = board.map((_, i) => i).filter(i => board[i] > 0);
   const moves: Move[] = [];
   for (let a = 0; a < nonEmpty.length; a++) {
     for (let b = a + 1; b < nonEmpty.length; b++) {

--- a/src/components/games/hunyadi-and-the-janissaries/gameplay.ts
+++ b/src/components/games/hunyadi-and-the-janissaries/gameplay.ts
@@ -63,7 +63,7 @@ const isSoldierAssignmentAllowed = (board: Board, soldiers: Soldier[]): boolean 
 
 export const moves = {
   killGroup: {
-    validate: (board: Board, { ctx }, group: SoldierColor) =>
+    validate: (_board: Board, { ctx }, group: SoldierColor) =>
       ctx.currentPlayer === HUNYADI && isColor(group),
     apply: (board: Board, _, group: SoldierColor) => {
       const nextBoard = board.map(row => row.filter(soldier => soldier !== group));
@@ -75,7 +75,7 @@ export const moves = {
     }
   },
   finalizeSeparation: {
-    validate: (board: Board, { ctx }) => ctx.currentPlayer === SULTAN,
+    validate: (_board: Board, { ctx }) => ctx.currentPlayer === SULTAN,
     apply: (board: Board) => ({ nextBoard: board, isTurnEnd: true })
   },
   setGroupOfSoldiers: {

--- a/src/components/games/single-number-increase/plus-one-two-three/gameplay.ts
+++ b/src/components/games/single-number-increase/plus-one-two-three/gameplay.ts
@@ -12,7 +12,7 @@ const isIncreaseValid = ({ board, number }: { board: Board; number: number }): b
 export const moves = {
   increaseTo: {
     validate: (board: Board, _, number: number) => isIncreaseValid({ board, number }),
-    apply: (_: Board, { ctx }: { ctx: Ctx }, number: number): MoveOutcome<Board> => {
+    apply: (_board: Board, { ctx }: { ctx: Ctx }, number: number): MoveOutcome<Board> => {
       if (number > target) {
         return { nextBoard: number, gameEnd: { winnerIndex: 1 - ctx.currentPlayer! } };
       }

--- a/src/components/games/two-of-three-takeaway/bot-strategy.ts
+++ b/src/components/games/two-of-three-takeaway/bot-strategy.ts
@@ -10,7 +10,7 @@ export const isWinningInOneMove = (board: Board, move: Move): boolean =>
   isTerminal(applyMove(board, move));
 
 const oddPiles = (board: Board): number[] =>
-  board.map((v, i) => i).filter(i => board[i] % 2 === 1);
+  board.map((_, i) => i).filter(i => board[i] % 2 === 1);
 
 // Because the total is even, the number of odd piles is even: either 0 (all
 // piles even — type (a)) or 2 (two odd, one even — type (b)). The player to

--- a/src/components/games/two-of-three-takeaway/gameplay.ts
+++ b/src/components/games/two-of-three-takeaway/gameplay.ts
@@ -24,7 +24,7 @@ export const isTakeAllowed = (board: Board, i: number, j: number): boolean =>
   isPile(i) && isPile(j) && i !== j && board[i] > 0 && board[j] > 0;
 
 export const getLegalMoves = (board: Board): Move[] => {
-  const nonEmpty = board.map((v, i) => i).filter(i => board[i] > 0);
+  const nonEmpty = board.map((_, i) => i).filter(i => board[i] > 0);
   const moves: Move[] = [];
   for (let a = 0; a < nonEmpty.length; a++) {
     for (let b = a + 1; b < nonEmpty.length; b++) {


### PR DESCRIPTION
`_` is already how this repo writes a parameter it cannot delete — ~154 of them across ~80 files — but nothing enforced it, and it wasn't written down.

## The rule was holding by accident

`@typescript-eslint/no-unused-vars` ran with **no options**, so `args` defaulted to `after-used`: a parameter before the last used one is never checked. That is the entire reason `validate: (board: Board, _, cell: number)` passes — not an ignore pattern, just a default that looks the other way. Two consequences:

- Four sites did exactly what three others spell `_board`, and simply didn't rename. Lint had nothing to say about it.
- The reverse hole: a *trailing* `_` **was** an error, for want of an `argsIgnorePattern`. The convention was half-illegal.

## The change

```js
'@typescript-eslint/no-unused-vars': ['error', {
  args: 'all',
  argsIgnorePattern: '^_',
  caughtErrors: 'all',
  caughtErrorsIgnorePattern: '^_'
}],
```

`args: 'all'` is what closes the hole; `argsIgnorePattern` is what keeps the ~154 existing sites legal and makes a trailing `_` legal too. The `caughtErrors` pair restates the v8 default and adds the matching escape hatch — both `catch` sites use the binding-less form, so it is purely forward-looking.

That flagged **exactly seven sites**, and they are the whole code diff:

| | sites | fix |
|---|---|---|
| `validate` reading only `ctx`, board unread | 4 | → `_board`, as `architect-and-bandits`, `primely-to-zero` and `three-piles-rebuild` already wrote it |
| one copy-pasted `board.map((v, i) => i)`, in three files | 3 | → `_`, as the other 32 array callbacks already wrote it |

Renames only — no behaviour change, and the engine and overview page are untouched. One extra line of the same kind: `plus-one-two-three` annotated the board slot `_: Board` where its two siblings write `_board: Board`.

## Writing it down

`AGENTS.md` gains a short **Unused parameters** section, and `src/components/CLAUDE.md` a note next to the `(board, { ctx }, ...args)` contract that causes ~95 of the cases — the meta slot sits *before* the game-specific args, so it has to be written even when ignored.

The rule: an unused parameter starts with `_`; a bare `_` when it is the only one, a name (`_board`, `_meta`) when a second would collide or the name earns its keep. A parameter that is merely *unwanted* is still dropped rather than underscored — trailing ones left off, unwanted keys left out of the destructuring, which is why bots write `({ board })` instead of underscoring `ctx`.

## Verification

`lint`, `typecheck` and the full suite (1784 tests, 189 files) pass. `tsc --noEmit --noUnusedParameters`, an independent second opinion, went 7 → 0. The rule was checked to actually bite: un-underscoring one `_board` errors, as it should.

---
_Generated by [Claude Code](https://claude.ai/code/session_013NQxnqF63PJPtENud3qPiB)_