### PR TITLE
Represent a card game's board as the cards each player still holds

### DIFF
--- a/src/components/games/five-five-card/bot-strategy.spec.ts
+++ b/src/components/games/five-five-card/bot-strategy.spec.ts
@@ -1,5 +1,5 @@
 import { runMatch, type MatchResult } from 'strategy-game-factory';
-import { type Board, getWinnerIndex, moves } from './gameplay';
+import { type Board, generateStartBoard, moves } from './gameplay';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 
 // Each player takes cards from the *other* hand, so over the eight moves each
@@ -7,18 +7,17 @@ import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 // moves last, which is what makes the whole game theirs.
 type Bot = typeof smartBotStrategy
 
-// generateStartBoard lives in the game .tsx; this is the same deal.
-const START: Board = [[1, 2, 3, 4, 5], [1, 2, 3, 4, 5]];
-
 const play = (startBoard: Board, strategies: [Bot, Bot]): MatchResult<Board> =>
   runMatch({ gameplay: { moves }, strategies, startBoard });
+
+const START = generateStartBoard();
 
 // Solved offline against the real getWinnerIndex: the opening is a second-player
 // win, and so is every position still holding four cards a side — the first
 // player never gets a chance to take the game. The earliest boards it can win
 // from have three cards each.
-const WON_FOR_MOVER: Board = [[null, 2, null, 4, 5], [null, null, 3, 4, 5]];
-const LOST_FOR_MOVER_AT_FOUR: Board = [[null, 2, 3, 4, 5], [null, 2, 3, 4, 5]];
+const WON_FOR_MOVER: Board = [[2, 4, 5], [3, 4, 5]];
+const LOST_FOR_MOVER_AT_FOUR: Board = [[2, 3, 4, 5], [2, 3, 4, 5]];
 
 describe('smartBotStrategy', () => {
   it('wins as the second player from the real start board, against a random opponent', () => {
@@ -62,9 +61,8 @@ describe('the game itself', () => {
   it('always ends with one card each, after eight removals', () => {
     const { board, history } = play(START, [randomBotStrategy, randomBotStrategy]);
     expect(history).toHaveLength(8);
-    expect(board[0]!.filter(v => v !== null)).toHaveLength(1);
-    expect(board[1]!.filter(v => v !== null)).toHaveLength(1);
-    expect(getWinnerIndex(board)).toBeDefined();
+    expect(board[0]).toHaveLength(1);
+    expect(board[1]).toHaveLength(1);
   });
 });
 

--- a/src/components/games/five-five-card/bot-strategy.ts
+++ b/src/components/games/five-five-card/bot-strategy.ts
@@ -1,32 +1,26 @@
-import { sample, range } from 'lodash';
+import { sample } from 'lodash';
 import type { BotStrategy } from 'strategy-game-factory';
-import { type Board, getWinnerIndex, type Moves } from './gameplay';
+import { getWinnerIndex, isGameEnd, withCardTaken, type Board, type Card, type Moves } from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>
 
-export const randomBotStrategy: Bot = ({ board, ctx }) => {
-  const opponentIdx = ctx.chosenRoleIndex!;
-  const validIds = range(1, 6).filter(id => board[opponentIdx][id - 1] !== null);
-  return { move: 'removeCard', args: [sample(validIds)!] };
-};
+export const randomBotStrategy: Bot = ({ board, ctx }) =>
+  ({ move: 'removeCard', args: [sample(board[1 - ctx.currentPlayer!])!] });
 
 export const smartBotStrategy: Bot = ({ board, ctx }) => {
   const botPlayerIndex = ctx.currentPlayer!;
-  const opponentIdx = 1 - botPlayerIndex;
 
   let bestScore = -Infinity;
-  let bestMoves: number[] = [];
+  let bestMoves: Card[] = [];
 
-  for (let i = 0; i < 5; i++) {
-    if (board[opponentIdx][i] === null) continue;
-    const nextBoard = board.map(row => [...row]);
-    nextBoard[opponentIdx][i] = null;
-    const score = minimax(nextBoard, 1 - botPlayerIndex, botPlayerIndex);
+  for (const card of board[1 - botPlayerIndex]) {
+    const next = withCardTaken(board, botPlayerIndex, card);
+    const score = minimax(next, 1 - botPlayerIndex, botPlayerIndex);
     if (score > bestScore) {
       bestScore = score;
-      bestMoves = [i + 1];
+      bestMoves = [card];
     } else if (score === bestScore) {
-      bestMoves.push(i + 1);
+      bestMoves.push(card);
     }
   }
 
@@ -34,19 +28,15 @@ export const smartBotStrategy: Bot = ({ board, ctx }) => {
 };
 
 // Return `+1` if the bot's player index won, `-1` otherwise.
-const minimax = (board: Board, currentPlayer, botPlayerIndex): number => {
-  const winner = getWinnerIndex(board);
-  if (winner !== undefined) return winner === botPlayerIndex ? 1 : -1;
+const minimax = (board: Board, currentPlayer: number, botPlayerIndex: number): number => {
+  if (isGameEnd(board)) return getWinnerIndex(board) === botPlayerIndex ? 1 : -1;
 
-  const opponentIdx = 1 - currentPlayer;
   const isMaximizing = currentPlayer === botPlayerIndex;
   let best = isMaximizing ? -Infinity : Infinity;
 
-  for (let i = 0; i < 5; i++) {
-    if (board[opponentIdx][i] === null) continue;
-    const nextBoard = board.map(row => [...row]);
-    nextBoard[opponentIdx][i] = null;
-    const score = minimax(nextBoard, 1 - currentPlayer, botPlayerIndex);
+  for (const card of board[1 - currentPlayer]) {
+    const next = withCardTaken(board, currentPlayer, card);
+    const score = minimax(next, 1 - currentPlayer, botPlayerIndex);
     best = isMaximizing ? Math.max(best, score) : Math.min(best, score);
   }
 

--- a/src/components/games/five-five-card/five-five-card.tsx
+++ b/src/components/games/five-five-card/five-five-card.tsx
@@ -1,8 +1,7 @@
-import { range } from 'lodash';
 import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { useTranslation } from 'language';
-import { moves, type Board } from './gameplay';
+import { CARDS, generateStartBoard, moves, type Board } from './gameplay';
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
@@ -17,21 +16,21 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
         {t({ hu: 'Második', en: 'Second' })}
       </h2>
 
-      {range(5).map(id => (
+      {CARDS.map(card => (
         [0, 1].map(playerIdx => (
           <button
-            key={`${playerIdx}-${id}`}
-            disabled={playerIdx === ctx.currentPlayer || !moves.removeCard.isAllowed(board, id + 1)}
-            onClick={() => moves.removeCard(board, id + 1)}
+            key={`${playerIdx}-${card}`}
+            disabled={playerIdx === ctx.currentPlayer || !moves.removeCard.isAllowed(board, card)}
+            onClick={() => moves.removeCard(board, card)}
             className={`
               ${playerIdx === 0 ? 'col-start-1' : 'col-start-4'}
               aspect-3/2 text-2xl border-4 rounded-lg
               enabled:border-green-400 enabled:border-dashed
               enabled:hocus:border-solid
-              ${board[playerIdx][id] === null ? 'opacity-0' : ''}
+              ${board[playerIdx].includes(card) ? '' : 'opacity-0'}
             `}
           >
-            {board[playerIdx][id]}
+            {card}
           </button>
         ))
       ))}
@@ -72,7 +71,7 @@ export const FiveFiveCard = strategyGameFactory({
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
     {
       botStrategy: smartBotStrategy,
-      generateStartBoard: () => [[1, 2, 3, 4, 5], [1, 2, 3, 4, 5]],
+      generateStartBoard,
       label: { hu: 'Teljes', en: 'Full' },
       isDefault: true
     }

--- a/src/components/games/five-five-card/gameplay.spec.ts
+++ b/src/components/games/five-five-card/gameplay.spec.ts
@@ -1,35 +1,29 @@
-import { moves, type Board } from './gameplay';
+import { CARDS, moves, type Board, type Card } from './gameplay';
 import { makeCtx, moveValidator } from 'test-utils';
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
 
-// The move takes from the other player's hand, so the mover is the opponent of
-// the hand the assertion names.
-const isRemovalAllowed = (board: Board, opponent: number, id: number): boolean =>
-  moveValidator(moves.removeCard, makeCtx({ currentPlayer: 1 - opponent }))(board, id);
-
-// A hand holding exactly the listed values, at their 1-based positions.
-const hand = (values: number[]): (number | null)[] =>
-  [1, 2, 3, 4, 5].map(v => (values.includes(v) ? v : null));
-
-const board = (first: number[], second: number[]): Board => [hand(first), hand(second)];
+// `mover` is whose turn it is; the card it names comes from the *other* hand.
+const isRemovalAllowed = (board: Board, mover: number, card: Card): boolean =>
+  moveValidator(moves.removeCard, asPlayer(mover).ctx)(board, card);
 
 describe('isRemovalAllowed', () => {
-  // Cards are addressed by their 1-based position in the other player's hand.
-  const table = board([1, 2, 4, 5], [1, 2, 3, 4, 5]);
+  const table: Board = [[1, 2, 4, 5], [1, 2, 3, 4, 5]];
 
   it('allows taking a card the other player still holds', () => {
-    expect([1, 2, 3, 4, 5].every(id => isRemovalAllowed(table, 1, id))).toBe(true);
+    expect(CARDS.every(card => isRemovalAllowed(table, 0, card))).toBe(true);
   });
 
   it('rejects a card the other player has already lost', () => {
-    expect(isRemovalAllowed(table, 0, 3)).toBe(false);
-    expect(isRemovalAllowed(table, 0, 2)).toBe(true);
+    expect(isRemovalAllowed(table, 1, 3)).toBe(false);
+    expect(isRemovalAllowed(table, 1, 2)).toBe(true);
   });
 
-  it('rejects a position outside the hand, including the 0 of 0-based indexing', () => {
-    expect(isRemovalAllowed(table, 1, 0)).toBe(false);
-    expect(isRemovalAllowed(table, 1, 6)).toBe(false);
+  // The engine validates whatever a stray dispatch passed, so a number that was
+  // never dealt has to be rejected rather than quietly missing every hand.
+  it('rejects a number the game does not deal, including the 0 of 0-based indexing', () => {
+    expect(isRemovalAllowed(table, 0, 0 as Card)).toBe(false);
+    expect(isRemovalAllowed(table, 0, 6 as Card)).toBe(false);
   });
 });
 
@@ -39,24 +33,24 @@ describe('isRemovalAllowed', () => {
 describe('end of game', () => {
   it('ends once both players are down to one card, odd sum going to the larger', () => {
     // player 0 takes the 5 from player 1, leaving 3 against 4: sum 7, larger wins
-    const outcome = moves.removeCard.apply(board([3], [4, 5]), asPlayer(0), 5);
+    const outcome = moves.removeCard.apply([[3], [4, 5]], asPlayer(0), 5);
     expect(outcome.gameEnd).toEqual({ winnerIndex: 1 });
     expect(outcome.isTurnEnd).toBeUndefined();
   });
 
   it('gives an even sum to the smaller card', () => {
     // leaves 3 against 5 -> sum 8, smaller (player 0) wins
-    const outcome = moves.removeCard.apply(board([1, 3], [5]), asPlayer(1), 1);
+    const outcome = moves.removeCard.apply([[1, 3], [5]], asPlayer(1), 1);
     expect(outcome.gameEnd).toEqual({ winnerIndex: 0 });
   });
 
   it('gives a tie to the starting player', () => {
-    const outcome = moves.removeCard.apply(board([3], [3, 4]), asPlayer(0), 4);
+    const outcome = moves.removeCard.apply([[3], [3, 4]], asPlayer(0), 4);
     expect(outcome.gameEnd).toEqual({ winnerIndex: 0 });
   });
 
   it('passes the turn while either player holds more than one card', () => {
-    const outcome = moves.removeCard.apply(board([1, 2, 3], [4, 5]), asPlayer(0), 5);
+    const outcome = moves.removeCard.apply([[1, 2, 3], [4, 5]], asPlayer(0), 5);
     expect(outcome.gameEnd).toBeUndefined();
     expect(outcome.isTurnEnd).toBe(true);
   });

--- a/src/components/games/five-five-card/gameplay.ts
+++ b/src/components/games/five-five-card/gameplay.ts
@@ -1,44 +1,43 @@
-import { cloneDeep } from 'lodash';
 import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
-export type Board = (number | null)[][]
+export const CARDS = [1, 2, 3, 4, 5] as const;
 
-const isGameEnd = (board: Board) => {
-  return (
-    board[0].filter(v => v !== null).length === 1 &&
-    board[1].filter(v => v !== null).length === 1
-  );
+export type Card = typeof CARDS[number]
+
+// The cards each player still holds, in `CARDS` order.
+export type Board = [Card[], Card[]]
+
+export const generateStartBoard = (): Board => [[...CARDS], [...CARDS]];
+
+// The board taking `card` leaves behind. A move takes from the *other* hand, so
+// `player` is the mover; the bot's look-ahead plays the same function forward.
+export const withCardTaken = (board: Board, player: number, card: Card): Board => {
+  const nextBoard: Board = [...board];
+  nextBoard[1 - player] = board[1 - player].filter(held => held !== card);
+  return nextBoard;
 };
 
-export const getWinnerIndex = (board: Board) => {
-  if (!isGameEnd(board)) return undefined;
-  const firstPlayerNumber = board[0].find(v => v !== null)!;
-  const secondPlayerNumber = board[1].find(v => v !== null)!
+export const isGameEnd = (board: Board) => board.every(hand => hand.length === 1);
 
-  if (firstPlayerNumber === secondPlayerNumber) return 0;
-  if ((firstPlayerNumber + secondPlayerNumber) % 2 === 0){
-    return firstPlayerNumber < secondPlayerNumber ? 0 : 1;
-  } else {
-    return firstPlayerNumber > secondPlayerNumber ? 0 : 1;
-  }
-}
+// Reached only on an ended board, so each hand's first card is its survivor.
+export const getWinnerIndex = (board: Board) => {
+  const [first] = board[0];
+  const [second] = board[1];
+  if (first === second) return 0;
+
+  const larger = first > second ? 0 : 1;
+  // An odd sum goes to the larger card, an even sum to the smaller.
+  return (first + second) % 2 === 1 ? larger : 1 - larger;
+};
 
 export const moves = {
   removeCard: {
-    // Cards are addressed by their 1-based position in the other player's hand,
-    // and only a card still lying there may be taken.
-    validate: (board: Board, { ctx }: { ctx: Ctx }, id: number) => {
-      const opponent = 1 - ctx.currentPlayer!;
-      return Number.isInteger(id) && id >= 1 && id <= board[opponent].length
-        && board[opponent][id - 1] !== null;
-    },
-    apply: (board: Board, { ctx }: { ctx: Ctx }, id: number): MoveOutcome<Board> => {
-      const nextBoard = cloneDeep(board);
-      nextBoard[1 - ctx.currentPlayer!][id - 1] = null;
-      // getWinnerIndex is undefined exactly while the game is still running.
-      const winnerIndex = getWinnerIndex(nextBoard);
-      if (winnerIndex !== undefined) {
-        return { nextBoard, gameEnd: { winnerIndex } };
+    validate: (board: Board, { ctx }: { ctx: Ctx }, card: Card) =>
+      board[1 - ctx.currentPlayer!].includes(card),
+    apply: (board: Board, { ctx }: { ctx: Ctx }, card: Card): MoveOutcome<Board> => {
+      const nextBoard = withCardTaken(board, ctx.currentPlayer!, card);
+      if (isGameEnd(nextBoard)) {
+        return { nextBoard, gameEnd: { winnerIndex: getWinnerIndex(nextBoard) } };
       }
       return { nextBoard, isTurnEnd: true };
     }

--- a/src/components/games/rock-paper-scissor/bot-strategy.spec.ts
+++ b/src/components/games/rock-paper-scissor/bot-strategy.spec.ts
@@ -1,17 +1,20 @@
 import { smartBotStrategy } from './bot-strategy';
-import { moves, type Board } from './gameplay';
-import { botNextMoveArgs, makeCtx } from 'test-utils';
+import { CARDS, generateStartBoard, moves, type Board, type Card } from './gameplay';
+import { botNextMoveArgs, makeCtx, moveValidator } from 'test-utils';
 
-const smartBotRemoval = (board: Board, currentPlayer: number): number =>
+const smartBotRemoval = (board: Board, currentPlayer: number): Card =>
   botNextMoveArgs(smartBotStrategy({ board, ctx: makeCtx({ currentPlayer }) }))[0];
 
-const START: Board = [['rock', 'paper', 'scissor'], ['rock', 'paper', 'scissor']];
+const remove = (board: Board, player: number, card: Card) =>
+  moves.removeCard.apply(board, { ctx: makeCtx({ currentPlayer: player }) }, card);
 
-const remove = (board: Board, player: number, idx: number) =>
-  moves.removeSymbol.apply(board, { ctx: makeCtx({ currentPlayer: player }) }, idx);
-
-const takeableIndices = (board: Board, player: number): number[] =>
-  [0, 1, 2].filter(idx => board[1 - player][idx] !== null);
+// Asking the move's own validator about every card in the game — rather than
+// reading the opponent hand directly — keeps the search below exploring exactly
+// the game the player plays.
+const takeableCards = (board: Board, player: number): Card[] => {
+  const isTakeable = moveValidator(moves.removeCard, makeCtx({ currentPlayer: player }));
+  return CARDS.filter(card => isTakeable(board, card));
+};
 
 // Winner under optimal play from `board` with `player` to move. Four moves at
 // three choices each, so a plain memoised search covers the whole game.
@@ -23,8 +26,8 @@ const optimalWinner = (board: Board, player: number): number => {
 
   // if no move wins for the mover, the opponent takes it
   let winner = 1 - player;
-  for (const idx of takeableIndices(board, player)) {
-    const outcome = remove(board, player, idx);
+  for (const card of takeableCards(board, player)) {
+    const outcome = remove(board, player, card);
     const result = outcome.gameEnd
       ? outcome.gameEnd.winnerIndex
       : optimalWinner(outcome.nextBoard, 1 - player);
@@ -34,6 +37,8 @@ const optimalWinner = (board: Board, player: number): number => {
   return winner;
 };
 
+const START = generateStartBoard();
+
 // Every position reachable from the start, paired with the player to move.
 const reachablePositions = (): { board: Board; player: number }[] => {
   const seen = new Map<string, { board: Board; player: number }>();
@@ -41,8 +46,8 @@ const reachablePositions = (): { board: Board; player: number }[] => {
     const key = `${JSON.stringify(board)}|${player}`;
     if (seen.has(key)) return;
     seen.set(key, { board, player });
-    for (const idx of takeableIndices(board, player)) {
-      const outcome = remove(board, player, idx);
+    for (const card of takeableCards(board, player)) {
+      const outcome = remove(board, player, card);
       if (!outcome.gameEnd) visit(outcome.nextBoard, 1 - player);
     }
   };
@@ -52,33 +57,21 @@ const reachablePositions = (): { board: Board; player: number }[] => {
 
 describe('smartBotStrategy', () => {
   it('as a second player remove useless piece in first step', () => {
-    expect(
-      smartBotRemoval([['rock', 'paper', 'scissor'], ['rock', null, 'scissor']], 1)
-    ).toEqual(0);
-    expect(
-      smartBotRemoval([['rock', 'paper', 'scissor'], ['rock', 'paper', null]], 1)
-    ).toEqual(1);
-    expect(
-      smartBotRemoval([['rock', 'paper', 'scissor'], [null, 'paper', 'scissor']], 1)
-    ).toEqual(2);
+    expect(smartBotRemoval([['rock', 'paper', 'scissor'], ['rock', 'scissor']], 1)).toEqual('rock');
+    expect(smartBotRemoval([['rock', 'paper', 'scissor'], ['rock', 'paper']], 1)).toEqual('paper');
+    expect(smartBotRemoval([['rock', 'paper', 'scissor'], ['paper', 'scissor']], 1)).toEqual('scissor');
   });
 
   it('as a second player remove useless piece in second step', () => {
-    expect(
-      smartBotRemoval([[null, 'paper', 'scissor'], [null, null, 'scissor']], 1)
-    ).toEqual(2);
+    expect(smartBotRemoval([['paper', 'scissor'], ['scissor']], 1)).toEqual('scissor');
   });
 
   it('as a first player remove a piece that you cannot beat if possible', () => {
-    expect(
-      smartBotRemoval([['rock', null, 'scissor'], ['rock', null, 'scissor']], 0)
-    ).toEqual(0);
+    expect(smartBotRemoval([['rock', 'scissor'], ['rock', 'scissor']], 0)).toEqual('rock');
   });
 
   it('as a first player remove a piece that can still beat you if possible', () => {
-    expect(
-      smartBotRemoval([['rock', 'paper', null], ['rock', null, 'scissor']], 0)
-    ).toEqual(2);
+    expect(smartBotRemoval([['rock', 'paper'], ['rock', 'scissor']], 0)).toEqual('scissor');
   });
 
   // The second player picks the first player's surviving card last, and a tie

--- a/src/components/games/rock-paper-scissor/bot-strategy.ts
+++ b/src/components/games/rock-paper-scissor/bot-strategy.ts
@@ -1,48 +1,35 @@
-import { random } from 'lodash';
+import { sample } from 'lodash';
 import type { BotStrategy } from 'strategy-game-factory';
-import type { Board, Moves } from './gameplay';
+import { beats, type Board, type Moves } from './gameplay';
 
 type Bot = BotStrategy<Board, Moves>
 
 export const smartBotStrategy: Bot = ({ board, ctx }) => {
   const currentPlayer = ctx.currentPlayer!;
-  // start with a random place as a first step
+  const ownHand = board[currentPlayer];
+  // A move takes from the other player's hand, so that hand is the choice.
+  const opponentHand = board[1 - currentPlayer];
+
+  // The opening is symmetric, so there is nothing to go on yet.
+  if (currentPlayer === 0 && opponentHand.length === 3) {
+    return { move: 'removeCard', args: [sample(opponentHand)!] };
+  }
+
+  // A card only threatens us while we cannot beat it, so take those away first.
+  // This is the whole of the second player's winning strategy, and the first
+  // player's best try at one.
+  const weCannotBeat = opponentHand.find(card => !ownHand.some(mine => beats(mine, card)));
+  if (weCannotBeat) return { move: 'removeCard', args: [weCannotBeat] };
+
+  // A tie goes to the first player, so as the first player a card whose twin we
+  // still hold is harmless too; the rest have to go.
   if (currentPlayer === 0) {
-    const allowedPlaces = [0, 1, 2].filter(i => board[1][i] !== null);
-    if (allowedPlaces.length === 3) {
-      return { move: 'removeSymbol', args: [random(0, 2)] };
-    }
+    const weCannotTie = opponentHand.find(card => !ownHand.includes(card));
+    if (weCannotTie) return { move: 'removeCard', args: [weCannotTie] };
   }
 
-  // as a first player still try to win if second player may not play optimally
-  if (currentPlayer === 0) {
-    // pairs to still have chance
-    // we have two cards left to choose from so at least one option is available
-    const pairs = [[0, 2], [1, 0], [2, 1], [0, 0], [1, 1], [2, 2]];
-    for (const p of pairs) {
-
-      // first is occupied, second is not from given pair
-      if (board[0][p[0]] === null && board[1][p[1]] !== null) {
-        return { move: 'removeSymbol', args: [p[1]] };
-      }
-    }
-  }
-
-  // as a second player proceed with chosing useless player's piece
-
-  if (currentPlayer === 1) {
-    // pairs beating each other
-    const pairs = [[0, 1], [1, 2], [2, 0]];
-    for (const p of pairs) {
-      // first is not occupied, second is occupied from given pair
-      if (board[0][p[0]] !== null && board[1][p[1]] === null) {
-        return { move: 'removeSymbol', args: [p[0]] };
-      }
-    }
-  }
-
-  // Unreachable: player 0 always moves first, so by any player-1 turn at least one
-  // of player 1's cards is already gone and a pair above matches. A player-0 turn
-  // likewise always returns (full board -> random, otherwise a pair matches).
+  // Unreachable: player 0 opens, so on any later turn the mover's own hand has
+  // lost a card, and a hand missing a card always faces one it can neither beat
+  // nor — as the first player — tie.
   throw new Error('no removable card found: the bot should always have a move here');
 };

--- a/src/components/games/rock-paper-scissor/gameplay.spec.ts
+++ b/src/components/games/rock-paper-scissor/gameplay.spec.ts
@@ -1,35 +1,28 @@
-import { moves, type Board } from './gameplay';
+import { CARDS, moves, type Board, type Card } from './gameplay';
 import { makeCtx, moveValidator } from 'test-utils';
 
 const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) });
 
-// The move takes from the other player's hand, so the mover is the opponent of
-// the hand the assertion names.
-const isRemovalAllowed = (board: Board, opponent: number, idx: number): boolean =>
-  moveValidator(moves.removeSymbol, makeCtx({ currentPlayer: 1 - opponent }))(board, idx);
-
-const ROCK = 0, PAPER = 1, SCISSOR = 2;
-
-const hand = (kept: number[]): Board[number] =>
-  (['rock', 'paper', 'scissor'] as const).map((s, i) => (kept.includes(i) ? s : null));
-
-const board = (first: number[], second: number[]): Board => [hand(first), hand(second)];
+// `mover` is whose turn it is; the card it names comes from the *other* hand.
+const isRemovalAllowed = (board: Board, mover: number, card: Card): boolean =>
+  moveValidator(moves.removeCard, asPlayer(mover).ctx)(board, card);
 
 describe('isRemovalAllowed', () => {
-  const table = board([ROCK, SCISSOR], [ROCK, PAPER, SCISSOR]);
+  const table: Board = [['rock', 'scissor'], ['rock', 'paper', 'scissor']];
 
-  it('allows taking a symbol the other player still holds', () => {
-    expect([0, 1, 2].every(idx => isRemovalAllowed(table, 1, idx))).toBe(true);
+  it('allows taking a card the other player still holds', () => {
+    expect(CARDS.every(card => isRemovalAllowed(table, 0, card))).toBe(true);
   });
 
-  it('rejects a symbol the other player has already lost', () => {
-    expect(isRemovalAllowed(table, 0, PAPER)).toBe(false);
-    expect(isRemovalAllowed(table, 0, ROCK)).toBe(true);
+  it('rejects a card the other player has already lost', () => {
+    expect(isRemovalAllowed(table, 1, 'paper')).toBe(false);
+    expect(isRemovalAllowed(table, 1, 'rock')).toBe(true);
   });
 
-  it('rejects a symbol that does not exist', () => {
-    expect(isRemovalAllowed(table, 1, 3)).toBe(false);
-    expect(isRemovalAllowed(table, 1, -1)).toBe(false);
+  // The engine validates whatever a stray dispatch passed, so a card that is not
+  // in the game has to be rejected rather than quietly missing every hand.
+  it('rejects a card the game does not have', () => {
+    expect(isRemovalAllowed(table, 0, 'lizard' as Card)).toBe(false);
   });
 });
 
@@ -39,31 +32,29 @@ describe('isRemovalAllowed', () => {
 describe('end of game', () => {
   it('ends once both players are down to one card, and the beating card wins', () => {
     // player 1 takes player 0's scissors, leaving rock against scissors
-    const outcome = moves.removeSymbol.apply(board([ROCK, SCISSOR], [SCISSOR]), asPlayer(1), SCISSOR);
+    const outcome = moves.removeCard.apply([['rock', 'scissor'], ['scissor']], asPlayer(1), 'scissor');
     expect(outcome.gameEnd).toEqual({ winnerIndex: 0 });
     expect(outcome.isTurnEnd).toBeUndefined();
   });
 
   it('gives the round to the second player when their card beats the first', () => {
     // leaves rock against paper: paper (player 1) wins
-    const outcome = moves.removeSymbol.apply(board([ROCK], [PAPER, ROCK]), asPlayer(0), ROCK);
+    const outcome = moves.removeCard.apply([['rock'], ['paper', 'rock']], asPlayer(0), 'rock');
     expect(outcome.gameEnd).toEqual({ winnerIndex: 1 });
   });
 
-  it.each([
-    ['rock', ROCK],
-    ['paper', PAPER],
-    ['scissor', SCISSOR]
-  ])('gives two %s cards to the starting player', (_name, symbol) => {
-    // player 1 takes player 0's spare card, leaving the same symbol on both sides
-    const spare = (symbol + 1) % 3;
-    const outcome = moves.removeSymbol.apply(board([symbol, spare], [symbol]), asPlayer(1), spare);
+  it.each(CARDS)('gives two %s cards to the starting player', card => {
+    // player 1 takes player 0's spare card, leaving the same card on both sides
+    const spare = CARDS.find(other => other !== card)!;
+    const outcome = moves.removeCard.apply([[card, spare], [card]], asPlayer(1), spare);
     expect(outcome.gameEnd).toEqual({ winnerIndex: 0 });
     expect(outcome.isTurnEnd).toBeUndefined();
   });
 
   it('passes the turn while either player holds more than one card', () => {
-    const outcome = moves.removeSymbol.apply(board([ROCK, PAPER, SCISSOR], [ROCK, PAPER]), asPlayer(0), PAPER);
+    const outcome = moves.removeCard.apply(
+      [['rock', 'paper', 'scissor'], ['rock', 'paper']], asPlayer(0), 'paper'
+    );
     expect(outcome.gameEnd).toBeUndefined();
     expect(outcome.isTurnEnd).toBe(true);
   });

--- a/src/components/games/rock-paper-scissor/gameplay.ts
+++ b/src/components/games/rock-paper-scissor/gameplay.ts
@@ -1,42 +1,36 @@
-import { cloneDeep } from 'lodash';
 import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
-export type Board = ('rock' | 'paper' | 'scissor' | null)[][]
+export const CARDS = ['rock', 'paper', 'scissor'] as const;
 
-const isGameEnd = (board: Board) => {
-  const remaining = (row: Board[number]) => row.filter(symbol => symbol !== null).length;
-  return remaining(board[0]) === 1 && remaining(board[1]) === 1;
-};
+export type Card = typeof CARDS[number]
 
-// A card's index is its symbol: 0 = rock, 1 = paper, 2 = scissor. Each symbol
-// beats the one two places along, so rock beats scissor, paper beats rock and
-// scissor beats paper.
-const beats = (a: number, b: number) => b === (a + 2) % 3;
+// The cards each player still holds, in `CARDS` order.
+export type Board = [Card[], Card[]]
 
-const getWinnerIndex = (board: Board) => {
-  if (!isGameEnd(board)) return undefined;
-  const first = board[0].findIndex(symbol => symbol !== null);
-  const second = board[1].findIndex(symbol => symbol !== null);
-  // Two cards showing the same symbol go to the starting player, so the second
-  // player only takes the round by beating them outright.
-  return beats(second, first) ? 1 : 0;
-};
+export const generateStartBoard = (): Board => [[...CARDS], [...CARDS]];
+
+const BEATS: Record<Card, Card> = { rock: 'scissor', paper: 'rock', scissor: 'paper' };
+
+export const beats = (a: Card, b: Card) => BEATS[a] === b;
+
+const isGameEnd = (board: Board) => board.every(hand => hand.length === 1);
 
 export const moves = {
-  removeSymbol: {
-    // Only a symbol the other player still holds may be taken away.
-    validate: (board: Board, { ctx }: { ctx: Ctx }, idx: number) => {
+  removeCard: {
+    validate: (board: Board, { ctx }: { ctx: Ctx }, card: Card) =>
+      board[1 - ctx.currentPlayer!].includes(card),
+    apply: (board: Board, { ctx }: { ctx: Ctx }, card: Card): MoveOutcome<Board> => {
       const opponent = 1 - ctx.currentPlayer!;
-      return Number.isInteger(idx) && idx >= 0 && idx < board[opponent].length
-        && board[opponent][idx] !== null;
-    },
-    apply: (board: Board, { ctx }: { ctx: Ctx }, idx: number): MoveOutcome<Board> => {
-      const nextBoard = cloneDeep(board);
-      nextBoard[1 - ctx.currentPlayer!][idx] = null;
-      // getWinnerIndex is undefined exactly while the game is still running.
-      const winnerIndex = getWinnerIndex(nextBoard);
-      if (winnerIndex !== undefined) {
-        return { nextBoard, gameEnd: { winnerIndex } };
+      const nextBoard: Board = [...board];
+      nextBoard[opponent] = board[opponent].filter(held => held !== card);
+      if (isGameEnd(nextBoard)) {
+        // Each hand is down to its survivor. Two cards showing the same symbol go
+        // to the starting player, so the second player only takes the round by
+        // beating them outright.
+        return {
+          nextBoard,
+          gameEnd: { winnerIndex: beats(nextBoard[1][0], nextBoard[0][0]) ? 1 : 0 }
+        };
       }
       return { nextBoard, isTurnEnd: true };
     }

--- a/src/components/games/rock-paper-scissor/rock-paper-scissor.tsx
+++ b/src/components/games/rock-paper-scissor/rock-paper-scissor.tsx
@@ -1,38 +1,43 @@
+import type { FC } from 'react';
 import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { smartBotStrategy } from './bot-strategy';
 import { RockSvg } from './symbols/rock-svg';
 import { PaperSvg } from './symbols/paper-svg';
 import { ScissorSvg } from '../shared/scissor-svg';
 import { useTranslation } from 'language';
-import { moves, type Board } from './gameplay';
+import { CARDS, generateStartBoard, moves, type Board, type Card } from './gameplay';
 
-const symbolSvgs = [RockSvg, PaperSvg, ScissorSvg];
+const cardSvgs: Record<Card, FC> = {
+  rock: RockSvg,
+  paper: PaperSvg,
+  scissor: ScissorSvg
+};
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
 
   return (
   <GameBoard>
-    <div className="grid grid-cols-3">
+    <div className="grid grid-cols-4 gap-y-3">
       <h2 className="text-center col-start-1">{t({ hu: 'Kezdő', en: 'First' })}</h2>
-      <h2 className="text-center col-start-3">{t({ hu: 'Második', en: 'Second' })}</h2>
+      <h2 className="text-center col-start-4">{t({ hu: 'Második', en: 'Second' })}</h2>
 
-      {[0, 1, 2].map(symbolIdx => {
-        const SymbolSvg = symbolSvgs[symbolIdx];
+      {CARDS.map(card => {
+        const CardSvg = cardSvgs[card];
         return [0, 1].map(playerIdx => (
           <button
-            key={`${playerIdx}-${symbolIdx}`}
-            disabled={playerIdx === ctx.currentPlayer || !moves.removeSymbol.isAllowed(board, symbolIdx)}
-            onClick={() => moves.removeSymbol(board, symbolIdx)}
+            key={`${playerIdx}-${card}`}
+            disabled={playerIdx === ctx.currentPlayer || !moves.removeCard.isAllowed(board, card)}
+            onClick={() => moves.removeCard(board, card)}
             className={`
-              ${playerIdx === 0 ? 'col-start-1' : 'col-start-3'}
+              ${playerIdx === 0 ? 'col-start-1' : 'col-start-4'}
               p-2 m-2 aspect-4/5 bg-surface-elevated rounded-lg drop-shadow-lg
               enabled:border-2 enabled:border-dashed
               enabled:hocus:opacity-50
-              ${board[playerIdx][symbolIdx] === null ? 'opacity-0' : ''}
+              ${board[playerIdx].includes(card) ? '' : 'opacity-0'}
             `}
           >
-            <SymbolSvg />
+            <CardSvg />
           </button>
         ));
       })}
@@ -68,9 +73,6 @@ export const RockPaperScissor = strategyGameFactory({
   BoardClient,
   gameplay: { moves },
   variants: [
-    {
-      botStrategy: smartBotStrategy,
-      generateStartBoard: (): Board => [['rock', 'paper', 'scissor'], ['rock', 'paper', 'scissor']]
-    }
+    { botStrategy: smartBotStrategy, generateStartBoard }
   ]
 });


### PR DESCRIPTION
Both card games stored every card twice: once as its position in a fixed-length row, once as its value — and nothing ever read the value. rock-paper-scissor's cells held 'rock' | 'paper' | 'scissor' | null at the matching index, and five-five-card's "1-based id" was the card number reached through hand[id - 1]. Every board helper existed to bridge index-land and value-land.

A hand is the set of cards still in front of a player, so make it one:

  export type Board = [Card[], Card[]]

isHeld, heldSymbols, holds, takeableIndices and takeableIds all go: a hand *is* its takeable set, so validate is board[1 - mover].includes(card) and removal is a filter — no cloneDeep, no lodash in either gameplay.ts. rock-paper-scissor's (a + 2) % 3 becomes a BEATS table that states the rules, and its bot's two pair tables collapse into the one rule they both encoded: take a card you cannot beat, and as the first player one you cannot tie either. five-five-card's getWinnerIndex loses its undefined sentinel now that isGameEnd is exported for apply and the bot's minimax to guard with, and both of them advance a position through the same withCardTaken.

Move args are Card, not an index, so a wrong one is a typecheck error rather than a validate rejection at play time; boards print themselves in memo keys and engine errors; and the specs write positions as literals ([[3], [4, 5]]), retiring both hand()/board() builders. generateStartBoard moves into gameplay.ts in both games, where the file layout says it belongs and where the specs can share it.

No change in play: rock-paper-scissor's exhaustive spec still proves the bot never throws away a win from any reachable position, and five-five-card's playouts still have the second player winning from the start board.