### PR TITLE
Let the three smart bots share one odd-cut helper

### DIFF
--- a/src/components/games/pile-splitting-games/bot-strategy.ts
+++ b/src/components/games/pile-splitting-games/bot-strategy.ts
@@ -14,6 +14,13 @@ export const asTurn = ({ removedPileId, pileId, pieceCount }: BotStep): BotMove<
   { move: 'splitPile', args: [{ pileId, pieceCount }] }
 ];
 
+// Every smart bot in the family wins by leaving two odd halves behind, so the
+// cut is an odd number of pieces; which odd number is free, and taking it at
+// random is what keeps the strategy from being readable off a few games. A pile
+// of 2 or 3 has only the one odd cut, and this arithmetic already says so.
+export const getOptimalDivision = (pieceCountInPile: number): number =>
+  1 + 2 * random(0, Math.floor((pieceCountInPile - 2) / 2));
+
 // Play a legal turn picked at random, on however many piles the board has: the
 // two halves of the turn are enumerated with the rules' own predicates rather
 // than with a restated "a pile of 2+ can be split".

--- a/src/components/games/pile-splitting-games/pile-splitter-3/bot-strategy.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter-3/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { random } from 'lodash';
-import { asTurn, type Bot, type BotStep } from '../bot-strategy';
+import { asTurn, getOptimalDivision, type Bot, type BotStep } from '../bot-strategy';
 import type { Board } from './gameplay';
 
 export { randomBotStrategy } from '../bot-strategy';
@@ -10,7 +10,7 @@ export const getSmartBotStep = (board: Board): BotStep => {
   const start = random(0, 2);
   let removedPileId: number, splitPileId: number;
 
-  if (board[0] % 2 === 1 || board[1] % 2 === 1 || board[2] % 2 === 1) {
+  if (board.some(size => size % 2 === 1)) {
     if (board[start] % 2 === 0) {
       if (board[(start + 1) % 3] % 2 === 0) {
         removedPileId = (start + 1) % 3;
@@ -40,13 +40,13 @@ export const getSmartBotStep = (board: Board): BotStep => {
     return {
       removedPileId,
       pileId: splitPileId,
-      pieceCount: getOptimalDivision(board, splitPileId)
+      pieceCount: getOptimalDivision(board[splitPileId])
     };
-  } else if (board[0] === 2 && board[1] === 2 && board[2] === 2) {
+  } else if (board.every(size => size === 2)) {
     return {
       removedPileId: (start + 1) % 3,
       pileId: start,
-      pieceCount: getOptimalDivision(board, start)
+      pieceCount: getOptimalDivision(board[start])
     };
   } else {
     // this is the case where all piles have even number of pieces
@@ -55,12 +55,4 @@ export const getSmartBotStep = (board: Board): BotStep => {
     const botStep = getSmartBotStep(board.map((x) => x / 2));
     return { ...botStep, pieceCount: botStep.pieceCount * 2 };
   }
-};
-
-const getOptimalDivision = (board: Board, pileId: number): number => {
-  const sum = board[pileId];
-
-  if (sum === 2) return 1;
-
-  return 1 + 2 * Math.ceil(Math.random() * Math.floor((sum - 2) / 2));
 };

--- a/src/components/games/pile-splitting-games/pile-splitter-4/bot-strategy.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter-4/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { random, range, sample } from 'lodash';
-import { asTurn, type Bot, type BotStep } from '../bot-strategy';
+import { asTurn, getOptimalDivision, type Bot, type BotStep } from '../bot-strategy';
 import type { Board } from './gameplay';
 
 export { randomBotStrategy } from '../bot-strategy';
@@ -13,26 +13,26 @@ export const getSmartBotStep = (board: Board): BotStep => {
   const odds = board.filter(p => p % 2 === 1).length;
 
   if (odds === 4) {
-    const notSinglePileIndices = range(0, 4).filter(i => board[i] !== 1);
+    const notSinglePileIndices = range(4).filter(i => board[i] !== 1);
     const first = sample(notSinglePileIndices)!;
     removedPileId = (first + 1) % 4;
     splitPileId = first;
   }
 
   if (odds === 3) {
-    const evenPileIndex = range(0, 4).find(i => board[i] % 2 === 0)!;
+    const evenPileIndex = range(4).find(i => board[i] % 2 === 0)!;
     removedPileId = (evenPileIndex + 1) % 4;
     splitPileId = evenPileIndex;
   }
 
   if (odds === 2) {
-    const evenPileIndices = range(0, 4).filter(i => board[i] % 2 === 0);
+    const evenPileIndices = range(4).filter(i => board[i] % 2 === 0);
     removedPileId = evenPileIndices[1];
     splitPileId = evenPileIndices[0];
   }
 
   if (odds === 1) {
-    const oddPile = range(0, 4).find(i => board[i] % 2 === 1)!;
+    const oddPile = range(4).find(i => board[i] % 2 === 1)!;
     if (
       board[oddPile] === 1 && board[(oddPile + 1) % 4] === 2 &&
       board[(oddPile + 2) % 4] === 2 && board[(oddPile + 3) % 4] === 2
@@ -52,7 +52,7 @@ export const getSmartBotStep = (board: Board): BotStep => {
   }
 
   if (odds === 0) {
-    if (board[0] === 2 && board[1] === 2 && board[2] === 2 && board[3] === 2) {
+    if (board.every(size => size === 2)) {
       removedPileId = (start + 1) % 4;
       splitPileId = start;
     } else {
@@ -64,14 +64,6 @@ export const getSmartBotStep = (board: Board): BotStep => {
   return {
     removedPileId,
     pileId: splitPileId,
-    pieceCount: getOptimalDivision(board, splitPileId)
+    pieceCount: getOptimalDivision(board[splitPileId])
   };
-};
-
-const getOptimalDivision = (board: Board, pileId: number): number => {
-  const sum = board[pileId];
-
-  if (sum === 2) return 1;
-
-  return 1 + 2 * Math.ceil(Math.random() * Math.floor((sum - 2) / 2));
 };

--- a/src/components/games/pile-splitting-games/pile-splitter/bot-strategy.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter/bot-strategy.ts
@@ -1,5 +1,5 @@
 import { random } from 'lodash';
-import { asTurn, type Bot } from '../bot-strategy';
+import { asTurn, getOptimalDivision, type Bot } from '../bot-strategy';
 import type { Board } from './gameplay';
 
 export { randomBotStrategy } from '../bot-strategy';
@@ -23,10 +23,4 @@ const getPileToSplit = (board: Board): number => {
   return (board[randomPileIndex] % 2 === 0 || board[1 - randomPileIndex] === 1)
     ? randomPileIndex
     : 1 - randomPileIndex;
-};
-
-const getOptimalDivision = (pieceCountInPile: number): number => {
-  if (pieceCountInPile === 2) return 1;
-
-  return 1 + 2 * random(0, Math.floor((pieceCountInPile - 2) / 2));
 };


### PR DESCRIPTION
Stacked on #461, which is stacked on #460 — this PR's diff is against #461.

`getOptimalDivision` was written out three times: byte-identical in the three-
and four-pile games, and once more in `pile-splitter` under a different
signature. All three answer the same question — where to cut a pile so both
halves come out odd — so it moves next to the shared bot, taking the pile's size
rather than the board and an index.

Two things fall out of writing it once:

- `if (sum === 2) return 1` was already what the arithmetic returns for a pile of
  2, so it goes.
- The two copies drew with `Math.ceil(Math.random() * k)`, which never returns
  the lowest cut, where `pile-splitter` used lodash's `random(0, k)`, which does.
  On the shared version the three- and four-pile bots gain the cut they were
  skipping. It is the same split with the halves swapped, so the strategy is
  untouched — their specs already allowed both values.

The parity tests that spelled out every pile become `some`/`every`, and
`range(0, 4)` becomes `range(4)`.

`npx tsc --noEmit`, `npm run lint` and the full suite (1890 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)