### PR TITLE
Pin the web container's Node in the session-start hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -9,9 +9,34 @@ fi
 
 cd "$CLAUDE_PROJECT_DIR"
 
-# Exact versions are pinned (save-exact + package-lock), so npm ci is the
-# right install. Skip it when node_modules already exists — the container
-# state is cached between sessions, so this keeps repeat startups fast.
-if [ ! -d node_modules ]; then
+# The web container is not the devcontainer, so nothing there pins Node: it
+# ships whatever its image has, and an npm of the wrong major resolves this
+# lockfile differently and fails `npm ci` outright. nvm is in the image, so
+# install the pinned Node and put it ahead of the image's own on PATH.
+# Symlinks are what makes that stick — every later shell is a fresh process,
+# so anything this one exports dies with it, and ~/.bashrc returns early for
+# non-interactive shells before it would load nvm.
+export NVM_DIR="${NVM_DIR:-/opt/nvm}"
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+  # nvm.sh returns non-zero on a clean load, which `set -e` would treat as fatal.
+  . "$NVM_DIR/nvm.sh" || true
+  nvm install > /dev/null  # no argument: reads .nvmrc, so the pin stays single-sourced
+  mkdir -p "$HOME/.local/bin"
+  for bin in node npm npx corepack; do
+    ln -sf "$(dirname "$(nvm which current)")/$bin" "$HOME/.local/bin/$bin"
+  done
+  case ":$PATH:" in
+    *":$HOME/.local/bin:"*) ;;
+    *) echo "session-start: $HOME/.local/bin is not on PATH, so the pinned Node is not in use." >&2 ;;
+  esac
+fi
+
+# Exact versions are pinned (save-exact + package-lock), so npm ci is the right
+# install. Ask npm whether the tree is sound rather than testing for the
+# directory: a failed npm ci leaves a partial node_modules behind, which a
+# directory test reads as installed, and the next session inherits the wreckage
+# because the container state is cached. A sound tree answers in well under a
+# second, so repeat startups stay fast.
+if ! npm ls --depth=0 > /dev/null 2>&1; then
   npm ci
 fi

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Two ways to get started:
   creation only has to run `npm ci`. It also ships the GitHub CLI and keeps `gh`
   and Claude Code logins in named volumes across rebuilds.
 
+Claude Code on the web is neither: its container ships its own Node and starts
+without `node_modules`, so `.claude/hooks/session-start.sh` installs the pinned
+Node through nvm and puts it on `PATH` ahead of the image's own, then runs
+`npm ci` unless the installed tree is already sound. It reads the version from
+`.nvmrc` rather than restating it, so it is not another place to keep in sync.
+
 <details>
 <summary>Devcontainer details</summary>
 


### PR DESCRIPTION
Claude Code on the web does not use the devcontainer, so the `node:1` feature that pins 24.11.1 never applies there — the container ships whatever Node its own image has. Here that was v22.22.2 with npm 10, one major behind the npm that wrote `package-lock.json`.

## The failure was self-perpetuating

npm 10 resolves this lockfile differently and aborts:

```
npm error `npm ci` can only install packages when your package.json and
npm error package-lock.json or npm-shrinkwrap.json are in sync.
npm error Missing: @emnapi/core@1.11.3 from lock file
```

The lockfile is not out of sync — `@emnapi/*` is in it, 19 entries, and `npm ci` succeeds under the pinned Node. The message is what npm 10 says about a tree it resolves differently.

The damage came next. A failed `npm ci` leaves a **partial** `node_modules` behind; `[ ! -d node_modules ]` reads that as installed; and the web container's state is cached between sessions. So every later session inherited a tree missing four direct dependencies (`eslint-plugin-react-hooks`, `@vitest/coverage-v8`, both `@stryker-mutator/*`) and never reinstalled — `npm run lint` died with `ERR_MODULE_NOT_FOUND` before running a single rule.

## Two changes

**Install the pinned Node.** nvm is in the image, so install `.nvmrc`'s version and symlink it into `~/.local/bin`, ahead of the image's own Node on `PATH`. Symlinks rather than exports because every later shell is a fresh process — anything the hook exports dies with it, and `~/.bashrc` returns early for non-interactive shells before it would load nvm (`NVM_DIR` is simply unset in them). `nvm install` takes no argument, so it reads `.nvmrc` and the version stays single-sourced — this is not a fifth place to keep in sync.

**Ask npm whether the tree is sound**, rather than testing for the directory. `npm ls --depth=0` heals a partial install instead of preserving it, and answers in well under a second when all is well, so cached containers still start fast.

## Verification

Ran on this session's container, which had the broken tree:

| | |
|---|---|
| `nvm install` picks up `.nvmrc` | `Found '.nvmrc' with version <24.11.1>` |
| plain shell after the hook | `node v24.11.1`, `npm 11.6.2` |
| `npm ci` under the pinned Node | succeeds, `package-lock.json` untouched |
| probe on a deliberately broken tree | returns 1, hook reinstalls, 0 direct deps missing after |
| hook on a sound tree | 4.2 s, no reinstall |
| `npm test` | lint, typecheck, 1785 tests / 189 files pass |

---
_Generated by [Claude Code](https://claude.ai/code/session_013NQxnqF63PJPtENud3qPiB)_