### PR TITLE
Sweep the twelve-squares refactor across the rest of the games

### DIFF
--- a/src/components/games/add-reduce-double/gameplay.ts
+++ b/src/components/games/add-reduce-double/gameplay.ts
@@ -5,17 +5,19 @@ export type Board = number[];
 export type Piece = { pileId: number; pieceId: number };
 type Transfer = { pileId: number; pieceCount: number };
 
+// An even number of pieces, at least two, and no more than the pile holds —
+// half of them then go to the other pile. Both players draw on the same two
+// piles, so whose turn it is does not enter into legality.
+const isTransferAllowed = (board: Board, { pileId, pieceCount }: Transfer): boolean =>
+  (pileId === 0 || pileId === 1)
+    && Number.isInteger(pieceCount)
+    && pieceCount >= 2
+    && pieceCount % 2 === 0
+    && pieceCount <= board[pileId];
+
 export const moves = {
   moveHalvedPieces: {
-    // An even number of pieces, at least two, and no more than the pile holds —
-    // half of them then go to the other pile. Both players draw on the same two
-    // piles, so whose turn it is does not enter into legality.
-    validate: (board: Board, _, { pileId, pieceCount }: Transfer) =>
-      (pileId === 0 || pileId === 1)
-        && Number.isInteger(pieceCount)
-        && pieceCount >= 2
-        && pieceCount % 2 === 0
-        && pieceCount <= board[pileId],
+    validate: (board: Board, _, piece: Transfer) => isTransferAllowed(board, piece),
     apply: (board: Board, { ctx }: { ctx: Ctx }, { pileId, pieceCount }: Transfer): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard[pileId] -= pieceCount;

--- a/src/components/games/add-reduce-double/gameplay.ts
+++ b/src/components/games/add-reduce-double/gameplay.ts
@@ -5,19 +5,17 @@ export type Board = number[];
 export type Piece = { pileId: number; pieceId: number };
 type Transfer = { pileId: number; pieceCount: number };
 
-// An even number of pieces, at least two, and no more than the pile holds —
-// half of them then go to the other pile. Both players draw on the same two
-// piles, so whose turn it is does not enter into legality.
-const isTransferAllowed = (board: Board, { pileId, pieceCount }: Transfer): boolean =>
-  (pileId === 0 || pileId === 1)
-    && Number.isInteger(pieceCount)
-    && pieceCount >= 2
-    && pieceCount % 2 === 0
-    && pieceCount <= board[pileId];
-
 export const moves = {
   moveHalvedPieces: {
-    validate: (board: Board, _, piece: Transfer) => isTransferAllowed(board, piece),
+    // An even number of pieces, at least two, and no more than the pile holds —
+    // half of them then go to the other pile. Both players draw on the same two
+    // piles, so whose turn it is does not enter into legality.
+    validate: (board: Board, _, { pileId, pieceCount }: Transfer) =>
+      (pileId === 0 || pileId === 1)
+        && Number.isInteger(pieceCount)
+        && pieceCount >= 2
+        && pieceCount % 2 === 0
+        && pieceCount <= board[pileId],
     apply: (board: Board, { ctx }: { ctx: Ctx }, { pileId, pieceCount }: Transfer): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard[pileId] -= pieceCount;

--- a/src/components/games/amor-and-cupido/gameplay.ts
+++ b/src/components/games/amor-and-cupido/gameplay.ts
@@ -41,11 +41,6 @@ export const generateStartBoard = (): Board => new Array(EDGES.length).fill(null
 export const getAllowedMoves = (board: Board): number[] =>
   board.flatMap((owner, e) => (owner === null ? [e] : []));
 
-// A pair may be claimed while nobody owns it. Both players claim from the same
-// 15 edges, so whose turn it is does not enter into legality.
-const isClaimAllowed = (board: Board, edge: number): boolean =>
-  Number.isInteger(edge) && edge >= 0 && edge < EDGES.length && board[edge] === null;
-
 // Would claiming `edge` for `player` complete a triangle entirely in their
 // colour? A move can only ever complete the mover's own triangle (you only add
 // to your own colour), so this is the single win condition. `edge` itself is
@@ -95,7 +90,10 @@ export const canonicalKey = (board: Board, toMove: number): string => {
 
 export const moves = {
   claimEdge: {
-    validate: (board: Board, _, edge: number) => isClaimAllowed(board, edge),
+    // A pair may be claimed while nobody owns it. Both players claim from the
+    // same 15 edges, so whose turn it is does not enter into legality.
+    validate: (board: Board, _, edge: number) =>
+      Number.isInteger(edge) && edge >= 0 && edge < EDGES.length && board[edge] === null,
     apply: (board: Board, { ctx }: { ctx: Ctx }, edge: number): MoveOutcome<Board> => {
       const nextBoard = board.slice();
       nextBoard[edge] = ctx.currentPlayer;

--- a/src/components/games/architect-and-bandits/gameplay.spec.ts
+++ b/src/components/games/architect-and-bandits/gameplay.spec.ts
@@ -1,4 +1,9 @@
-import { type Board, isArchitectStepAllowed, isDestructionAllowed } from './gameplay';
+import { type Board, BANDITS, isArchitectStepAllowed, makeMoves } from './gameplay';
+import { makeCtx, moveValidator } from 'test-utils';
+
+const isDestructionAllowed = moveValidator(
+  makeMoves(40).destroyTower, makeCtx({ currentPlayer: BANDITS })
+);
 
 // A fresh day on a regular polygon with `vertexCount` towers, all standing, the
 // architect at A(0).

--- a/src/components/games/architect-and-bandits/gameplay.spec.ts
+++ b/src/components/games/architect-and-bandits/gameplay.spec.ts
@@ -1,8 +1,14 @@
-import { type Board, BANDITS, isArchitectStepAllowed, makeMoves } from './gameplay';
+import { type Board, ARCHITECT, BANDITS, makeMoves } from './gameplay';
 import { makeCtx, moveValidator } from 'test-utils';
 
 const isDestructionAllowed = moveValidator(
   makeMoves(40).destroyTower, makeCtx({ currentPlayer: BANDITS })
+);
+
+// The step rule reads the day's allowance as well as the board, so each variant
+// asks its own moves.
+const stepAllowedWith = (kmPerDay: number) => moveValidator(
+  makeMoves(kmPerDay).moveArchitect, makeCtx({ currentPlayer: ARCHITECT })
 );
 
 // A fresh day on a regular polygon with `vertexCount` towers, all standing, the
@@ -19,7 +25,7 @@ describe('isArchitectStepAllowed', () => {
   // Variant A: an 8-vertex wall, 40 km (four edges) per day.
   describe('on the octagon', () => {
     const octagon = boardOn(8);
-    const stepAllowed = (board, target: number) => isArchitectStepAllowed(board, target, 40);
+    const stepAllowed = stepAllowedWith(40);
 
     it('allows a step to either neighbour along the wall', () => {
       expect(stepAllowed(octagon({ architectPosition: 3 }), 2)).toBe(true);
@@ -57,7 +63,7 @@ describe('isArchitectStepAllowed', () => {
   // gives different answers — it reads both off the board and the allowance.
   describe('on the decagon', () => {
     const decagon = boardOn(10);
-    const stepAllowed = (board, target: number) => isArchitectStepAllowed(board, target, 50);
+    const stepAllowed = stepAllowedWith(50);
 
     it('wraps round at vertex 9, which is not a neighbour of A on the octagon', () => {
       expect(stepAllowed(decagon({ architectPosition: 0 }), 9)).toBe(true);

--- a/src/components/games/architect-and-bandits/gameplay.ts
+++ b/src/components/games/architect-and-bandits/gameplay.ts
@@ -24,10 +24,6 @@ export const isArchitectStepAllowed = (board: Board, targetVertex: number, kmPer
   return gap === 1 || gap === board.towers.length - 1; // neighbours, wrapping round
 };
 
-// The bandits knock down one standing tower each night.
-export const isDestructionAllowed = (board: Board, vertex: number): boolean =>
-  isVertex(board, vertex) && board.towers[vertex];
-
 export const makeStartBoard = (vertexCount: number) => (): Board => {
   const towers = Array(vertexCount).fill(false);
   /*
@@ -71,8 +67,9 @@ export const makeMoves = (kmPerDay: number) => ({
     }
   },
   destroyTower: {
+    // The bandits knock down one standing tower each night.
     validate: (board: Board, { ctx }: { ctx: Ctx }, vertex: number) =>
-      ctx.currentPlayer === BANDITS && isDestructionAllowed(board, vertex),
+      ctx.currentPlayer === BANDITS && isVertex(board, vertex) && board.towers[vertex],
     apply: (board: Board, _, vertex: number): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard.towers[vertex] = false;

--- a/src/components/games/bacteria/gameplay.spec.ts
+++ b/src/components/games/bacteria/gameplay.spec.ts
@@ -1,9 +1,16 @@
 import {
   moves, applyAttackMove, totalBacteria,
-  hasBacterium, isAttackAllowed, ATTACKER, DEFENDER, type MoveType
+  hasBacterium, ATTACKER, DEFENDER, type Board, type MoveType
 } from './gameplay';
 import { reverse } from 'lodash';
 import { makeCtx } from 'test-utils';
+
+// Each attack type is its own move, so the type the assertion names picks the
+// move its legality is read from.
+const isAttackAllowed = (
+  board: Board, { type, row, col }: { type: MoveType, row: number, col: number }
+): boolean =>
+  moves[type].validate(board, { ctx: makeCtx({ currentPlayer: ATTACKER }) }, { row, col });
 
 describe('moves', () => {
   const meta = { ctx: makeCtx({ currentPlayer: DEFENDER }) };

--- a/src/components/games/bank-robbers/gameplay.spec.ts
+++ b/src/components/games/bank-robbers/gameplay.spec.ts
@@ -1,7 +1,9 @@
-import { isRobbable, moves, type Board } from './gameplay';
-import { makeCtx } from 'test-utils';
+import { moves, type Board } from './gameplay';
+import { makeCtx, moveValidator } from 'test-utils';
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
+
+const isRobbable = moveValidator(moves.rob);
 
 const board = (standing: boolean[]): Board => ({
   circle: standing,

--- a/src/components/games/chess-ducks/bot-strategy.spec.ts
+++ b/src/components/games/chess-ducks/bot-strategy.spec.ts
@@ -1,12 +1,14 @@
 import { range } from 'lodash';
 import { runMatch, type MatchResult } from 'strategy-game-factory';
 import {
-  getAllowedMoves, isPlacementAllowed, withDuckPlaced, moves, type Board, type Field
+  getAllowedMoves, withDuckPlaced, moves, type Board, type Field
 } from './gameplay';
 import {
   smartBotStrategy, randomBotStrategy, smartBotOptimalSecondSteps, smartBotOptimalThirdSteps
 } from './bot-strategy';
-import { botNextMoveArgs, makeCtx } from 'test-utils';
+import { botNextMoveArgs, makeCtx, moveValidator } from 'test-utils';
+
+const isPlacementAllowed = moveValidator(moves.placeDuck);
 
 const emptyBoard = (rows: number, cols: number): Board =>
   range(rows).map(() => range(cols).map(() => null));

--- a/src/components/games/chess-ducks/gameplay.spec.ts
+++ b/src/components/games/chess-ducks/gameplay.spec.ts
@@ -1,10 +1,12 @@
 import { range } from 'lodash';
 import {
-  DUCK, FORBIDDEN, moves, isPlacementAllowed, getAllowedMoves, withDuckPlaced, type Board
+  DUCK, FORBIDDEN, moves, getAllowedMoves, withDuckPlaced, type Board
 } from './gameplay';
-import { makeCtx } from 'test-utils';
+import { makeCtx, moveValidator } from 'test-utils';
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
+
+const isPlacementAllowed = moveValidator(moves.placeDuck);
 
 const emptyBoard = (rows: number, cols: number): Board =>
   range(rows).map(() => range(cols).map(() => null));

--- a/src/components/games/chess-ducks/gameplay.ts
+++ b/src/components/games/chess-ducks/gameplay.ts
@@ -33,12 +33,6 @@ export const markForbiddenFields = (board: Board, { row, col }: Field): void => 
   }
 };
 
-// A duck goes on a field that is still free — neither holding a duck nor
-// attacked by one. Both players place on the same board, so whose turn it is
-// does not enter into legality.
-export const isPlacementAllowed = (board: Board, field: Field): boolean =>
-  !!field && board[field.row]?.[field.col] === null;
-
 // The board transform a placement performs, with no turn or game consequences.
 // Shared by the move and by the bot's lookahead search, which wants the next
 // board and nothing else.
@@ -51,7 +45,11 @@ export const withDuckPlaced = (board: Board, { row, col }: Field): Board => {
 
 export const moves = {
   placeDuck: {
-    validate: (board: Board, _, field: Field) => isPlacementAllowed(board, field),
+    // A duck goes on a field that is still free — neither holding a duck nor
+    // attacked by one. Both players place on the same board, so whose turn it is
+    // does not enter into legality.
+    validate: (board: Board, _, field: Field) =>
+      !!field && board[field.row]?.[field.col] === null,
     apply: (board: Board, { ctx }: { ctx: Ctx }, field: Field): MoveOutcome<Board> => {
       const nextBoard = withDuckPlaced(board, field);
       if (getAllowedMoves(nextBoard).length === 0) {

--- a/src/components/games/cube-coloring/gameplay.spec.ts
+++ b/src/components/games/cube-coloring/gameplay.spec.ts
@@ -1,5 +1,8 @@
-import { isAllowedStep, generateStartBoard, moves, neighbours, type Board } from './gameplay';
-import { makeCtx } from 'test-utils';
+import { generateStartBoard, moves, neighbours, type Board } from './gameplay';
+import { makeCtx, moveValidator } from 'test-utils';
+
+const isAllowedStep = (board: Board, vertex: number, color: string | null): boolean =>
+  moveValidator(moves.colorVertex)(board, { vertex, color });
 
 describe('cube-coloring isAllowedStep', () => {
   const empty = (): Board => generateStartBoard();

--- a/src/components/games/digit-subtraction/gameplay.ts
+++ b/src/components/games/digit-subtraction/gameplay.ts
@@ -2,16 +2,14 @@ import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
 export type Board = number
 
-// Only a non-zero digit that actually appears in the current number may be
-// subtracted. Both players draw from the same number, so whose turn it is does
-// not enter into legality.
-const isSubtractableDigit = (board: Board, digit: number): boolean =>
-  Number.isInteger(digit) && digit >= 1 && digit <= 9
-    && String(board).includes(String(digit));
-
 export const moves = {
   subtractDigit: {
-    validate: (board: Board, _, digit: number) => isSubtractableDigit(board, digit),
+    // Only a non-zero digit that actually appears in the current number may be
+    // subtracted. Both players draw from the same number, so whose turn it is
+    // does not enter into legality.
+    validate: (board: Board, _, digit: number) =>
+      Number.isInteger(digit) && digit >= 1 && digit <= 9
+        && String(board).includes(String(digit)),
     apply: (board: Board, { ctx }: { ctx: Ctx }, digit: number): MoveOutcome<Board> => {
       const nextBoard = board - digit;
       if (nextBoard === 0) {

--- a/src/components/games/discs-flip-or-remove/gameplay.spec.ts
+++ b/src/components/games/discs-flip-or-remove/gameplay.spec.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { isRemovalAllowed, moves } from './gameplay';
+import { moves } from './gameplay';
 import { makeCtx, moveValidator } from 'test-utils';
 
+const isRemovalAllowed = moveValidator(moves.removeDiscs);
 const isFlipAllowed = moveValidator(moves.turnDiscs);
 
 describe('isRemovalAllowed', () => {

--- a/src/components/games/discs-flip-or-remove/gameplay.ts
+++ b/src/components/games/discs-flip-or-remove/gameplay.ts
@@ -21,15 +21,10 @@ export const generateStartBoard = (maxDiscs: number) => (): Board => {
 // discs from its own pile — no more, and never from an emptier pile than that.
 // Both players draw on the same two piles, so whose turn it is does not enter
 // into legality.
-export const isRemovalAllowed = (board: Board, count: number): boolean =>
-  (count === 1 || count === 2) && count <= board[0];
-
-const isFlipAllowed = (board: Board, count: number): boolean =>
-  (count === 1 || count === 2) && count <= board[1];
-
 export const moves = {
   removeDiscs: {
-    validate: (board: Board, _, count: number) => isRemovalAllowed(board, count),
+    validate: (board: Board, _, count: number) =>
+      (count === 1 || count === 2) && count <= board[0],
     apply: (board: Board, { ctx }: { ctx: Ctx }, count: number): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard[0] -= count;
@@ -40,7 +35,8 @@ export const moves = {
     }
   },
   turnDiscs: {
-    validate: (board: Board, _, count: number) => isFlipAllowed(board, count),
+    validate: (board: Board, _, count: number) =>
+      (count === 1 || count === 2) && count <= board[1],
     apply: (board: Board, { ctx }: { ctx: Ctx }, count: number): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard[1] -= count;

--- a/src/components/games/dominoes-4x4/gameplay.spec.ts
+++ b/src/components/games/dominoes-4x4/gameplay.spec.ts
@@ -1,7 +1,10 @@
-import { isDominoAllowed, moves, getPossibleMoves, type Board, type Domino } from './gameplay';
-import { makeCtx } from 'test-utils';
+import { moves, getPossibleMoves, type Board, type Domino } from './gameplay';
+import { makeCtx, moveValidator } from 'test-utils';
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
+
+const isDominoAllowed = (board: Board, player: number, domino: Domino): boolean =>
+  moveValidator(moves.placeDomino, makeCtx({ currentPlayer: player }))(board, domino);
 
 const emptyBoard: Board = [];
 // Player 0 (Árgyélus) places vertical dominoes, player 1 (Félix) horizontal ones.

--- a/src/components/games/dominoes-4x4/gameplay.ts
+++ b/src/components/games/dominoes-4x4/gameplay.ts
@@ -22,18 +22,16 @@ export const getPossibleMoves = (board: Board, player: number): Board => {
   return possibleMoves;
 };
 
-// A domino is legal when it covers two uncovered fields along the current
-// player's own axis, which is what `getPossibleMoves` enumerates for them. The
-// player picks the two fields in either order, so the pair is matched unordered.
-export const isDominoAllowed = (board: Board, player: number, domino: Domino): boolean =>
-  Array.isArray(domino) && domino.length === 2
-    && getPossibleMoves(board, player)
-      .some(m => isEqual(m, domino) || isEqual(m, [domino[1], domino[0]]));
-
 export const moves = {
   placeDomino: {
+    // A domino is legal when it covers two uncovered fields along the current
+    // player's own axis, which is what `getPossibleMoves` enumerates for them.
+    // The player picks the two fields in either order, so the pair is matched
+    // unordered.
     validate: (board: Board, { ctx }: { ctx: Ctx }, domino: Domino) =>
-      isDominoAllowed(board, ctx.currentPlayer!, domino),
+      Array.isArray(domino) && domino.length === 2
+        && getPossibleMoves(board, ctx.currentPlayer!)
+          .some(m => isEqual(m, domino) || isEqual(m, [domino[1], domino[0]])),
     apply: (board: Board, { ctx }: { ctx: Ctx }, domino: Domino): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard.push(domino);

--- a/src/components/games/dominoes-4x4/gameplay.ts
+++ b/src/components/games/dominoes-4x4/gameplay.ts
@@ -22,16 +22,18 @@ export const getPossibleMoves = (board: Board, player: number): Board => {
   return possibleMoves;
 };
 
+// A domino is legal when it covers two uncovered fields along the current
+// player's own axis, which is what `getPossibleMoves` enumerates for them. The
+// player picks the two fields in either order, so the pair is matched unordered.
+const isDominoAllowed = (board: Board, player: number, domino: Domino): boolean =>
+  Array.isArray(domino) && domino.length === 2
+    && getPossibleMoves(board, player)
+      .some(m => isEqual(m, domino) || isEqual(m, [domino[1], domino[0]]));
+
 export const moves = {
   placeDomino: {
-    // A domino is legal when it covers two uncovered fields along the current
-    // player's own axis, which is what `getPossibleMoves` enumerates for them.
-    // The player picks the two fields in either order, so the pair is matched
-    // unordered.
     validate: (board: Board, { ctx }: { ctx: Ctx }, domino: Domino) =>
-      Array.isArray(domino) && domino.length === 2
-        && getPossibleMoves(board, ctx.currentPlayer!)
-          .some(m => isEqual(m, domino) || isEqual(m, [domino[1], domino[0]])),
+      isDominoAllowed(board, ctx.currentPlayer!, domino),
     apply: (board: Board, { ctx }: { ctx: Ctx }, domino: Domino): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard.push(domino);

--- a/src/components/games/dominoes-on-chessboard/gameplay.spec.ts
+++ b/src/components/games/dominoes-on-chessboard/gameplay.spec.ts
@@ -1,7 +1,9 @@
-import { isDominoAllowed, moves, getPossibleMoves, type Board, type Domino } from './gameplay';
-import { makeCtx } from 'test-utils';
+import { moves, getPossibleMoves, type Board, type Domino } from './gameplay';
+import { makeCtx, moveValidator } from 'test-utils';
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
+
+const isDominoAllowed = moveValidator(moves.placeDomino);
 
 const emptyBoard: Board = [];
 

--- a/src/components/games/dominoes-on-chessboard/gameplay.ts
+++ b/src/components/games/dominoes-on-chessboard/gameplay.ts
@@ -24,14 +24,16 @@ export const getPossibleMoves = (board: Board) => {
   return possibleMoves;
 }
 
+// A domino is legal when it covers two uncovered neighbouring fields, which is
+// what `getPossibleMoves` enumerates. The player picks the two fields in either
+// order, so the pair is matched unordered.
+const isDominoAllowed = (board: Board, domino: Domino): boolean =>
+  Array.isArray(domino) && domino.length === 2
+    && getPossibleMoves(board).some(m => isEqual(m, domino) || isEqual(m, [domino[1], domino[0]]));
+
 export const moves = {
   placeDomino: {
-    // A domino is legal when it covers two uncovered neighbouring fields, which
-    // is what `getPossibleMoves` enumerates. The player picks the two fields in
-    // either order, so the pair is matched unordered.
-    validate: (board: Board, _, domino: Domino) =>
-      Array.isArray(domino) && domino.length === 2
-        && getPossibleMoves(board).some(m => isEqual(m, domino) || isEqual(m, [domino[1], domino[0]])),
+    validate: (board: Board, _, domino: Domino) => isDominoAllowed(board, domino),
     apply: (board: Board, { ctx }: { ctx: Ctx }, domino: Domino): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard.push(domino);

--- a/src/components/games/dominoes-on-chessboard/gameplay.ts
+++ b/src/components/games/dominoes-on-chessboard/gameplay.ts
@@ -24,16 +24,14 @@ export const getPossibleMoves = (board: Board) => {
   return possibleMoves;
 }
 
-// A domino is legal when it covers two uncovered neighbouring fields, which is
-// what `getPossibleMoves` enumerates. The player picks the two fields in either
-// order, so the pair is matched unordered.
-export const isDominoAllowed = (board: Board, domino: Domino): boolean =>
-  Array.isArray(domino) && domino.length === 2
-    && getPossibleMoves(board).some(m => isEqual(m, domino) || isEqual(m, [domino[1], domino[0]]));
-
 export const moves = {
   placeDomino: {
-    validate: (board: Board, _, domino: Domino) => isDominoAllowed(board, domino),
+    // A domino is legal when it covers two uncovered neighbouring fields, which
+    // is what `getPossibleMoves` enumerates. The player picks the two fields in
+    // either order, so the pair is matched unordered.
+    validate: (board: Board, _, domino: Domino) =>
+      Array.isArray(domino) && domino.length === 2
+        && getPossibleMoves(board).some(m => isEqual(m, domino) || isEqual(m, [domino[1], domino[0]])),
     apply: (board: Board, { ctx }: { ctx: Ctx }, domino: Domino): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard.push(domino);

--- a/src/components/games/five-connected-fields/gameplay.spec.ts
+++ b/src/components/games/five-connected-fields/gameplay.spec.ts
@@ -1,5 +1,7 @@
-import { hasAnyMove, isNodePlayable, legalNodes, moves, type Board } from './gameplay';
-import { makeCtx } from 'test-utils';
+import { hasAnyMove, legalNodes, moves, type Board } from './gameplay';
+import { makeCtx, moveValidator } from 'test-utils';
+
+const isNodePlayable = moveValidator(moves.placeCoin);
 
 // K(2,3): 0=A and 1=B are the hubs, each joined to 2=C, 3=D and 4=E. Neither
 // hub is joined to the other, and C, D, E are not joined to each other.

--- a/src/components/games/five-five-card/gameplay.spec.ts
+++ b/src/components/games/five-five-card/gameplay.spec.ts
@@ -1,7 +1,12 @@
-import { isRemovalAllowed, moves, type Board } from './gameplay';
-import { makeCtx } from 'test-utils';
+import { moves, type Board } from './gameplay';
+import { makeCtx, moveValidator } from 'test-utils';
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
+
+// The move takes from the other player's hand, so the mover is the opponent of
+// the hand the assertion names.
+const isRemovalAllowed = (board: Board, opponent: number, id: number): boolean =>
+  moveValidator(moves.removeCard, makeCtx({ currentPlayer: 1 - opponent }))(board, id);
 
 // A hand holding exactly the listed values, at their 1-based positions.
 const hand = (values: number[]): (number | null)[] =>

--- a/src/components/games/five-five-card/gameplay.ts
+++ b/src/components/games/five-five-card/gameplay.ts
@@ -23,15 +23,15 @@ export const getWinnerIndex = (board: Board) => {
   }
 }
 
-// Cards are addressed by their 1-based position in the other player's hand, and
-// only a card still lying there may be taken.
-export const isRemovalAllowed = (board: Board, opponent: number, id: number): boolean =>
-  Number.isInteger(id) && id >= 1 && id <= board[opponent].length && board[opponent][id - 1] !== null;
-
 export const moves = {
   removeCard: {
-    validate: (board: Board, { ctx }: { ctx: Ctx }, id: number) =>
-      isRemovalAllowed(board, 1 - ctx.currentPlayer!, id),
+    // Cards are addressed by their 1-based position in the other player's hand,
+    // and only a card still lying there may be taken.
+    validate: (board: Board, { ctx }: { ctx: Ctx }, id: number) => {
+      const opponent = 1 - ctx.currentPlayer!;
+      return Number.isInteger(id) && id >= 1 && id <= board[opponent].length
+        && board[opponent][id - 1] !== null;
+    },
     apply: (board: Board, { ctx }: { ctx: Ctx }, id: number): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard[1 - ctx.currentPlayer!][id - 1] = null;

--- a/src/components/games/four-connected-fields/gameplay.spec.ts
+++ b/src/components/games/four-connected-fields/gameplay.spec.ts
@@ -1,5 +1,7 @@
-import { hasAnyMove, isNodePlayable, moves, type Board } from './gameplay';
-import { makeCtx } from 'test-utils';
+import { hasAnyMove, moves, type Board } from './gameplay';
+import { makeCtx, moveValidator } from 'test-utils';
+
+const isNodePlayable = moveValidator(moves.placeCoin);
 
 // 0=A and 1=B are the hubs, joined to each other and to both 2=C and 3=D;
 // C and D are not joined.

--- a/src/components/games/four-piles-spread-ahead/gameplay.ts
+++ b/src/components/games/four-piles-spread-ahead/gameplay.ts
@@ -7,20 +7,17 @@ export type Piece = { pileId: number; pieceId: number };
 export const generateStartBoard = (): Board => ([random(0, 9), random(0, 9), random(0, 9), random(4, 9)]);
 export const generateTestStartBoard = (): Board => ([random(0, 6), random(0, 6), random(0, 6), random(4, 6)]);
 
-// A move takes `pieceCount` pieces off pile `pileId` and puts one on each of the
-// `pieceCount` piles immediately in front of it, so it can never reach past the
-// first pile — hence the cap at `pileId`.
-const isSpreadAllowed = (board: Board, pileId: number, pieceCount: number): boolean =>
-  Number.isInteger(pileId) && pileId >= 0 && pileId < board.length
-    && Number.isInteger(pieceCount)
-    && pieceCount >= 1
-    && pieceCount <= pileId
-    && pieceCount <= board[pileId];
-
 export const moves = {
   spreadPieces: {
+    // A move takes `pieceCount` pieces off pile `pileId` and puts one on each of
+    // the `pieceCount` piles immediately in front of it, so it can never reach
+    // past the first pile — hence the cap at `pileId`.
     validate: (board: Board, _, { pileId, pieceCount }: { pileId: number; pieceCount: number }) =>
-      isSpreadAllowed(board, pileId, pieceCount),
+      Number.isInteger(pileId) && pileId >= 0 && pileId < board.length
+        && Number.isInteger(pieceCount)
+        && pieceCount >= 1
+        && pieceCount <= pileId
+        && pieceCount <= board[pileId],
     apply: (
       board: Board,
       { ctx }: { ctx: Ctx },

--- a/src/components/games/four-piles-spread-ahead/gameplay.ts
+++ b/src/components/games/four-piles-spread-ahead/gameplay.ts
@@ -7,17 +7,20 @@ export type Piece = { pileId: number; pieceId: number };
 export const generateStartBoard = (): Board => ([random(0, 9), random(0, 9), random(0, 9), random(4, 9)]);
 export const generateTestStartBoard = (): Board => ([random(0, 6), random(0, 6), random(0, 6), random(4, 6)]);
 
+// A move takes `pieceCount` pieces off pile `pileId` and puts one on each of the
+// `pieceCount` piles immediately in front of it, so it can never reach past the
+// first pile — hence the cap at `pileId`.
+const isSpreadAllowed = (board: Board, pileId: number, pieceCount: number): boolean =>
+  Number.isInteger(pileId) && pileId >= 0 && pileId < board.length
+    && Number.isInteger(pieceCount)
+    && pieceCount >= 1
+    && pieceCount <= pileId
+    && pieceCount <= board[pileId];
+
 export const moves = {
   spreadPieces: {
-    // A move takes `pieceCount` pieces off pile `pileId` and puts one on each of
-    // the `pieceCount` piles immediately in front of it, so it can never reach
-    // past the first pile — hence the cap at `pileId`.
     validate: (board: Board, _, { pileId, pieceCount }: { pileId: number; pieceCount: number }) =>
-      Number.isInteger(pileId) && pileId >= 0 && pileId < board.length
-        && Number.isInteger(pieceCount)
-        && pieceCount >= 1
-        && pieceCount <= pileId
-        && pieceCount <= board[pileId],
+      isSpreadAllowed(board, pileId, pieceCount),
     apply: (
       board: Board,
       { ctx }: { ctx: Ctx },

--- a/src/components/games/four-piles-two-grabs/gameplay.ts
+++ b/src/components/games/four-piles-two-grabs/gameplay.ts
@@ -18,6 +18,15 @@ export const isTerminal = (board: Board): boolean => !canMove(board);
 export const applyMove = (board: Board, move: Move): Board =>
   board.map((v, i) => v - move[i]);
 
+// A move takes from exactly two piles, at least one stone and at most the whole
+// pile from each. Checked directly rather than as membership in getLegalMoves,
+// which enumerates a quadratic number of moves.
+const isMoveLegal = (board: Board, move: Move): boolean =>
+  Array.isArray(move)
+    && move.length === board.length
+    && move.every((removed, i) => Number.isInteger(removed) && removed >= 0 && removed <= board[i])
+    && move.filter(removed => removed > 0).length === 2;
+
 // Every legal move: pick two non-empty piles, remove between 1 and the whole
 // pile from each. Amounts removed from the two piles are independent.
 export const getLegalMoves = (board: Board): Move[] => {
@@ -95,14 +104,7 @@ export const generateStartBoard = (): Board => {
 
 export const moves = {
   takeStones: {
-    // A move takes from exactly two piles, at least one stone and at most the
-    // whole pile from each. Checked directly rather than as membership in
-    // getLegalMoves, which enumerates a quadratic number of moves.
-    validate: (board: Board, _, move: Move) =>
-      Array.isArray(move)
-        && move.length === board.length
-        && move.every((removed, i) => Number.isInteger(removed) && removed >= 0 && removed <= board[i])
-        && move.filter(removed => removed > 0).length === 2,
+    validate: (board: Board, _, move: Move) => isMoveLegal(board, move),
     apply: (board: Board, { ctx }: { ctx: Ctx }, move: Move): MoveOutcome<Board> => {
       const nextBoard = applyMove(board, move);
       if (isTerminal(nextBoard)) {

--- a/src/components/games/four-piles-two-grabs/gameplay.ts
+++ b/src/components/games/four-piles-two-grabs/gameplay.ts
@@ -18,15 +18,6 @@ export const isTerminal = (board: Board): boolean => !canMove(board);
 export const applyMove = (board: Board, move: Move): Board =>
   board.map((v, i) => v - move[i]);
 
-// A move takes from exactly two piles, at least one stone and at most the whole
-// pile from each. Checked directly rather than as membership in getLegalMoves,
-// which enumerates a quadratic number of moves.
-const isMoveLegal = (board: Board, move: Move): boolean =>
-  Array.isArray(move)
-    && move.length === board.length
-    && move.every((removed, i) => Number.isInteger(removed) && removed >= 0 && removed <= board[i])
-    && move.filter(removed => removed > 0).length === 2;
-
 // Every legal move: pick two non-empty piles, remove between 1 and the whole
 // pile from each. Amounts removed from the two piles are independent.
 export const getLegalMoves = (board: Board): Move[] => {
@@ -104,7 +95,14 @@ export const generateStartBoard = (): Board => {
 
 export const moves = {
   takeStones: {
-    validate: (board: Board, _, move: Move) => isMoveLegal(board, move),
+    // A move takes from exactly two piles, at least one stone and at most the
+    // whole pile from each. Checked directly rather than as membership in
+    // getLegalMoves, which enumerates a quadratic number of moves.
+    validate: (board: Board, _, move: Move) =>
+      Array.isArray(move)
+        && move.length === board.length
+        && move.every((removed, i) => Number.isInteger(removed) && removed >= 0 && removed <= board[i])
+        && move.filter(removed => removed > 0).length === 2,
     apply: (board: Board, { ctx }: { ctx: Ctx }, move: Move): MoveOutcome<Board> => {
       const nextBoard = applyMove(board, move);
       if (isTerminal(nextBoard)) {

--- a/src/components/games/hunyadi-and-the-janissaries/gameplay.ts
+++ b/src/components/games/hunyadi-and-the-janissaries/gameplay.ts
@@ -53,14 +53,6 @@ export const [SULTAN, HUNYADI] = [0, 1];
 // colour being present on the staircase is not part of legality.
 const isColor = (group: string): group is SoldierColor => group === 'blue' || group === 'red';
 
-// A soldier reference points at an actual soldier on the staircase, and the
-// group it is assigned to is one of the two colours the sultan splits into.
-const isSoldierAssignmentAllowed = (board: Board, soldiers: Soldier[]): boolean =>
-  Array.isArray(soldiers) && soldiers.every(
-    ({ rowIndex, pieceIndex, group }) =>
-      isColor(group) && board[rowIndex]?.[pieceIndex] !== undefined
-  );
-
 export const moves = {
   killGroup: {
     validate: (_board: Board, { ctx }, group: SoldierColor) =>
@@ -79,8 +71,14 @@ export const moves = {
     apply: (board: Board) => ({ nextBoard: board, isTurnEnd: true })
   },
   setGroupOfSoldiers: {
+    // A soldier reference points at an actual soldier on the staircase, and the
+    // group it is assigned to is one of the two colours the sultan splits into.
     validate: (board: Board, { ctx }, soldiers: Soldier[]) =>
-      ctx.currentPlayer === SULTAN && isSoldierAssignmentAllowed(board, soldiers),
+      ctx.currentPlayer === SULTAN
+        && Array.isArray(soldiers) && soldiers.every(
+          ({ rowIndex, pieceIndex, group }) =>
+            isColor(group) && board[rowIndex]?.[pieceIndex] !== undefined
+        ),
     apply: (board: Board, _, soldiers: Soldier[]) => {
       const nextBoard = cloneDeep(board);
       for (const soldier of soldiers) {

--- a/src/components/games/hunyadi-and-the-janissaries/gameplay.ts
+++ b/src/components/games/hunyadi-and-the-janissaries/gameplay.ts
@@ -53,6 +53,14 @@ export const [SULTAN, HUNYADI] = [0, 1];
 // colour being present on the staircase is not part of legality.
 const isColor = (group: string): group is SoldierColor => group === 'blue' || group === 'red';
 
+// A soldier reference points at an actual soldier on the staircase, and the
+// group it is assigned to is one of the two colours the sultan splits into.
+const isSoldierAssignmentAllowed = (board: Board, soldiers: Soldier[]): boolean =>
+  Array.isArray(soldiers) && soldiers.every(
+    ({ rowIndex, pieceIndex, group }) =>
+      isColor(group) && board[rowIndex]?.[pieceIndex] !== undefined
+  );
+
 export const moves = {
   killGroup: {
     validate: (_board: Board, { ctx }, group: SoldierColor) =>
@@ -71,14 +79,8 @@ export const moves = {
     apply: (board: Board) => ({ nextBoard: board, isTurnEnd: true })
   },
   setGroupOfSoldiers: {
-    // A soldier reference points at an actual soldier on the staircase, and the
-    // group it is assigned to is one of the two colours the sultan splits into.
     validate: (board: Board, { ctx }, soldiers: Soldier[]) =>
-      ctx.currentPlayer === SULTAN
-        && Array.isArray(soldiers) && soldiers.every(
-          ({ rowIndex, pieceIndex, group }) =>
-            isColor(group) && board[rowIndex]?.[pieceIndex] !== undefined
-        ),
+      ctx.currentPlayer === SULTAN && isSoldierAssignmentAllowed(board, soldiers),
     apply: (board: Board, _, soldiers: Soldier[]) => {
       const nextBoard = cloneDeep(board);
       for (const soldier of soldiers) {

--- a/src/components/games/magic-box/magic-box-a/gameplay.spec.ts
+++ b/src/components/games/magic-box/magic-box-a/gameplay.spec.ts
@@ -1,5 +1,7 @@
-import { generateEmptyBoard, hasFullLine, isPlacementAllowed, moves } from './gameplay';
-import { makeCtx } from 'test-utils';
+import { generateEmptyBoard, hasFullLine, moves } from './gameplay';
+import { makeCtx, moveValidator } from 'test-utils';
+
+const isPlacementAllowed = moveValidator(moves.placeStone);
 
 describe('hasFullLine', () => {
   it('should be false for an empty board', () => {

--- a/src/components/games/magic-box/magic-box-a/gameplay.ts
+++ b/src/components/games/magic-box/magic-box-a/gameplay.ts
@@ -12,10 +12,6 @@ export const generateEmptyBoard = (): Board => Array(9).fill(false);
 
 export const placeStone = (board: Board, i: number): Board => [...board.slice(0, i), true, ...board.slice(i + 1)];
 
-// A stone goes into any compartment that is still empty.
-export const isPlacementAllowed = (board: Board, id: number): boolean =>
-  Number.isInteger(id) && id >= 0 && id < board.length && !board[id];
-
 const LINES = [
   [0, 1, 2],
   [3, 4, 5],
@@ -31,7 +27,9 @@ export const isGameEnd = hasFullLine;
 
 export const moves = {
   placeStone: {
-    validate: (board: Board, _, id: number) => isPlacementAllowed(board, id),
+    // A stone goes into any compartment that is still empty.
+    validate: (board: Board, _, id: number) =>
+      Number.isInteger(id) && id >= 0 && id < board.length && !board[id],
     apply: (board: Board, { ctx }: { ctx: Ctx }, id: number): MoveOutcome<Board> => {
       const nextBoard = placeStone(board, id);
       // The box breaks under the stone just placed, so the mover loses.

--- a/src/components/games/magic-box/magic-box-b/gameplay.spec.ts
+++ b/src/components/games/magic-box/magic-box-b/gameplay.spec.ts
@@ -2,13 +2,13 @@ import {
   LINES,
   emptyCellsInLine,
   isLineFull,
-  isPlacementAllowed,
   moves,
   placeStoneAt,
   type Board
 } from './gameplay';
 import { makeCtx, moveValidator } from 'test-utils';
 
+const isPlacementAllowed = moveValidator(moves.placeStone);
 const isDesignationAllowed = moveValidator(moves.designateLine);
 
 describe('isLineFull', () => {

--- a/src/components/games/magic-box/magic-box-b/gameplay.ts
+++ b/src/components/games/magic-box/magic-box-b/gameplay.ts
@@ -31,20 +31,12 @@ export const placeStoneAt = (stones: boolean[], cellId: number): boolean[] =>
 // itself carries — a designated line is waiting for a stone, and only once that
 // stone is placed may the next line be designated. So neither half needs turn
 // state to know whether it is its moment.
-export const isPlacementAllowed = (board: Board, cellId: number): boolean =>
-  board.pendingLine !== null
-    && LINES[board.pendingLine].includes(cellId)
-    && !board.stones[cellId];
-
-const isDesignationAllowed = (board: Board, lineIndex: number): boolean =>
-  board.pendingLine === null
-    && Number.isInteger(lineIndex)
-    && lineIndex >= 0
-    && lineIndex < LINES.length;
-
 export const moves = {
   placeStone: {
-    validate: (board: Board, _, cellId: number) => isPlacementAllowed(board, cellId),
+    validate: (board: Board, _, cellId: number) =>
+      board.pendingLine !== null
+        && LINES[board.pendingLine].includes(cellId)
+        && !board.stones[cellId],
     // First half of the turn: place a stone, then designate a line — the turn
     // stays open in between.
     apply: (board: Board, _, cellId: number): MoveOutcome<Board> => {
@@ -54,7 +46,11 @@ export const moves = {
   },
 
   designateLine: {
-    validate: (board: Board, _, lineIndex: number) => isDesignationAllowed(board, lineIndex),
+    validate: (board: Board, _, lineIndex: number) =>
+      board.pendingLine === null
+        && Number.isInteger(lineIndex)
+        && lineIndex >= 0
+        && lineIndex < LINES.length,
     apply: (board: Board, { ctx }: { ctx: Ctx }, lineIndex: number): MoveOutcome<Board> => {
       const nextBoard: Board = { stones: board.stones, pendingLine: lineIndex };
       // A full designated line leaves the other player nowhere to place.

--- a/src/components/games/magic-box/magic-box-b/gameplay.ts
+++ b/src/components/games/magic-box/magic-box-b/gameplay.ts
@@ -31,12 +31,20 @@ export const placeStoneAt = (stones: boolean[], cellId: number): boolean[] =>
 // itself carries — a designated line is waiting for a stone, and only once that
 // stone is placed may the next line be designated. So neither half needs turn
 // state to know whether it is its moment.
+const isPlacementAllowed = (board: Board, cellId: number): boolean =>
+  board.pendingLine !== null
+    && LINES[board.pendingLine].includes(cellId)
+    && !board.stones[cellId];
+
+const isDesignationAllowed = (board: Board, lineIndex: number): boolean =>
+  board.pendingLine === null
+    && Number.isInteger(lineIndex)
+    && lineIndex >= 0
+    && lineIndex < LINES.length;
+
 export const moves = {
   placeStone: {
-    validate: (board: Board, _, cellId: number) =>
-      board.pendingLine !== null
-        && LINES[board.pendingLine].includes(cellId)
-        && !board.stones[cellId],
+    validate: (board: Board, _, cellId: number) => isPlacementAllowed(board, cellId),
     // First half of the turn: place a stone, then designate a line — the turn
     // stays open in between.
     apply: (board: Board, _, cellId: number): MoveOutcome<Board> => {
@@ -46,11 +54,7 @@ export const moves = {
   },
 
   designateLine: {
-    validate: (board: Board, _, lineIndex: number) =>
-      board.pendingLine === null
-        && Number.isInteger(lineIndex)
-        && lineIndex >= 0
-        && lineIndex < LINES.length,
+    validate: (board: Board, _, lineIndex: number) => isDesignationAllowed(board, lineIndex),
     apply: (board: Board, { ctx }: { ctx: Ctx }, lineIndex: number): MoveOutcome<Board> => {
       const nextBoard: Board = { stones: board.stones, pendingLine: lineIndex };
       // A full designated line leaves the other player nowhere to place.

--- a/src/components/games/matches-on-edges/gameplay.ts
+++ b/src/components/games/matches-on-edges/gameplay.ts
@@ -64,14 +64,6 @@ export const legalMoves = (board: Board): Move[] => {
   return moves;
 };
 
-// Is [a, b] one of the windows the player to move may play? The size is forced
-// (always the largest legal one), and the window must sit strictly inside a
-// single match-free block — so this is not a bounds check but the game's whole
-// move rule. Matching against the generated list keeps the two definitions from
-// drifting; there are only O(n) legal moves.
-const isWindowAllowed = (board: Board, a: number, b: number): boolean =>
-  legalMoves(board).some(m => m.a === a && m.b === b);
-
 // The bounding edges of window [a, b] that are still free and would receive a
 // match. Used both to apply a move and to preview it in the UI.
 export const boundaryEdgesToPlace = (board: Board, a: number, b: number): number[] => {
@@ -151,7 +143,13 @@ export const moves = {
   // If that leaves the other player with no legal move, they lose; otherwise the
   // turn passes.
   placeWindow: {
-    validate: (board: Board, _, a: number, b: number) => isWindowAllowed(board, a, b),
+    // Is [a, b] one of the windows the player to move may play? The size is
+    // forced (always the largest legal one), and the window must sit strictly
+    // inside a single match-free block — so this is not a bounds check but the
+    // game's whole move rule. Matching against the generated list keeps the two
+    // definitions from drifting; there are only O(n) legal moves.
+    validate: (board: Board, _, a: number, b: number) =>
+      legalMoves(board).some(m => m.a === a && m.b === b),
     apply: (
       board: Board, { ctx }: { ctx: Ctx }, a: number, b: number
     ): MoveOutcome<Board> => {

--- a/src/components/games/matchstick-piles/gameplay.spec.ts
+++ b/src/components/games/matchstick-piles/gameplay.spec.ts
@@ -1,5 +1,8 @@
-import { isRemovalAllowed, isSplitAllowed, moves, type Board } from './gameplay';
-import { makeCtx } from 'test-utils';
+import { moves, type Board } from './gameplay';
+import { makeCtx, moveValidator } from 'test-utils';
+
+const isRemovalAllowed = moveValidator(moves.removeMatch);
+const isSplitAllowed = moveValidator(moves.splitPile);
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
 

--- a/src/components/games/matchstick-piles/gameplay.ts
+++ b/src/components/games/matchstick-piles/gameplay.ts
@@ -7,6 +7,13 @@ export type Board = number[];
 const isPileId = (board: Board, pileId: number): boolean =>
   Number.isInteger(pileId) && pileId >= 0 && pileId < board.length;
 
+// A split has to leave both halves non-empty.
+const isSplitAllowed = (board: Board, pileId: number, firstPart: number): boolean =>
+  isPileId(board, pileId)
+    && Number.isInteger(firstPart)
+    && firstPart >= 1
+    && firstPart <= board[pileId] - 1;
+
 export const moves = {
   removeMatch: {
     // Empty piles are dropped from the board, so every pile has a match to give up.
@@ -23,12 +30,8 @@ export const moves = {
     }
   },
   splitPile: {
-    // A split has to leave both halves non-empty.
     validate: (board: Board, _, pileId: number, firstPart: number) =>
-      isPileId(board, pileId)
-        && Number.isInteger(firstPart)
-        && firstPart >= 1
-        && firstPart <= board[pileId] - 1,
+      isSplitAllowed(board, pileId, firstPart),
     apply: (board: Board, _, pileId: number, firstPart: number): MoveOutcome<Board> => {
       const size = board[pileId];
       const nextBoard = board.flatMap((n, i) =>

--- a/src/components/games/matchstick-piles/gameplay.ts
+++ b/src/components/games/matchstick-piles/gameplay.ts
@@ -7,20 +7,11 @@ export type Board = number[];
 const isPileId = (board: Board, pileId: number): boolean =>
   Number.isInteger(pileId) && pileId >= 0 && pileId < board.length;
 
-// Empty piles are dropped from the board, so every pile has a match to give up.
-export const isRemovalAllowed = (board: Board, pileId: number): boolean =>
-  isPileId(board, pileId) && board[pileId] >= 1;
-
-// A split has to leave both halves non-empty.
-export const isSplitAllowed = (board: Board, pileId: number, firstPart: number): boolean =>
-  isPileId(board, pileId)
-    && Number.isInteger(firstPart)
-    && firstPart >= 1
-    && firstPart <= board[pileId] - 1;
-
 export const moves = {
   removeMatch: {
-    validate: (board: Board, _, pileId: number) => isRemovalAllowed(board, pileId),
+    // Empty piles are dropped from the board, so every pile has a match to give up.
+    validate: (board: Board, _, pileId: number) =>
+      isPileId(board, pileId) && board[pileId] >= 1,
     apply: (board: Board, { ctx }: { ctx: Ctx }, pileId: number): MoveOutcome<Board> => {
       const nextBoard = board
         .map((n, i) => (i === pileId ? n - 1 : n))
@@ -32,8 +23,12 @@ export const moves = {
     }
   },
   splitPile: {
+    // A split has to leave both halves non-empty.
     validate: (board: Board, _, pileId: number, firstPart: number) =>
-      isSplitAllowed(board, pileId, firstPart),
+      isPileId(board, pileId)
+        && Number.isInteger(firstPart)
+        && firstPart >= 1
+        && firstPart <= board[pileId] - 1,
     apply: (board: Board, _, pileId: number, firstPart: number): MoveOutcome<Board> => {
       const size = board[pileId];
       const nextBoard = board.flatMap((n, i) =>

--- a/src/components/games/modified-mill/gameplay.spec.ts
+++ b/src/components/games/modified-mill/gameplay.spec.ts
@@ -5,13 +5,14 @@ import {
   generateEmptyBoard,
   hasLine,
   isBoardFull,
-  isPlacementAllowed,
   moves,
   playerColor,
   playerHasLine
 } from './gameplay';
 import { LINES } from './board-data';
-import { makeCtx } from 'test-utils';
+import { makeCtx, moveValidator } from 'test-utils';
+
+const isPlacementAllowed = moveValidator(moves.placePiece);
 
 describe('modified mill helpers', () => {
   it('has a 24-cell board and 16 winning lines of three cells each', () => {

--- a/src/components/games/modified-mill/gameplay.ts
+++ b/src/components/games/modified-mill/gameplay.ts
@@ -50,14 +50,12 @@ export const playerHasLine = (board: Board, playerIndex: number): boolean => {
 
 export const isBoardFull = (board: Board): boolean => board.every((cell) => cell !== null);
 
-// A disc may go on any cell of the board that is still empty; both players draw
-// from the same pool of cells, so whose turn it is does not matter.
-export const isPlacementAllowed = (board: Board, node: number): boolean =>
-  Number.isInteger(node) && node >= 0 && node < CELL_COUNT && board[node] === null;
-
 export const moves = {
   placePiece: {
-    validate: (board: Board, _, node: number) => isPlacementAllowed(board, node),
+    // A disc may go on any cell of the board that is still empty; both players
+    // draw from the same pool of cells, so whose turn it is does not matter.
+    validate: (board: Board, _, node: number) =>
+      Number.isInteger(node) && node >= 0 && node < CELL_COUNT && board[node] === null,
     apply: (board: Board, { ctx }: { ctx: Ctx }, node: number): MoveOutcome<Board> => {
       const nextBoard = board.slice();
       nextBoard[node] = playerColor(ctx.currentPlayer!);

--- a/src/components/games/number-covering/gameplay.ts
+++ b/src/components/games/number-covering/gameplay.ts
@@ -7,14 +7,13 @@ export const COVERED = -1 as const;
 
 export const getRemaining = (board: Board) => board.filter(i => i !== COVERED);
 
-// Numbers are addressed by their value, which is also their 1-based position;
-// only one that is still showing may be covered.
-const isCoveringAllowed = (board: Board, number: number): boolean =>
-  Number.isInteger(number) && number >= 1 && number <= board.length && board[number - 1] !== COVERED;
-
 export const moves = {
   coverNumber: {
-    validate: (board: Board, _, number: number) => isCoveringAllowed(board, number),
+    // Numbers are addressed by their value, which is also their 1-based
+    // position; only one that is still showing may be covered.
+    validate: (board: Board, _, number: number) =>
+      Number.isInteger(number) && number >= 1 && number <= board.length
+        && board[number - 1] !== COVERED,
     apply: (board: Board, _, number: number): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard[number-1] = COVERED;

--- a/src/components/games/pile-union/gameplay.spec.ts
+++ b/src/components/games/pile-union/gameplay.spec.ts
@@ -1,6 +1,9 @@
-import { isPile, moves, type TurnState } from './gameplay';
+import { moves, type TurnState } from './gameplay';
 import { makeCtx, moveValidator } from 'test-utils';
 
+// Taking a match is legal exactly for an index that names a pile, so this is
+// both the removal rule and what `isPile` means.
+const isPile = moveValidator(moves.removeOne);
 const isMergeAllowed = moveValidator(moves.mergePiles);
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx<TurnState>({ currentPlayer }) });

--- a/src/components/games/pile-union/gameplay.ts
+++ b/src/components/games/pile-union/gameplay.ts
@@ -10,11 +10,6 @@ export type TurnState = { firstSelectedPile: number }
 export const isPile = (board: Board, pileIndex: number): boolean =>
   Number.isInteger(pileIndex) && pileIndex >= 0 && pileIndex < board.length;
 
-// Merging needs two piles, and they have to be different ones.
-const isMergeAllowed = (board: Board, piles: number[]): boolean =>
-  Array.isArray(piles) && piles.length === 2
-    && isPile(board, piles[0]) && isPile(board, piles[1]) && piles[0] !== piles[1];
-
 export const moves = {
   removeOne: {
     validate: (board: Board, _: { ctx: Ctx<TurnState> }, pileIndex: number) => isPile(board, pileIndex),
@@ -35,7 +30,10 @@ export const moves = {
     }
   },
   mergePiles: {
-    validate: (board: Board, _: { ctx: Ctx<TurnState> }, piles: number[]) => isMergeAllowed(board, piles),
+    // Merging needs two piles, and they have to be different ones.
+    validate: (board: Board, _: { ctx: Ctx<TurnState> }, piles: number[]) =>
+      Array.isArray(piles) && piles.length === 2
+        && isPile(board, piles[0]) && isPile(board, piles[1]) && piles[0] !== piles[1],
     apply: (
       board: Board, _: { ctx: Ctx<TurnState> }, [pileIndex1, pileIndex2]: number[]
     ): MoveOutcome<Board, TurnState> => {

--- a/src/components/games/polynomial-building/gameplay.ts
+++ b/src/components/games/polynomial-building/gameplay.ts
@@ -4,13 +4,6 @@ export type Board = { a: number | null; b: number | null; c: number | null }
 
 export const COEFS: Coef[] = ['a', 'b', 'c'];
 
-// Any integer may be chosen for any coefficient nobody has fixed yet — the two
-// players pick from the same three slots, so whose turn it is does not enter
-// into legality. The safe-integer bound is what keeps the root arithmetic
-// exact; the board client caps the input at 12 digits for the same reason.
-const isCoefficientChoiceAllowed = (board: Board, coef: Coef, value: number): boolean =>
-  COEFS.includes(coef) && board[coef] === null && Number.isSafeInteger(value);
-
 // All integer divisors (positive and negative) of a nonzero integer.
 export const divisors = (n: number): number[] => {
   const m = Math.abs(n);
@@ -112,8 +105,13 @@ export const canComplete = (board: Board): boolean => completionValue(board) !==
 
 export const moves = {
   setCoefficient: {
+    // Any integer may be chosen for any coefficient nobody has fixed yet — the
+    // two players pick from the same three slots, so whose turn it is does not
+    // enter into legality. The safe-integer bound is what keeps the root
+    // arithmetic exact; the board client caps the input at 12 digits for the
+    // same reason.
     validate: (board: Board, _, coef: Coef, value: number) =>
-      isCoefficientChoiceAllowed(board, coef, value),
+      COEFS.includes(coef) && board[coef] === null && Number.isSafeInteger(value),
     apply: (board: Board, _, coef: Coef, value: number): MoveOutcome<Board> => {
       const nextBoard = { ...board, [coef]: value };
       const filled = nextBoard.a !== null && nextBoard.b !== null && nextBoard.c !== null;

--- a/src/components/games/recolouring-discs/gameplay.spec.ts
+++ b/src/components/games/recolouring-discs/gameplay.spec.ts
@@ -4,7 +4,6 @@ import {
   RED,
   applyMove,
   encode,
-  isPlacementAllowed,
   legalMoves,
   majorityWinner,
   moveTargets,
@@ -18,6 +17,9 @@ import { makeCtx } from 'test-utils';
 
 const isDiscMoveAllowed = (cells: Cell[], player: number, from: number, to: number) =>
   moves.moveDisc.validate({ cells }, { ctx: makeCtx({ currentPlayer: player }) }, from, to);
+
+const isPlacementAllowed = (cells: Cell[], player: number, at: number) =>
+  moves.placeDisc.validate({ cells }, { ctx: makeCtx({ currentPlayer: player }) }, at);
 
 const cells = (s: string): Cell[] =>
   [...s].map(c => (c === 'R' ? 'red' : c === 'B' ? 'blue' : null));

--- a/src/components/games/recolouring-discs/gameplay.ts
+++ b/src/components/games/recolouring-discs/gameplay.ts
@@ -69,15 +69,6 @@ export const placeTargets = (cells: Cell[], color: 'red' | 'blue'): number[] =>
         (j + 1 < cells.length && cells[j + 1] === color))
   );
 
-// A player may only pick up a disc of their own colour, and only drop it on a
-// cell `moveTargets` offers (empty, 1–2 away).
-const isDiscMoveAllowed = (cells: Cell[], player: number, from: number, to: number): boolean =>
-  cells[from] === colorOf(player) && moveTargets(cells, from).includes(to);
-
-// A new disc may only go on an empty cell next to one of the player's own discs.
-export const isPlacementAllowed = (cells: Cell[], player: number, at: number): boolean =>
-  placeTargets(cells, colorOf(player)).includes(at);
-
 export const legalMoves = (cells: Cell[], player: number): Move[] => {
   const color = colorOf(player);
   const result: Move[] = [{ type: 'pass' }];
@@ -150,14 +141,18 @@ const finalize = (nextCells: Board['cells'], ctx: Ctx): MoveOutcome<Board> => {
 // validator.
 export const moves = {
   moveDisc: {
+    // A player may only pick up a disc of their own colour, and only drop it on
+    // a cell `moveTargets` offers (empty, 1–2 away).
     validate: (board: Board, { ctx }: { ctx: Ctx }, from: number, to: number) =>
-      isDiscMoveAllowed(board.cells, ctx.currentPlayer!, from, to),
+      board.cells[from] === colorOf(ctx.currentPlayer!)
+        && moveTargets(board.cells, from).includes(to),
     apply: (board: Board, { ctx }: { ctx: Ctx }, from: number, to: number) =>
       finalize(applyMove(board.cells, ctx.currentPlayer!, { type: 'move', from, to }), ctx)
   },
   placeDisc: {
+    // A new disc may only go on an empty cell next to one of the player's own discs.
     validate: (board: Board, { ctx }: { ctx: Ctx }, at: number) =>
-      isPlacementAllowed(board.cells, ctx.currentPlayer!, at),
+      placeTargets(board.cells, colorOf(ctx.currentPlayer!)).includes(at),
     apply: (board: Board, { ctx }: { ctx: Ctx }, at: number) =>
       finalize(applyMove(board.cells, ctx.currentPlayer!, { type: 'place', to: at }), ctx)
   },

--- a/src/components/games/remove-divisor-multiple/gameplay.spec.ts
+++ b/src/components/games/remove-divisor-multiple/gameplay.spec.ts
@@ -1,6 +1,8 @@
 import { range } from 'lodash';
-import { isAllowed, moves } from './gameplay';
-import { makeCtx } from 'test-utils';
+import { moves } from './gameplay';
+import { makeCtx, moveValidator } from 'test-utils';
+
+const isAllowed = moveValidator(moves.removeNumber);
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
 

--- a/src/components/games/remove-row-or-column/gameplay.spec.ts
+++ b/src/components/games/remove-row-or-column/gameplay.spec.ts
@@ -1,10 +1,13 @@
 import {
   type Board, type Grid, type Move, type TurnState,
-  getRectangleAt, getRectangles, applyMove, isEmpty, getAllMoves, isRemovalAllowed, moves
+  getRectangleAt, getRectangles, applyMove, isEmpty, getAllMoves, moves
 } from './gameplay';
-import { makeCtx } from 'test-utils';
+import { makeCtx, moveValidator } from 'test-utils';
 
 const g = (rows: number[][]): Grid => rows.map(r => r.map(Boolean));
+
+const isRemovalAllowed = (grid: Grid, move: Move): boolean =>
+  moveValidator(moves.removeLine)({ grid }, move);
 
 describe('getRectangleAt', () => {
   it('returns the bounding box of a solid rectangle', () => {

--- a/src/components/games/remove-row-or-column/gameplay.ts
+++ b/src/components/games/remove-row-or-column/gameplay.ts
@@ -52,15 +52,6 @@ export const getRectangles = (grid: Grid): Rect[] => {
   return rects;
 };
 
-// A move names a disc and an orientation; the rectangle it belongs to, and
-// hence the line removed, follow from the grid. Every disc's row and column are
-// removable, so "there is a disc at (r, c)" is the whole of legality — but it
-// matters, since applyMove reads the rectangle around that disc and there is
-// none around an empty cell.
-export const isRemovalAllowed = (grid: Grid, move: Move): boolean =>
-  !!move && (move.orientation === 'row' || move.orientation === 'col')
-    && grid[move.r]?.[move.c] === true;
-
 // Remove every disc in the chosen row / column of the rectangle containing (r, c).
 export const applyMove = (grid: Grid, { r, c, orientation }: Move): Grid => {
   const rect = getRectangleAt(grid, r, c)!;
@@ -77,7 +68,14 @@ export const isEmpty = (grid: Grid): boolean => grid.every(row => row.every(cell
 
 export const moves = {
   removeLine: {
-    validate: (board: Board, _: { ctx: Ctx<TurnState> }, move: Move) => isRemovalAllowed(board.grid, move),
+    // A move names a disc and an orientation; the rectangle it belongs to, and
+    // hence the line removed, follow from the grid. Every disc's row and column
+    // are removable, so "there is a disc at (r, c)" is the whole of legality —
+    // but it matters, since applyMove reads the rectangle around that disc and
+    // there is none around an empty cell.
+    validate: (board: Board, _: { ctx: Ctx<TurnState> }, move: Move) =>
+      !!move && (move.orientation === 'row' || move.orientation === 'col')
+        && board.grid[move.r]?.[move.c] === true,
     apply: (board: Board, { ctx }: { ctx: Ctx<TurnState> }, move: Move): MoveOutcome<Board, TurnState> => {
       const nextBoard = { grid: applyMove(board.grid, move) };
       // nextTurnState clears the disc the BoardClient parked in ctx.turnState

--- a/src/components/games/rock-paper-scissor/gameplay.spec.ts
+++ b/src/components/games/rock-paper-scissor/gameplay.spec.ts
@@ -1,7 +1,12 @@
-import { isRemovalAllowed, moves, type Board } from './gameplay';
-import { makeCtx } from 'test-utils';
+import { moves, type Board } from './gameplay';
+import { makeCtx, moveValidator } from 'test-utils';
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
+
+// The move takes from the other player's hand, so the mover is the opponent of
+// the hand the assertion names.
+const isRemovalAllowed = (board: Board, opponent: number, idx: number): boolean =>
+  moveValidator(moves.removeSymbol, makeCtx({ currentPlayer: 1 - opponent }))(board, idx);
 
 const ROCK = 0, PAPER = 1, SCISSOR = 2;
 

--- a/src/components/games/rock-paper-scissor/gameplay.ts
+++ b/src/components/games/rock-paper-scissor/gameplay.ts
@@ -22,14 +22,14 @@ const getWinnerIndex = (board: Board) => {
   return beats(second, first) ? 1 : 0;
 };
 
-// Only a symbol the other player still holds may be taken away.
-export const isRemovalAllowed = (board: Board, opponent: number, idx: number): boolean =>
-  Number.isInteger(idx) && idx >= 0 && idx < board[opponent].length && board[opponent][idx] !== null;
-
 export const moves = {
   removeSymbol: {
-    validate: (board: Board, { ctx }: { ctx: Ctx }, idx: number) =>
-      isRemovalAllowed(board, 1 - ctx.currentPlayer!, idx),
+    // Only a symbol the other player still holds may be taken away.
+    validate: (board: Board, { ctx }: { ctx: Ctx }, idx: number) => {
+      const opponent = 1 - ctx.currentPlayer!;
+      return Number.isInteger(idx) && idx >= 0 && idx < board[opponent].length
+        && board[opponent][idx] !== null;
+    },
     apply: (board: Board, { ctx }: { ctx: Ctx }, idx: number): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard[1 - ctx.currentPlayer!][idx] = null;

--- a/src/components/games/single-number-increase/plus-one-two-three/gameplay.ts
+++ b/src/components/games/single-number-increase/plus-one-two-three/gameplay.ts
@@ -5,13 +5,11 @@ export type Board = number
 export const target = 40;
 export const maxStep = 3;
 
-// A step advances to a strictly larger whole number, by at most maxStep.
-const isIncreaseValid = ({ board, number }: { board: Board; number: number }): boolean =>
-  Number.isInteger(number) && number > board && (number - board) <= maxStep;
-
 export const moves = {
   increaseTo: {
-    validate: (board: Board, _, number: number) => isIncreaseValid({ board, number }),
+    // A step advances to a strictly larger whole number, by at most maxStep.
+    validate: (board: Board, _, number: number) =>
+      Number.isInteger(number) && number > board && (number - board) <= maxStep,
     apply: (_board: Board, { ctx }: { ctx: Ctx }, number: number): MoveOutcome<Board> => {
       if (number > target) {
         return { nextBoard: number, gameEnd: { winnerIndex: 1 - ctx.currentPlayer! } };

--- a/src/components/games/single-number-increase/superstitious-counting/gameplay.ts
+++ b/src/components/games/single-number-increase/superstitious-counting/gameplay.ts
@@ -3,11 +3,6 @@ import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
 export type Board = { current: number, target: number, restricted: number | null }
 
-// A step adds a positive whole number below 13, and superstition forbids the one
-// that would complete 13 together with the previous player's step.
-const isStepAllowed = (board: Board, step: number): boolean =>
-  Number.isInteger(step) && step > 0 && step < 13 && step !== board.restricted;
-
 export const generateStartBoard = (): Board => {
   const losingPositions = range(29, 127, 14);
   const winningPositions = difference(range(26, 115), losingPositions);
@@ -24,7 +19,10 @@ export const generateTestStartBoard = (): Board => {
 
 export const moves = {
   step: {
-    validate: (board: Board, _, step: number) => isStepAllowed(board, step),
+    // A step adds a positive whole number below 13, and superstition forbids the
+    // one that would complete 13 together with the previous player's step.
+    validate: (board: Board, _, step: number) =>
+      Number.isInteger(step) && step > 0 && step < 13 && step !== board.restricted,
     apply: (board: Board, { ctx }: { ctx: Ctx }, step: number): MoveOutcome<Board> => {
       const numberAfterStep = board.current + step;
       const nextBoard = { current: numberAfterStep, target: board.target, restricted: 13 - step };

--- a/src/components/games/single-pile-removal/prime-exponentials/gameplay.ts
+++ b/src/components/games/single-pile-removal/prime-exponentials/gameplay.ts
@@ -29,12 +29,6 @@ export const allPrimePowers = (() => {
   return entries.sort((a, b) => a.value - b.value);
 })();
 
-// Only a genuine prime power that fits within the number may be subtracted, so
-// legality is membership in the enumeration above rather than an arithmetic
-// check, which would also accept a composite base.
-const isSubtractionAllowed = (board: Board, { prime, exponent }: { prime: number; exponent: number }) =>
-  allPrimePowers.some(e => e.prime === prime && e.exponent === exponent && e.value <= board);
-
 export const generateStartBoard = () => {
   if (random(0, 1)) {
     return random(3, 166) * 6;
@@ -47,8 +41,11 @@ export const generateSmallStartBoard = () => random(12, 72);
 
 export const moves = {
   subtractPrimeExponent: {
-    validate: (board: Board, _, entry: { prime: number; exponent: number }) =>
-      isSubtractionAllowed(board, entry),
+    // Only a genuine prime power that fits within the number may be subtracted,
+    // so legality is membership in the enumeration above rather than an
+    // arithmetic check, which would also accept a composite base.
+    validate: (board: Board, _, { prime, exponent }: { prime: number; exponent: number }) =>
+      allPrimePowers.some(e => e.prime === prime && e.exponent === exponent && e.value <= board),
     apply: (
       board: Board,
       { ctx }: { ctx: Ctx },

--- a/src/components/games/six-fields-circle/gameplay.spec.ts
+++ b/src/components/games/six-fields-circle/gameplay.spec.ts
@@ -1,7 +1,9 @@
 import {
-  getLegalMoves, hasLegalMove, isOpposite, isRemovalAllowed, moves, type Board, type TurnState
+  getLegalMoves, hasLegalMove, isOpposite, moves, type Board, type TurnState
 } from './gameplay';
-import { makeCtx } from 'test-utils';
+import { makeCtx, moveValidator } from 'test-utils';
+
+const isRemovalAllowed = moveValidator(moves.removeFromTwo);
 
 describe('isRemovalAllowed', () => {
   const board: Board = [2, 1, 0, 3, 1, 1];

--- a/src/components/games/stones-remove-one-not-twice-from-left/gameplay.spec.ts
+++ b/src/components/games/stones-remove-one-not-twice-from-left/gameplay.spec.ts
@@ -1,10 +1,14 @@
 import { times, uniqWith, isEqual } from 'lodash';
 import {
   type Board, boardAfterRemoval, generateStartBoard, generateTestStartBoard, hasNoLegalMove,
-  isRemovalAllowed, moves, openPiles
+  moves, openPiles
 } from './gameplay';
 import { isWinningForMover } from './bot-strategy';
-import { makeCtx } from 'test-utils';
+import { makeCtx, moveValidator } from 'test-utils';
+
+// Which pile is open depends on who is taking, so the mover goes into the ctx.
+const isRemovalAllowed = (board: Board, player: number, pileId: number): boolean =>
+  moveValidator(moves.removeStone, makeCtx({ currentPlayer: player }))(board, pileId);
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
 

--- a/src/components/games/sum-fifteen/gameplay.ts
+++ b/src/components/games/sum-fifteen/gameplay.ts
@@ -15,11 +15,6 @@ export const numbersOwnedBy = (owner: Owner, player: 0 | 1): number[] =>
 export const freeNumbers = (owner: Owner): number[] =>
   allNumbers.filter(n => owner[n - 1] === null);
 
-// A player may claim any of 1..9 that nobody has claimed yet. Both players draw
-// from the same nine numbers, so whose turn it is does not enter into legality.
-const isChoiceAllowed = (owner: Owner, n: number): boolean =>
-  Number.isInteger(n) && n >= 1 && n <= allNumbers.length && owner[n - 1] === null;
-
 // The first player owns numbers on even move counts, so the player to move is
 // simply the parity of how many numbers have been claimed.
 export const currentPlayerFromOwner = (owner: Owner): 0 | 1 =>
@@ -53,7 +48,11 @@ export const findWinningTriple = (nums: number[]): number[] | null => {
 
 export const moves = {
   chooseNumber: {
-    validate: (board: Board, _, n: number) => isChoiceAllowed(board.owner, n),
+    // A player may claim any of 1..9 that nobody has claimed yet. Both players
+    // draw from the same nine numbers, so whose turn it is does not enter into
+    // legality.
+    validate: (board: Board, _, n: number) =>
+      Number.isInteger(n) && n >= 1 && n <= allNumbers.length && board.owner[n - 1] === null,
     apply: (board: Board, { ctx }: { ctx: Ctx }, n: number): MoveOutcome<Board> => {
       const player = ctx.currentPlayer as 0 | 1;
       const owner = board.owner.slice() as Board['owner'];

--- a/src/components/games/take-and-point/bot-strategy.spec.ts
+++ b/src/components/games/take-and-point/bot-strategy.spec.ts
@@ -4,7 +4,6 @@ import { chooseRemoval, choosePointing } from './bot-strategy';
 import {
   applyRemoval,
   countMinPiles,
-  isRemovalAllowed,
   minPileSize,
   moves,
   nonEmptyIndices,
@@ -13,6 +12,7 @@ import {
 import { moveValidator } from 'test-utils';
 
 const isPointingAllowed = moveValidator(moves.pointPiles);
+const isRemovalAllowed = moveValidator(moves.takeStones);
 
 // ---- brute-force oracle (independent of the bot) ----
 const cache = new Map<string, boolean>();

--- a/src/components/games/take-and-point/gameplay.spec.ts
+++ b/src/components/games/take-and-point/gameplay.spec.ts
@@ -10,11 +10,11 @@ import {
   nonEmptyIndices,
   removerWins,
   requiredPointCount,
-  isRemovalAllowed,
   type Board
 } from './gameplay';
 
 const isPointingAllowed = moveValidator(moves.pointPiles);
+const isRemovalAllowed = moveValidator(moves.takeStones);
 
 // Brute-force ground truth: does the player who is about to be pointed at (and
 // then takes) win the rest of the game with optimal play from both sides?

--- a/src/components/games/take-and-point/gameplay.ts
+++ b/src/components/games/take-and-point/gameplay.ts
@@ -32,23 +32,6 @@ export const applyRemoval = (piles: number[], index: number, amount: number): nu
 export const requiredPointCount = (piles: number[]): number =>
   nonEmptyIndices(piles).length === 1 ? 1 : 2;
 
-// The two halves of a turn are told apart by the board alone: `pointed` is null
-// until someone has pointed, and `takeStones` clears it again. Pointing means
-// naming exactly the required number of distinct non-empty piles.
-const isPointingAllowed = (board: Board, indices: number[]): boolean =>
-  board.pointed === null
-    && Array.isArray(indices)
-    && indices.length === requiredPointCount(board.piles)
-    && uniq(indices).length === indices.length
-    && indices.every(i => board.piles[i] > 0);
-
-// Taking means removing between one stone and the whole pile from one of the
-// piles the other player pointed at.
-export const isRemovalAllowed = (board: Board, index: number, amount: number): boolean =>
-  board.pointed !== null
-    && board.pointed.includes(index)
-    && Number.isInteger(amount) && amount >= 1 && amount <= board.piles[index];
-
 // Random start position. Every extra pile is strictly larger than the smallest
 // pile size, so the number of minimal piles (which decides who wins) is `mCount`
 // — drawn uniformly from {1,2,3,4} to keep the two roles at roughly 50/50.
@@ -66,8 +49,12 @@ export const moves = {
   // Take `amount` stones from a pointed pile. The turn does NOT end here: the
   // same player then points at piles for the other player (see `pointPiles`).
   takeStones: {
+    // Taking means removing between one stone and the whole pile from one of the
+    // piles the other player pointed at.
     validate: (board: Board, _, index: number, amount: number) =>
-      isRemovalAllowed(board, index, amount),
+      board.pointed !== null
+        && board.pointed.includes(index)
+        && Number.isInteger(amount) && amount >= 1 && amount <= board.piles[index],
     apply: (
       board: Board, { ctx }: { ctx: Ctx }, index: number, amount: number
     ): MoveOutcome<Board> => {
@@ -81,7 +68,15 @@ export const moves = {
 
   // Point at the piles the other player will choose from, then hand over the turn.
   pointPiles: {
-    validate: (board: Board, _, indices: number[]) => isPointingAllowed(board, indices),
+    // The two halves of a turn are told apart by the board alone: `pointed` is
+    // null until someone has pointed, and `takeStones` clears it again. Pointing
+    // means naming exactly the required number of distinct non-empty piles.
+    validate: (board: Board, _, indices: number[]) =>
+      board.pointed === null
+        && Array.isArray(indices)
+        && indices.length === requiredPointCount(board.piles)
+        && uniq(indices).length === indices.length
+        && indices.every(i => board.piles[i] > 0),
     apply: (board: Board, _, indices: number[]): MoveOutcome<Board> =>
       ({ nextBoard: { piles: board.piles, pointed: indices }, isTurnEnd: true })
   }

--- a/src/components/games/take-and-point/gameplay.ts
+++ b/src/components/games/take-and-point/gameplay.ts
@@ -45,16 +45,29 @@ export const generateStartBoard = (): Board => {
   return { piles: shuffle(piles), pointed: null };
 };
 
+// The two halves of a turn are told apart by the board alone: `pointed` is null
+// until someone has pointed, and `takeStones` clears it again. Pointing means
+// naming exactly the required number of distinct non-empty piles.
+const isPointingAllowed = (board: Board, indices: number[]): boolean =>
+  board.pointed === null
+    && Array.isArray(indices)
+    && indices.length === requiredPointCount(board.piles)
+    && uniq(indices).length === indices.length
+    && indices.every(i => board.piles[i] > 0);
+
+// Taking means removing between one stone and the whole pile from one of the
+// piles the other player pointed at.
+const isRemovalAllowed = (board: Board, index: number, amount: number): boolean =>
+  board.pointed !== null
+    && board.pointed.includes(index)
+    && Number.isInteger(amount) && amount >= 1 && amount <= board.piles[index];
+
 export const moves = {
   // Take `amount` stones from a pointed pile. The turn does NOT end here: the
   // same player then points at piles for the other player (see `pointPiles`).
   takeStones: {
-    // Taking means removing between one stone and the whole pile from one of the
-    // piles the other player pointed at.
     validate: (board: Board, _, index: number, amount: number) =>
-      board.pointed !== null
-        && board.pointed.includes(index)
-        && Number.isInteger(amount) && amount >= 1 && amount <= board.piles[index],
+      isRemovalAllowed(board, index, amount),
     apply: (
       board: Board, { ctx }: { ctx: Ctx }, index: number, amount: number
     ): MoveOutcome<Board> => {
@@ -68,15 +81,7 @@ export const moves = {
 
   // Point at the piles the other player will choose from, then hand over the turn.
   pointPiles: {
-    // The two halves of a turn are told apart by the board alone: `pointed` is
-    // null until someone has pointed, and `takeStones` clears it again. Pointing
-    // means naming exactly the required number of distinct non-empty piles.
-    validate: (board: Board, _, indices: number[]) =>
-      board.pointed === null
-        && Array.isArray(indices)
-        && indices.length === requiredPointCount(board.piles)
-        && uniq(indices).length === indices.length
-        && indices.every(i => board.piles[i] > 0),
+    validate: (board: Board, _, indices: number[]) => isPointingAllowed(board, indices),
     apply: (board: Board, _, indices: number[]): MoveOutcome<Board> =>
       ({ nextBoard: { piles: board.piles, pointed: indices }, isTurnEnd: true })
   }

--- a/src/components/games/ten-coins/gameplay.ts
+++ b/src/components/games/ten-coins/gameplay.ts
@@ -12,16 +12,13 @@ export type TurnState = number
 
 const totalCoins = 10;
 
-// A move needs a value K that is actually on the table, and a strictly smaller
-// positive L to turn those coins into. Both players draw on the same table, so
-// whose turn it is does not enter into legality.
-const isConversionAllowed = (board: Board, k: number, l: number): boolean =>
-  Number.isInteger(k) && Number.isInteger(l) && l >= 1 && l < k && board.includes(k);
-
 export const moves = {
   convert: {
+    // A move needs a value K that is actually on the table, and a strictly
+    // smaller positive L to turn those coins into. Both players draw on the same
+    // table, so whose turn it is does not enter into legality.
     validate: (board: Board, _: { ctx: Ctx<TurnState> }, k: number, l: number) =>
-      isConversionAllowed(board, k, l),
+      Number.isInteger(k) && Number.isInteger(l) && l >= 1 && l < k && board.includes(k),
     apply: (
       board: Board, { ctx }: { ctx: Ctx<TurnState> }, k: number, l: number
     ): MoveOutcome<Board, TurnState> => {

--- a/src/components/games/ten-digit-number/gameplay.ts
+++ b/src/components/games/ten-digit-number/gameplay.ts
@@ -5,15 +5,13 @@ export type Board = { digits: number[], sumMod9: number }
 export const totalDigits = 10;
 export const availableDigits = [1, 2, 3, 4, 5, 6];
 
-// Only one of the six offered digits may be appended, and only while the number
-// is still short of its ten digits. Both players draw from the same six, so
-// whose turn it is does not enter into legality.
-const isDigitChoiceAllowed = (board: Board, digit: number): boolean =>
-  board.digits.length < totalDigits && availableDigits.includes(digit);
-
 export const moves = {
   chooseDigit: {
-    validate: (board: Board, _, digit: number) => isDigitChoiceAllowed(board, digit),
+    // Only one of the six offered digits may be appended, and only while the
+    // number is still short of its ten digits. Both players draw from the same
+    // six, so whose turn it is does not enter into legality.
+    validate: (board: Board, _, digit: number) =>
+      board.digits.length < totalDigits && availableDigits.includes(digit),
     apply: (board: Board, _, digit: number): MoveOutcome<Board> => {
       const newDigits = [...board.digits, digit];
       const newSumMod9 = (board.sumMod9 + digit) % 9;

--- a/src/components/games/three-piles-rebuild/gameplay.spec.ts
+++ b/src/components/games/three-piles-rebuild/gameplay.spec.ts
@@ -2,7 +2,6 @@ import {
   generateStartBoard,
   generateTestStartBoard,
   isLosingNumber,
-  isSplitAllowed,
   isTerminal,
   isWinningBoard,
   isWinningNumber,
@@ -12,6 +11,7 @@ import {
 import { makeCtx, moveValidator } from 'test-utils';
 
 const isKeepAllowed = moveValidator(moves.keepPile);
+const isSplitAllowed = moveValidator(moves.splitPile);
 
 describe('three-piles-rebuild gameplay', () => {
   describe('isWinningNumber / isLosingNumber', () => {

--- a/src/components/games/three-piles-rebuild/gameplay.ts
+++ b/src/components/games/three-piles-rebuild/gameplay.ts
@@ -22,12 +22,6 @@ export const keptPileId = (board: Board): number | undefined =>
 export const withOtherPilesDiscarded = (board: Board, keepId: number): Board =>
   board.map((v, i) => (i === keepId ? v : 0));
 
-// A pile can be kept only at the start of a turn, and only if it can be split.
-const isKeepAllowed = (board: Board, keepId: number): boolean =>
-  Number.isInteger(keepId) && keepId >= 0 && keepId < board.length
-    && keptPileId(board) === undefined
-    && canSplit(board[keepId]);
-
 // The rebuild has to use up the kept pile exactly, in three non-empty parts.
 export const isSplitAllowed = (board: Board, parts: number[]): boolean => {
   const keptId = keptPileId(board);
@@ -86,7 +80,11 @@ export const generateTestStartBoard = (): Board =>
 export const moves = {
   // Step 1 of a turn: keep one pile, discard the other two (shown as 0).
   keepPile: {
-    validate: (board: Board, _, keepId: number) => isKeepAllowed(board, keepId),
+    // A pile can be kept only at the start of a turn, and only if it can be split.
+    validate: (board: Board, _, keepId: number) =>
+      Number.isInteger(keepId) && keepId >= 0 && keepId < board.length
+        && keptPileId(board) === undefined
+        && canSplit(board[keepId]),
     // First half of the turn: keep one pile, then rebuild from it — the turn
     // stays open in between.
     apply: (board: Board, _, keepId: number): MoveOutcome<Board> =>

--- a/src/components/games/tictactoe-alikes/tictactoe/gameplay.ts
+++ b/src/components/games/tictactoe-alikes/tictactoe/gameplay.ts
@@ -25,14 +25,6 @@ export const otherPlayerColor = (ctx: Ctx) =>
     ? (ctx.currentPlayer === 0 ? 'red' : 'blue')
     : (ctx.currentPlayer === ctx.chosenRoleIndex ? botColor : pColor);
 
-// Whitening only starts once the board is full, and a player may only whiten one
-// of the *other* player's pieces — never an own or an already whitened one. The
-// phase check is what stops a player from whitening mid-placement; for placing,
-// "the cell is empty" already implies the placing phase, so that move needs no
-// phase check of its own.
-const isWhiteningAllowed = (board: Board, ctx: Ctx, id: number) =>
-  !inPlacingPhase(board) && board[id] === otherPlayerColor(ctx);
-
 export const moves = {
   placePiece: {
     validate: validatePlacement,
@@ -46,7 +38,13 @@ export const moves = {
     }
   },
   whitenPiece: {
-    validate: (board: Board, { ctx }: { ctx: Ctx }, id: number) => isWhiteningAllowed(board, ctx, id),
+    // Whitening only starts once the board is full, and a player may only whiten
+    // one of the *other* player's pieces — never an own or an already whitened
+    // one. The phase check is what stops a player from whitening mid-placement;
+    // for placing, "the cell is empty" already implies the placing phase, so that
+    // move needs no phase check of its own.
+    validate: (board: Board, { ctx }: { ctx: Ctx }, id: number) =>
+      !inPlacingPhase(board) && board[id] === otherPlayerColor(ctx),
     apply: (board: Board, { ctx }: { ctx: Ctx }, id: number): MoveOutcome<Board> => {
       const nextBoard = cloneDeep(board);
       nextBoard[id] = 'white';

--- a/src/components/games/triangle-circle-game/gameplay.ts
+++ b/src/components/games/triangle-circle-game/gameplay.ts
@@ -43,17 +43,6 @@ export const freeTriangles = (board: Board): number[] => {
   return result;
 };
 
-// The two players never compete for the same resource: the line player only
-// shades edges, the circle player only fills triangles. Each may use anything
-// their opponent has not — and they cannot — touched, so "still free" is the
-// whole of legality on both sides.
-const isShadeAllowed = (board: Board, edgeId: number): boolean =>
-  Number.isInteger(edgeId) && edgeId >= 0 && edgeId < EDGE_COUNT && !board.edges[edgeId];
-
-const isCirclePlacementAllowed = (board: Board, triangleId: number): boolean =>
-  Number.isInteger(triangleId) && triangleId >= 0 && triangleId < TRIANGLE_COUNT
-    && !board.circles[triangleId];
-
 export const applyShade = (board: Board, edgeId: number): Board => {
   const edges = board.edges.slice();
   edges[edgeId] = true;
@@ -97,13 +86,18 @@ export const isWinningShade = (board: Board, edgeId: number): boolean =>
   );
 
 // Each move belongs to exactly one role, so both validators check who is on
-// turn: shading is not a thing the circle player can do at all.
+// turn: shading is not a thing the circle player can do at all. Beyond that the
+// two players never compete for the same resource — the line player only shades
+// edges, the circle player only fills triangles — so "still free" is the whole
+// of legality on both sides.
 export const moves = {
   // Line player shades one edge; they win at once if it completes an un-circled
   // triangle, otherwise the turn passes.
   shadeEdge: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, edgeId: number) =>
-      ctx.currentPlayer === LINE && isShadeAllowed(board, edgeId),
+      ctx.currentPlayer === LINE
+        && Number.isInteger(edgeId) && edgeId >= 0 && edgeId < EDGE_COUNT
+        && !board.edges[edgeId],
     apply: (board: Board, _, edgeId: number): MoveOutcome<Board> => {
       const nextBoard = applyShade(board, edgeId);
       if (isLineWin(nextBoard)) {
@@ -116,7 +110,9 @@ export const moves = {
   // is circled, otherwise the turn passes.
   placeCircle: {
     validate: (board: Board, { ctx }: { ctx: Ctx }, triangleId: number) =>
-      ctx.currentPlayer === CIRCLE && isCirclePlacementAllowed(board, triangleId),
+      ctx.currentPlayer === CIRCLE
+        && Number.isInteger(triangleId) && triangleId >= 0 && triangleId < TRIANGLE_COUNT
+        && !board.circles[triangleId],
     apply: (board: Board, _, triangleId: number): MoveOutcome<Board> => {
       const nextBoard = applyCircle(board, triangleId);
       if (isCircleWin(nextBoard)) {

--- a/src/components/games/triangle-coloring/gameplay.spec.ts
+++ b/src/components/games/triangle-coloring/gameplay.spec.ts
@@ -1,8 +1,10 @@
 import { range } from 'lodash';
-import { moves, isColoringAllowed } from './gameplay';
-import { makeCtx } from 'test-utils';
+import { moves } from './gameplay';
+import { makeCtx, moveValidator } from 'test-utils';
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
+
+const isColoringAllowed = moveValidator(moves.colorTriangle);
 
 const [ALLOWED, COLORED, FORBIDDEN] = [1, 2, 3] as const;
 type Board = Parameters<typeof moves.colorTriangle.apply>[0];

--- a/src/components/games/triangle-coloring/gameplay.ts
+++ b/src/components/games/triangle-coloring/gameplay.ts
@@ -23,12 +23,6 @@ export const triangles = [
   { id: 15, v: [9, 13, 14], neighbors: [14] }
 ];
 
-// A triangle may be coloured while it is still ALLOWED — neither coloured
-// already nor forbidden by a neighbour someone coloured earlier. Both players
-// colour from the same board, so whose turn it is does not enter into legality.
-export const isColoringAllowed = (board: Board, id: number): boolean =>
-  Number.isInteger(id) && id >= 0 && id < triangles.length && board[id] === ALLOWED;
-
 // The board transform a colouring performs, with no turn or game consequences.
 // Shared by the move and by the lookahead search below, which wants the next
 // board and nothing else.
@@ -43,7 +37,11 @@ export const withTriangleColored = (board: Board, id: number): Board => {
 
 export const moves = {
   colorTriangle: {
-    validate: (board: Board, _, id: number) => isColoringAllowed(board, id),
+    // A triangle may be coloured while it is still ALLOWED — neither coloured
+    // already nor forbidden by a neighbour someone coloured earlier. Both players
+    // colour from the same board, so whose turn it is does not enter into legality.
+    validate: (board: Board, _, id: number) =>
+      Number.isInteger(id) && id >= 0 && id < triangles.length && board[id] === ALLOWED,
     apply: (board: Board, { ctx }: { ctx: Ctx }, id: number): MoveOutcome<Board> => {
       const nextBoard = withTriangleColored(board, id);
       if (getAllowedMoves(nextBoard).length === 0) {

--- a/src/components/games/two-of-three-takeaway/gameplay.spec.ts
+++ b/src/components/games/two-of-three-takeaway/gameplay.spec.ts
@@ -3,12 +3,13 @@ import {
   canMove,
   generateStartBoard,
   getLegalMoves,
-  isTakeAllowed,
   isTerminal,
   moves,
   type Board
 } from './gameplay';
-import { makeCtx } from 'test-utils';
+import { makeCtx, moveValidator } from 'test-utils';
+
+const isTakeAllowed = moveValidator(moves.takeChips);
 
 describe('two-of-three-takeaway gameplay', () => {
   describe('move mechanics', () => {

--- a/src/components/games/two-of-three-takeaway/gameplay.ts
+++ b/src/components/games/two-of-three-takeaway/gameplay.ts
@@ -19,10 +19,6 @@ export const applyMove = (board: Board, [i, j]: Move): Board =>
 
 export const isPile = (i: number): boolean => Number.isInteger(i) && i >= 0 && i < 3;
 
-// A move takes one chip from each of two *distinct* non-empty piles.
-export const isTakeAllowed = (board: Board, i: number, j: number): boolean =>
-  isPile(i) && isPile(j) && i !== j && board[i] > 0 && board[j] > 0;
-
 export const getLegalMoves = (board: Board): Move[] => {
   const nonEmpty = board.map((_, i) => i).filter(i => board[i] > 0);
   const moves: Move[] = [];
@@ -74,7 +70,9 @@ export const generateStartBoard = (): Board => {
 
 export const moves = {
   takeChips: {
-    validate: (board: Board, _, i: number, j: number) => isTakeAllowed(board, i, j),
+    // A move takes one chip from each of two *distinct* non-empty piles.
+    validate: (board: Board, _, i: number, j: number) =>
+      isPile(i) && isPile(j) && i !== j && board[i] > 0 && board[j] > 0,
     apply: (
       board: Board, { ctx }: { ctx: Ctx }, i: number, j: number
     ): MoveOutcome<Board> => {


### PR DESCRIPTION
Follows the second commit of #449 (`dde3320`), which in twelve-squares deleted a
legality predicate that existed only for one `validate` to delegate to, moved
its body and comment into the validator, and had the bot and the spec read
legality back through the move. I checked whether the same opportunity existed
elsewhere: 50 more predicates matched, across ~45 games.

Two commits, both mechanical, following the design already merged in #449 and
(for the spec half) #428.

## 1. Inline single-use legality predicates — 41 predicates, 38 games

A predicate referenced exactly once, by one `validate`, is a name the move
already carries. Body and comment move into the validator; exported ones lose
their export, and their specs read the rule back through
`moveValidator(moves.X)` — or through the move with a ctx naming the mover where
the rule depends on whose turn it is (`five-five-card`, `rock-paper-scissor`,
`dominoes-4x4`, `recolouring-discs`, `architect-and-bandits`). Two bot specs
(`chess-ducks`, `take-and-point`) were rewired the same way.

Not swept:

- **8 with multi-statement bodies** — `architect-and-bandits`' step rule,
  `bacteria`, `chocolate-breaking`, `number-pyramid`, `six-fields-circle`,
  `three-piles-rebuild`'s split, `primely-to-zero`, `take-power-of-two`.
  Inlining a 5–6 line block into the `moves` object costs more readability than
  the indirection does.
- **`bank-robbers`' `isRobbable`** — the board client uses it deliberately
  alongside `moves.rob.isAllowed`. Since the client's `isAllowed` is turn
  ownership **and** `validate`, the raw predicate answers a different question
  ("could this bank ever be robbed"), which is what drives the greyed-out
  styling.

## 2. Read legality through the move in the remaining specs — 11 spec files

The predicates here are genuinely multi-use — `openPiles`, `getAllowedMoves` and
the board clients call them too — so they stay in `gameplay.ts`. Only the spec's
route changes, for the reason the comment on `moveValidator` gives: a spec
calling the bare predicate keeps passing after its move loses its `validate:`
line, while the game silently starts accepting illegal moves.

Covers `stones-remove-one-not-twice-from-left`, `cube-coloring`,
`remove-divisor-multiple`, `six-fields-circle`, `five-`/`four-connected-fields`,
`pile-union`, `bank-robbers`, `three-piles-rebuild`, `bacteria` (whose four
attack types are four separate moves, so the type the assertion names picks the
move) and `architect-and-bandits`.

Three left alone, each for its own reason:

- **`totem-poles`** — converted, then `tsc` rejected
  `isAllowed(board, { from: 0, to: null })` and `isAllowed(board)`. Not sloppy
  tests: the board client asks about a rope the player is halfway through
  picking, so `isAllowed` has a deliberately wider contract than `validate`.
- **`policeman-thief`** — already asserts legality through `moves.X.validate`;
  its `isNeighbour`/`isVertex` imports serve a separate graph-geometry describe.
- **Shared parent-level rules** (`pile-splitting-games`, `single-pile-removal`'s
  `validateTake`, `tictactoe-alikes`' `validatePlacement`, `shark-chase`,
  `thief-sheriff-mean`, `distinct-squares`) — these *are* the validator, shared
  verbatim by several variants, so there is no one move to read them through.
  Worth naming as a gap: if a variant dropped `validate: validateTake`, no
  parent spec would notice. Closing that belongs in the per-variant specs.

## Checks

`npm test` 1785 tests / 189 files green, `tsc --noEmit` and `eslint src` clean —
after each commit. No behaviour change intended anywhere: every inlined body is
the predicate's body verbatim, with the arguments the delegating call already
passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AnsFXgptEdRGUCe3XreMFN

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnsFXgptEdRGUCe3XreMFN)_