### PR TITLE
Gate PRs on the coverage of the non-JSX lines they add

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -66,6 +66,12 @@ jobs:
           # The merge base has to exist locally for `<base>...HEAD` to resolve; the default shallow
           # fetch gives one commit and the diff would come out as the whole repository.
           fetch-depth: 0
+      # actions/checkout marks the workspace safe itself, but under a HOME it overrides for the
+      # duration of its own steps, so in a container job the setting is gone by the time a later
+      # `run:` calls git — which fails with "detected dubious ownership" rather than anything about
+      # ownership being fine. The other jobs never notice: they run npm, not git.
+      - name: Let git read the checkout
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Cache npm downloads
         uses: actions/cache@v6
         with:

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -43,3 +43,43 @@ jobs:
       - name: Build
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: npm run build
+
+  # A separate job rather than another step of `test`, so the coverage run — the suite again, and
+  # instrumented, so a couple of minutes — happens alongside the checks a contributor is actually
+  # waiting on rather than after them, and so a PR failing this one can still be read as passing
+  # everything else at a glance.
+  #
+  # Skipped, not failed, when the PR carries the `skip coverage` label: a diff with nothing worth
+  # asserting — a generated table, a renamed symbol, a batch of copy edits — should not need a green
+  # check invented for it.
+  patch-coverage:
+    if: >-
+      github.event.pull_request.draft == false &&
+      !contains(github.event.pull_request.labels.*.name, 'skip coverage')
+    runs-on: ubuntu-24.04
+    container:
+      image: node:24.11.1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          # The merge base has to exist locally for `<base>...HEAD` to resolve; the default shallow
+          # fetch gives one commit and the diff would come out as the whole repository.
+          fetch-depth: 0
+      - name: Cache npm downloads
+        uses: actions/cache@v6
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
+      - name: Install dependencies
+        run: npm ci
+      # Deliberately not `npm run coverage`: the plays-to-an-end and renders sweeps execute nearly
+      # every line under games/ while asserting almost nothing, so measured against them a new game
+      # with no spec at all reads as fully covered. See the comment atop scripts/patch-coverage.mjs.
+      - name: Measure coverage without the sweeps
+        run: npm run coverage:unswept -- --coverage.reporter=lcovonly
+      # base.sha is the base branch as of the last sync, which is exactly the merge base the diff
+      # should be taken against — commits landed on main since are not this PR's to cover.
+      - name: Report coverage of added lines
+        run: node scripts/patch-coverage.mjs --base ${{ github.event.pull_request.base.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ npm-debug.log*
 stats.html
 # `npm run report:outdated -- --out dependency-report.md` output
 dependency-report.md
-# `npm run coverage` html report
+# coverage output: the `npm run coverage` html report, and the lcov file
+# `npm run coverage:patch` reads
 /reports
 .claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,20 @@ all**. That is why `coverage.include` in `vite.config.js` names every file under
 drops to near zero is the game logic nothing but a sweep touches. Neither one is
 a measure of whether the bots are right; that is what a bot's own spec is for.
 
+The one coverage number CI does gate on is a different question again:
+`npm run coverage:patch` (`scripts/patch-coverage.mjs`, run by the
+`patch-coverage` job on every PR) measures the lines a branch **adds** to
+non-JSX files under `src/`, against `coverage:unswept`. Added lines cannot be
+diluted by the rest of the repo, so unlike a global percentage the number means
+the same thing in every PR; and measuring without the sweeps is what stops
+`gameList.ts` registration from reading as coverage. Under 85% fails, diffs
+under twenty measured lines never do, and the `skip coverage` label skips the
+job. The bar is a floor under existing habit, not a stretch above it: measured
+over any range of recent history wide enough to mean anything, this repo already
+sits at 87–96%.
+A gate on either of the other two reports would still be wrong for the reasons
+above — don't add one.
+
 ## Planned future directions
 
 ### Primary (ongoing)

--- a/README.md
+++ b/README.md
@@ -120,9 +120,11 @@ npm run lint:fix
 ```bash
 npm run coverage         # line coverage, on demand
 npm run coverage:unswept # the same, without the two all-games sweeps
+npm run coverage:patch   # how much of what your branch adds a spec reaches
 ```
 
-On demand, never part of `npm run test` or CI, and with no threshold to pass.
+The first two are on demand, never part of `npm run test`, and with no threshold
+to pass.
 The plain report is for finding code **no spec loads at all** — it
 lists every file under `src/`, not only the ones a test imported. The global
 percentage is not a target: `plays-to-an-end.spec.ts` and `renders.spec.tsx`
@@ -130,6 +132,17 @@ execute nearly every line under `games/` while asserting almost nothing, so it
 reads high whatever the state of the tests. `coverage:unswept` drops those two,
 and what falls to near zero there is the game logic those sweeps are the only
 thing touching.
+
+`coverage:patch` is the one that runs on every PR. It measures only the lines
+your branch **adds** to non-JSX files under `src/`, and only against
+`coverage:unswept` — so registering a game in `gameList.ts` does not count as
+covering it. Under 85% fails the build, and diffs under twenty measured lines
+never do — below that the percentage is arithmetic rather than a judgement.
+Failing means the added logic is not *unit-tested*, not that it is untested:
+a registered game is still played by `plays-to-an-end.spec.ts`, which catches an
+illegal move or a game that never ends, but nothing there asserts the strategy
+is right. Label the PR `skip coverage` to skip the job when a diff genuinely has
+nothing worth asserting.
 
 ### Build for prod
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:watch": "vitest",
     "coverage": "vitest run --coverage",
     "coverage:unswept": "vitest run --coverage --exclude \"**/plays-to-an-end.spec.ts\" --exclude \"**/renders.spec.tsx\"",
+    "coverage:patch": "npm run coverage:unswept -- --coverage.reporter=lcovonly && node scripts/patch-coverage.mjs",
     "typecheck": "tsc --noEmit",
     "lint": "eslint \"src/**/*.{ts,tsx}\" --no-fix",
     "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix",

--- a/scripts/check-versions.mjs
+++ b/scripts/check-versions.mjs
@@ -45,12 +45,19 @@ compare('Playwright', [
 // instead, the same way the Dockerfile is read above.
 const devcontainer = read('.devcontainer/devcontainer.json');
 
+// A workflow can run more than one containerised job, so every `image: node:` in it is a separate
+// place the version is written down — matching only the first would let a second job drift.
+const workflowNodeImages = file => {
+  const images = [...read(file).matchAll(/^\s*image:\s*node:(.+)$/gm)];
+  return images.length === 0 ? [[file, undefined]] : images.map(([, version], i) => [`${file} job ${i + 1}`, version]);
+};
+
 compare('Node', [
   ['.nvmrc', read('.nvmrc').trim()],
   // ">=24.11.1 <25" — only the lower bound names an exact version.
   ['package.json engines.node', packageJson.engines?.node?.match(/>=\s*(\d+\.\d+\.\d+)/)?.[1]],
-  ['.github/workflows/pr_test.yml', read('.github/workflows/pr_test.yml').match(/^\s*image:\s*node:(.+)$/m)?.[1]],
-  ['.github/workflows/test_and_deploy.yml', read('.github/workflows/test_and_deploy.yml').match(/^\s*image:\s*node:(.+)$/m)?.[1]],
+  ...workflowNodeImages('.github/workflows/pr_test.yml'),
+  ...workflowNodeImages('.github/workflows/test_and_deploy.yml'),
   ['.devcontainer/devcontainer.json node feature', devcontainer.match(/features\/node:1"\s*:\s*\{\s*"version"\s*:\s*"(.+?)"/)?.[1]]
 ]);
 

--- a/scripts/patch-coverage.mjs
+++ b/scripts/patch-coverage.mjs
@@ -1,0 +1,214 @@
+// Reports how much of the *logic* a pull request adds is reached by a spec, and fails the build
+// when too little of it is. Not a coverage threshold: the global percentage is not a measure of
+// anything here (see AGENTS.md § Testing), and a gate on it would be satisfied by registering
+// another game. Only the lines this PR adds are measured, so the number cannot be diluted by the
+// rest of the repo and cannot drift as the repo grows.
+//
+// Two decisions make it mean what it says:
+//
+//   - It reads the coverage of `npm run coverage:unswept`, not `npm run coverage`. The two sweeps
+//     (plays-to-an-end, renders) execute nearly every line under games/ while asserting almost
+//     nothing, so a new game registered in gameList.ts is *executed* the moment it exists. Measured
+//     against the full run, a game with no spec at all reads as fully covered — precisely the PR
+//     this is here to catch. With the sweeps excluded, what is left is coverage a real spec caused.
+//
+//   - It measures added *lines*, not files. Every non-spec .ts file in src/ is already at non-zero
+//     coverage, because the overview specs import gameList, which transitively loads every game;
+//     the floor is ~10% of top-level import and const lines, not 0%. So "this file is uncovered"
+//     never fires, while "these added lines never ran" does.
+//
+// Failing here means the added logic is not *unit-tested*. It does not mean it is untested: a
+// registered game still gets real conformance checking from the plays-to-an-end sweep, which throws
+// on an illegal move, a move named after the turn ended, and a game that never ends.
+import { appendFileSync, existsSync, readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const root = fileURLToPath(new URL('..', import.meta.url));
+
+// Below this, the percentage says more about arithmetic than about testing: at twelve lines two
+// uncovered ones are already 83%, which is how #450 — a two-line fix to a memo key — would have been
+// blocked. Twenty is where a single line stops moving the number by more than the bar's own width.
+// The thing this is actually for, a new game or bot, is hundreds of lines and never near the floor.
+const MIN_MEASURED_LINES = 20;
+// Recent history runs 87-96% over any range wide enough to measure, so this is a floor under the
+// habit rather than a stretch above it: what fails here is untested logic, not an imperfect diff.
+const THRESHOLD = 85;
+
+// The .tsx half is the JSX half, and is swept by renders.spec.tsx rather than unit-tested; the
+// exclusions mirror `coverage.exclude` in vite.config.js, which are absent from the report anyway.
+export const isMeasured = path =>
+  path.startsWith('src/') &&
+  path.endsWith('.ts') &&
+  !path.endsWith('.spec.ts') &&
+  path !== 'src/test-utils.ts' &&
+  path !== 'src/test-setup.ts';
+
+// `git diff --unified=0` output in, { path -> Set of added line numbers } out. A hunk header reads
+// `@@ -12,0 +13,4 @@`, where the count after the comma defaults to 1 when omitted.
+export const parseAddedLines = diff => {
+  const added = new Map();
+  let path = null;
+  for (const line of diff.split('\n')) {
+    if (line.startsWith('+++ ')) {
+      // `+++ /dev/null` is a deleted file: nothing was added to it, and it has no coverage to read.
+      const target = line.slice(4).trim();
+      path = target === '/dev/null' ? null : target.replace(/^b\//, '');
+      continue;
+    }
+    if (!path || !line.startsWith('@@')) continue;
+    const [, start, count] = line.match(/^@@ -\S+ \+(\d+)(?:,(\d+))? @@/) ?? [];
+    if (start === undefined) continue;
+    const lines = added.get(path) ?? new Set();
+    for (let i = 0; i < Number(count ?? 1); i++) lines.add(Number(start) + i);
+    added.set(path, lines);
+  }
+  return added;
+};
+
+// lcov.info in, { path -> { line -> hit count } } out. Only executable lines get a DA record, so
+// blank lines, comments and type-only declarations drop out of the measurement by themselves.
+export const parseLcov = lcov => {
+  const hits = new Map();
+  let lines = null;
+  for (const line of lcov.split('\n')) {
+    if (line.startsWith('SF:')) {
+      lines = new Map();
+      hits.set(line.slice(3).trim(), lines);
+    } else if (lines && line.startsWith('DA:')) {
+      const [number, count] = line.slice(3).split(',');
+      lines.set(Number(number), Number(count));
+    } else if (line.startsWith('end_of_record')) {
+      lines = null;
+    }
+  }
+  return hits;
+};
+
+// A file is { path, measured, uncovered, unloaded }, where `measured` counts the added lines that
+// are executable at all and `uncovered` lists those of them that never ran.
+//
+// `unloaded` is the case that took a probe to find: a module no spec imports gets an lcov record
+// with no DA lines whatsoever — v8 only ever sees the files something loaded, and `coverage.include`
+// adds the rest as empty records rather than as fully-uncovered ones. Left to the percentage those
+// files would count as zero added lines and pass as "nothing to measure", which is the wrong answer
+// for a module nothing in the repo touches. It is not a failure either, because a type-only module
+// (`export type Board = number[]`) is indistinguishable from lcov's side — types are erased, so it
+// has no executable line to report whether it was loaded or not. So: named in the report, counted
+// in neither column, and left to the reviewer.
+export const collect = (added, hits) =>
+  [...added]
+    .filter(([path]) => isMeasured(path))
+    .flatMap(([path, lines]) => {
+      const fileHits = hits.get(path);
+      // Absent from the report altogether despite `coverage.include` naming every file under src/ —
+      // a file deleted by a later commit in the same PR. Nothing to say about it.
+      if (!fileHits) return [];
+      if (fileHits.size === 0) return [{ path, measured: 0, uncovered: [], unloaded: true }];
+      const executable = [...lines].filter(line => fileHits.has(line)).sort((a, b) => a - b);
+      if (executable.length === 0) return [];
+      return [{
+        path,
+        measured: executable.length,
+        uncovered: executable.filter(line => fileHits.get(line) === 0),
+        unloaded: false
+      }];
+    })
+    .sort((a, b) => b.uncovered.length - a.uncovered.length);
+
+const listLines = uncovered => {
+  const shown = uncovered.slice(0, 8).join(', ');
+  return uncovered.length > 8 ? `${shown} … +${uncovered.length - 8} more` : shown;
+};
+
+// Pure: files in, { passed, markdown } out. Everything branchy lives here, and so does the spec.
+export const formatReport = files => {
+  const measured = files.reduce((sum, file) => sum + file.measured, 0);
+  const uncovered = files.reduce((sum, file) => sum + file.uncovered.length, 0);
+  const unloaded = files.filter(file => file.unloaded);
+
+  const unloadedNote =
+    unloaded.length === 0
+      ? []
+      : [
+        '',
+        `No executable line was measured in ${unloaded.map(file => `\`${file.path}\``).join(', ')} — ` +
+          'either the module is type-only, or nothing in the repo imports it, in which case no spec ' +
+          'can be reaching it. Not counted above either way.'
+      ];
+
+  if (measured === 0) {
+    return {
+      passed: true,
+      markdown: ['No non-JSX source lines added — nothing to measure.', ...unloadedNote].join('\n')
+    };
+  }
+
+  const percent = Math.round(((measured - uncovered) * 100) / measured);
+  // Small diffs are reported but never fail: see MIN_MEASURED_LINES.
+  const passed = percent >= THRESHOLD || measured < MIN_MEASURED_LINES;
+  const headline = `**${percent}%** of the ${measured} non-JSX lines this PR adds are reached by a spec.`;
+
+  if (uncovered === 0) {
+    return { passed, markdown: [`${headline} Nothing to flag.`, ...unloadedNote].join('\n') };
+  }
+
+  return {
+    passed,
+    markdown: [
+      headline,
+      '',
+      '| file | added | not reached |',
+      '| --- | --- | --- |',
+      ...files
+        .filter(file => file.uncovered.length > 0)
+        .map(file => `| \`${file.path}\` | ${file.measured} | ${listLines(file.uncovered)} |`),
+      '',
+      passed
+        ? `<sub>Passing: the bar is ${THRESHOLD}%, and a diff under ${MIN_MEASURED_LINES} measured ` +
+          'lines never fails.</sub>'
+        : `Below the ${THRESHOLD}% bar. These lines are not *unit-tested* — a registered game is ` +
+          'still played by the plays-to-an-end sweep, which catches an illegal move or a game that ' +
+          'never ends, but nothing here asserts that the strategy is right. Add a spec next to the ' +
+          'module (`gameplay.spec.ts`, `bot-strategy.spec.ts`), or label the PR `skip coverage` if ' +
+          'this diff genuinely has nothing worth asserting.',
+      ...unloadedNote,
+      '',
+      '<sub>Measured against `npm run coverage:unswept`, so the plays-to-an-end and renders sweeps ' +
+        'do not count as coverage. Run `npm run coverage:patch` locally.</sub>'
+    ].join('\n')
+  };
+};
+
+const git = (...args) => execFileSync('git', args, { cwd: root, encoding: 'utf8' });
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const base = (process.argv.includes('--base') && process.argv[process.argv.indexOf('--base') + 1]) || 'origin/main';
+
+  let mergeBase;
+  try {
+    // Against the merge base rather than the tip of the base branch: commits landed on main since
+    // this branch forked are not its to cover. Needs the full history (`fetch-depth: 0` in CI) —
+    // under the default shallow fetch there is no common ancestor to find.
+    mergeBase = git('merge-base', base, 'HEAD').trim();
+  } catch {
+    console.error(`Could not find the merge base of ${base} and HEAD. Fetch it first, or pass --base <ref>.`);
+    process.exit(1);
+  }
+  // No second commit, so the working tree is what gets compared: run this before committing and it
+  // still measures what you just wrote. In CI the tree is clean and this is `<base>...HEAD`.
+  const diff = git('diff', '--unified=0', mergeBase);
+
+  const lcovPath = `${root}reports/coverage/lcov.info`;
+  if (!existsSync(lcovPath)) {
+    console.error(`No coverage at ${lcovPath}. Run \`npm run coverage:patch\`, which measures it first.`);
+    process.exit(1);
+  }
+  const lcov = readFileSync(lcovPath, 'utf8');
+
+  const { passed, markdown } = formatReport(collect(parseAddedLines(diff), parseLcov(lcov)));
+
+  console.log(markdown);
+  if (process.env.GITHUB_STEP_SUMMARY) appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${markdown}\n`);
+  if (!passed) process.exit(1);
+}

--- a/scripts/patch-coverage.mjs
+++ b/scripts/patch-coverage.mjs
@@ -192,7 +192,9 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
     // under the default shallow fetch there is no common ancestor to find.
     mergeBase = git('merge-base', base, 'HEAD').trim();
   } catch {
-    console.error(`Could not find the merge base of ${base} and HEAD. Fetch it first, or pass --base <ref>.`);
+    // git's own error is on stderr above; naming one cause here would have sent the first CI
+    // failure of this job hunting a shallow fetch when the problem was file ownership.
+    console.error(`Could not find the merge base of ${base} and HEAD — see git's error above.`);
     process.exit(1);
   }
   // No second commit, so the working tree is what gets compared: run this before committing and it

--- a/scripts/patch-coverage.spec.mjs
+++ b/scripts/patch-coverage.spec.mjs
@@ -1,0 +1,232 @@
+// The two parsers and the verdict are tested; the main block is a git call, a file read and an exit
+// code, and a spec that mocked those would assert the mock. What could quietly mislead is a line
+// counted in the wrong place — an off-by-one in a hunk header, or a .tsx file slipping into the
+// measurement — which would fail a PR for lines it never wrote, the fastest way to get a check
+// deleted.
+import { collect, formatReport, isMeasured, parseAddedLines, parseLcov } from './patch-coverage.mjs';
+
+describe('isMeasured', () => {
+  it('measures the framework-free half of a game', () => {
+    expect(isMeasured('src/components/games/cube-coloring/gameplay.ts')).toBe(true);
+    expect(isMeasured('src/components/games/cube-coloring/bot-strategy.ts')).toBe(true);
+  });
+
+  it('leaves JSX out — it is swept by renders.spec.tsx, not unit-tested', () => {
+    expect(isMeasured('src/components/games/cube-coloring/cube-coloring.tsx')).toBe(false);
+    expect(isMeasured('src/components/games/cube-coloring/board-client.tsx')).toBe(false);
+  });
+
+  it('leaves out specs, test helpers and anything outside src/', () => {
+    expect(isMeasured('src/components/games/cube-coloring/gameplay.spec.ts')).toBe(false);
+    expect(isMeasured('src/test-utils.ts')).toBe(false);
+    expect(isMeasured('src/test-setup.ts')).toBe(false);
+    expect(isMeasured('scripts/patch-coverage.mjs')).toBe(false);
+    expect(isMeasured('vite.config.js')).toBe(false);
+  });
+});
+
+describe('parseAddedLines', () => {
+  it('reads a hunk header as a run of added lines starting at the given line', () => {
+    const diff = ['--- a/src/a.ts', '+++ b/src/a.ts', '@@ -12,0 +13,3 @@', '+one', '+two', '+three'].join('\n');
+
+    expect(parseAddedLines(diff).get('src/a.ts')).toEqual(new Set([13, 14, 15]));
+  });
+
+  it('reads an omitted count as a single line', () => {
+    const diff = ['--- a/src/a.ts', '+++ b/src/a.ts', '@@ -12 +13 @@', '+one'].join('\n');
+
+    expect(parseAddedLines(diff).get('src/a.ts')).toEqual(new Set([13]));
+  });
+
+  it('collects every hunk of a file, and keeps files apart', () => {
+    const diff = [
+      '--- a/src/a.ts',
+      '+++ b/src/a.ts',
+      '@@ -1,0 +2,2 @@',
+      '+one',
+      '+two',
+      '@@ -20,0 +30,1 @@',
+      '+three',
+      'diff --git a/src/b.ts b/src/b.ts',
+      '--- a/src/b.ts',
+      '+++ b/src/b.ts',
+      '@@ -5,0 +6,1 @@',
+      '+four'
+    ].join('\n');
+    const added = parseAddedLines(diff);
+
+    expect(added.get('src/a.ts')).toEqual(new Set([2, 3, 30]));
+    expect(added.get('src/b.ts')).toEqual(new Set([6]));
+  });
+
+  it('ignores a deleted file rather than attributing its hunk to the file before it', () => {
+    const diff = [
+      '--- a/src/a.ts',
+      '+++ b/src/a.ts',
+      '@@ -1,0 +2,1 @@',
+      '+one',
+      'diff --git a/src/gone.ts b/src/gone.ts',
+      '--- a/src/gone.ts',
+      '+++ /dev/null',
+      '@@ -1,4 +0,0 @@'
+    ].join('\n');
+    const added = parseAddedLines(diff);
+
+    expect(added.get('src/a.ts')).toEqual(new Set([2]));
+    expect(added.has('src/gone.ts')).toBe(false);
+  });
+});
+
+describe('parseLcov', () => {
+  it('reads hit counts per line and keeps records apart', () => {
+    const lcov = [
+      'SF:src/a.ts',
+      'DA:1,4',
+      'DA:2,0',
+      'end_of_record',
+      'SF:src/b.ts',
+      'DA:1,1',
+      'end_of_record'
+    ].join('\n');
+    const hits = parseLcov(lcov);
+
+    expect(hits.get('src/a.ts')).toEqual(new Map([[1, 4], [2, 0]]));
+    expect(hits.get('src/b.ts')).toEqual(new Map([[1, 1]]));
+  });
+});
+
+describe('collect', () => {
+  const hits = parseLcov(
+    ['SF:src/a.ts', 'DA:1,3', 'DA:2,0', 'DA:4,0', 'end_of_record', 'SF:src/b.ts', 'DA:9,2', 'end_of_record'].join('\n')
+  );
+
+  it('splits added lines into measured and never-reached', () => {
+    const files = collect(new Map([['src/a.ts', new Set([1, 2, 4])]]), hits);
+
+    expect(files).toEqual([{ path: 'src/a.ts', measured: 3, uncovered: [2, 4], unloaded: false }]);
+  });
+
+  it('skips an added line with no DA record — a blank, a comment or a type-only declaration', () => {
+    const files = collect(new Map([['src/a.ts', new Set([1, 2, 3])]]), hits);
+
+    expect(files).toEqual([{ path: 'src/a.ts', measured: 2, uncovered: [2], unloaded: false }]);
+  });
+
+  it('drops a file the report does not mention rather than counting it as uncovered', () => {
+    expect(collect(new Map([['src/types.ts', new Set([1, 2])]]), hits)).toEqual([]);
+  });
+
+  // An empty lcov record, not a missing one: v8 sees only the files something imported, and
+  // coverage.include adds the rest as records with no DA lines. Dropping those would let a module
+  // nothing in the repo touches pass as "nothing to measure".
+  it('flags a file whose record has no lines at all rather than dropping it', () => {
+    const withEmpty = parseLcov(['SF:src/a.ts', 'DA:1,3', 'end_of_record', 'SF:src/new.ts', 'end_of_record'].join('\n'));
+    const files = collect(new Map([['src/new.ts', new Set([1, 2, 3])]]), withEmpty);
+
+    expect(files).toEqual([{ path: 'src/new.ts', measured: 0, uncovered: [], unloaded: true }]);
+  });
+
+  it('drops a file whose added lines are all unmeasurable', () => {
+    expect(collect(new Map([['src/b.ts', new Set([3, 4])]]), hits)).toEqual([]);
+  });
+
+  it('never measures JSX', () => {
+    const jsxHits = parseLcov(['SF:src/a.tsx', 'DA:1,0', 'end_of_record'].join('\n'));
+
+    expect(collect(new Map([['src/a.tsx', new Set([1])]]), jsxHits)).toEqual([]);
+  });
+
+  it('puts the worst file first', () => {
+    const files = collect(new Map([['src/b.ts', new Set([9])], ['src/a.ts', new Set([1, 2, 4])]]), hits);
+
+    expect(files.map(({ path }) => path)).toEqual(['src/a.ts', 'src/b.ts']);
+  });
+});
+
+describe('formatReport', () => {
+  const file = (path, measured, uncovered) => ({ path, measured, uncovered, unloaded: false });
+  const unloadedFile = path => ({ path, measured: 0, uncovered: [], unloaded: true });
+  const uncoveredLines = count => Array.from({ length: count }, (_, i) => i + 1);
+
+  it('says there is nothing to measure when the PR adds no logic', () => {
+    const { passed, markdown } = formatReport([]);
+
+    expect(passed).toBe(true);
+    expect(markdown).toBe('No non-JSX source lines added — nothing to measure.');
+  });
+
+  it('passes a fully covered diff without printing a table', () => {
+    const { passed, markdown } = formatReport([file('src/a.ts', 40, [])]);
+
+    expect(passed).toBe(true);
+    expect(markdown).toContain('**100%** of the 40 non-JSX lines this PR adds are reached by a spec.');
+    expect(markdown).not.toContain('| file |');
+  });
+
+  it('fails a diff below the bar and names the lines that never ran', () => {
+    const { passed, markdown } = formatReport([file('src/a.ts', 40, [7, 8, 9, 10, 11, 12, 13, 14, 15, 16])]);
+
+    expect(passed).toBe(false);
+    expect(markdown).toContain('**75%** of the 40 non-JSX lines');
+    expect(markdown).toContain('| `src/a.ts` | 40 | 7, 8, 9, 10, 11, 12, 13, 14 … +2 more |');
+    expect(markdown).toContain('Below the 85% bar.');
+  });
+
+  it('passes a diff that is only just above the bar', () => {
+    const { passed } = formatReport([file('src/a.ts', 40, uncoveredLines(6))]);
+
+    expect(passed).toBe(true);
+  });
+
+  it('reports a small diff but never fails it', () => {
+    const { passed, markdown } = formatReport([file('src/a.ts', 19, uncoveredLines(19))]);
+
+    expect(passed).toBe(true);
+    expect(markdown).toContain('**0%** of the 19 non-JSX lines');
+    expect(markdown).toContain('| `src/a.ts` | 19 |');
+  });
+
+  it('fails the same ratio once the diff is big enough to mean something', () => {
+    expect(formatReport([file('src/a.ts', 20, uncoveredLines(20))]).passed).toBe(false);
+  });
+
+  it('totals across files rather than judging each one', () => {
+    const { passed, markdown } = formatReport([file('src/a.ts', 40, uncoveredLines(5)), file('src/b.ts', 60, [])]);
+
+    expect(passed).toBe(true);
+    expect(markdown).toContain('**95%** of the 100 non-JSX lines');
+  });
+
+  it('lists only the files with something to flag', () => {
+    const { markdown } = formatReport([file('src/a.ts', 10, uncoveredLines(9)), file('src/b.ts', 90, [])]);
+
+    expect(markdown).toContain('| `src/a.ts` |');
+    expect(markdown).not.toContain('| `src/b.ts` |');
+  });
+
+  it('names a file nothing loaded instead of reporting the PR as unmeasurable', () => {
+    const { passed, markdown } = formatReport([unloadedFile('src/new-game/bot-strategy.ts')]);
+
+    expect(markdown).toContain('No non-JSX source lines added — nothing to measure.');
+    expect(markdown).toContain('`src/new-game/bot-strategy.ts`');
+    expect(markdown).toContain('nothing in the repo imports it');
+    // Type-only modules land here too and are not a defect, so this reports rather than fails.
+    expect(passed).toBe(true);
+  });
+
+  it('names it alongside a measured verdict as well', () => {
+    const covered = formatReport([file('src/a.ts', 40, []), unloadedFile('src/new.ts')]);
+    const failing = formatReport([file('src/a.ts', 40, uncoveredLines(20)), unloadedFile('src/new.ts')]);
+
+    expect(covered.markdown).toContain('`src/new.ts`');
+    expect(failing.markdown).toContain('`src/new.ts`');
+    expect(failing.passed).toBe(false);
+  });
+
+  it('says failing means not unit-tested, not untested', () => {
+    const { markdown } = formatReport([file('src/a.ts', 40, uncoveredLines(20))]);
+
+    expect(markdown).toContain('plays-to-an-end sweep');
+    expect(markdown).toContain('skip coverage');
+  });
+});


### PR DESCRIPTION
A global coverage threshold would be meaningless here, and AGENTS.md argues against one: the two sweeps execute ~94% of `src/` while asserting almost nothing, so the number reads high whatever the tests are worth, and a gate on it would be satisfied by registering another game.

Coverage of the lines a branch **adds** is a different measurement. It cannot be diluted by the rest of the repo, it means the same thing in every PR, and it answers the question actually worth gating on: is this new logic unit-tested?

## What runs

`npm run coverage:patch` — and a `patch-coverage` job on every PR, parallel to `test`. It measures added lines in non-spec `.ts` files under `src/`, writes a table to the job summary, and fails under 85%. `.tsx` is out: JSX is swept by `renders.spec.tsx`, not unit-tested.

No PR comment, by design — the check status is the only thing that speaks, and the detail lives in the Actions tab. That is the same shape as `dependency_report.yml`, and it needs no `permissions:` block, so it works on fork PRs too.

## Two decisions that make it mean what it says

Both found by probing, not assumed.

**It reads `coverage:unswept`, not `coverage`.** A game registered in `gameList.ts` is executed by the sweeps the moment it exists. Measured against the full run, a game with no spec at all reads as fully covered — precisely the PR this is for.

**It measures added lines, not files.** Every non-spec `.ts` file under `src/` is already at non-zero coverage: the overview specs import `gameList`, which transitively loads every game, so the floor is ~10% of top-level import and const lines rather than 0%. `policeman-thief-ab/bot-strategy.ts` sits at 7.89%, `cube-coloring/bot-strategy.ts` at 12.76%. "This file is uncovered" would never fire; "these added lines never ran" does.

## A module nothing imports

It gets an lcov record with no `DA:` lines at all — v8 only sees the files something loaded, and `coverage.include` pads the rest with empty records. The first version of this dropped them as "nothing to measure", which would have waved through a completely unimported new file.

They are now named in the report. Not failed, though: a type-only module (`export type Board = number[]`) produces an identical empty record whether it was loaded or not, so lcov cannot tell the two apart and a hard failure would misfire.

## Thresholds calibrated against history, not picked

Recent PRs run 87–96% over any range wide enough to measure, so the 85% bar is a floor under existing habit rather than a stretch above it.

Diffs under twenty measured lines never fail. At ten, this blocked #450 — a two-line fix to a memo key, 12 measured lines, 83%. At the shipped settings nothing in recent history would have been blocked. The `skip coverage` label skips the job outright.

Failing means the added logic is not *unit-tested*. It does not mean untested: a registered game is still played by `plays-to-an-end.spec.ts`, which throws on an illegal move, a move named after the turn ended, and a game that never ends. The failure message says so, so it does not read as an accusation.

## Verified

A throwaway game folder with a real bot strategy and no spec:

- unimported → named in the report rather than silently skipped;
- wired in so `gameList` reaches it, which is the actual new-game case → **18%**, all nine body lines flagged. It passes only because the probe is 11 lines; a real game is dozens to hundreds.

Then removed. `npm run test` is green — 190 files, 1811 tests, plus lint and typecheck. `scripts/patch-coverage.spec.mjs` covers the two parsers and the verdict with 26 tests, following `dependency-report.spec.mjs` in testing only the pure functions.

## Also here

`check:versions` now compares every `image: node:` in a workflow rather than just the first, since `pr_test.yml` has two containerised jobs and the second could otherwise drift unnoticed.

## Reviewing this

The coverage cost is the suite a second time, instrumented — about 50s locally, in a job that runs alongside the checks you are already waiting on. Worth a look: whether 85%/20 lines is where you want it, and whether the `skip coverage` label is the escape hatch you would reach for.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B6XXLPaeri2tajTLVC3J2q)_