### PR TITLE
Memoise chess-ducks' win search instead of budgeting for it

### DIFF
--- a/src/components/games/chess-ducks/bot-strategy.spec.ts
+++ b/src/components/games/chess-ducks/bot-strategy.spec.ts
@@ -40,14 +40,11 @@ describe('smartBotStrategy', () => {
     for (let trial = 0; trial < 3; trial++) {
       expect(play(emptyBoard(rows, cols), [randomBotStrategy, smartBotStrategy]).winnerIndex).toBe(1);
     }
-  }, 20000);
+  });
 
-  // The budget covers the coverage job as well as `npm test`: 4x7 optimal play
-  // is the slowest search in the repo, and V8 instrumentation pushed it past a
-  // 20s limit on a CI runner while taking a third of that uninstrumented.
   it.each([[4, 6], [4, 7]])('wins as the replier on %ix%i in optimal-vs-optimal play', (rows, cols) => {
     expect(play(emptyBoard(rows, cols), [smartBotStrategy, smartBotStrategy]).winnerIndex).toBe(1);
-  }, 45000);
+  });
 });
 
 // The 4x7 opening books are generated offline by

--- a/src/components/games/chess-ducks/bot-strategy.ts
+++ b/src/components/games/chess-ducks/bot-strategy.ts
@@ -116,10 +116,21 @@ const invertTransformation = (stepCoords: Coords, type: TransformationType): Coo
   }
 };
 
+// The search reads nothing but which fields are still free, and the order the
+// ducks were placed in cannot be recovered from that — so the same position is
+// reached along many move orders, and without this the recursion re-derives the
+// same subtree once per order. Keyed on the free-field pattern for that reason.
+const winningStateCache = new Map<string, boolean>();
+
+const freeFieldKey = (board: Board): string =>
+  board.map(row => row.map(cell => cell === null ? '.' : '#').join('')).join('/');
+
 // given board *after* your step, are you set up to win the game for sure?
 const isWinningState = (board: Board): boolean => {
-  if (getAllowedMoves(board).length === 0) {
-    return true;
+  const key = freeFieldKey(board);
+  const cached = winningStateCache.get(key);
+  if (cached !== undefined) {
+    return cached;
   }
 
   const allowedPlacesForOther = getAllowedMoves(board);
@@ -127,7 +138,10 @@ const isWinningState = (board: Board): boolean => {
   const optimalPlaceForOther = allowedPlacesForOther.find(({ row, col }) => {
     return isWinningState(withDuckPlaced(board, { row, col }));
   });
-  return optimalPlaceForOther === undefined;
+
+  const isWinning = optimalPlaceForOther === undefined;
+  winningStateCache.set(key, isWinning);
+  return isWinning;
 };
 
 // see scripts/pre-generate-ai-moves/chess-ducks-optimal-2nd-moves.cjs


### PR DESCRIPTION
`isWinningState` is a plain minimax with no transposition table, and a position here says nothing about the order its ducks were placed in, so the same subtree was re-derived once per order that reaches it. The cost is heavy-tailed rather than uniformly high — most random-bot matches finish in tens of milliseconds, a few take seconds — which is why the 4x7 match only tipped over the 20s budget on one run in three across the open PRs, under the V8 instrumentation the patch-coverage job adds.

A `Map` keyed on the free-field pattern — all the search reads — removes the repetition. Over 60 random-bot matches per board size the total goes from 42s to 0.4s, and the slowest single match from 2.4s to 26ms; under `--coverage` the whole spec now runs in a quarter of a second, where the run that failed spent 82s in it. One game adds ~2k entries to the cache, so the browser pays a few hundred KB for a search that used to freeze it for seconds.

Both bespoke timeouts go with it. The early `getAllowedMoves(board).length === 0` return goes too: `find` over no allowed moves already returns undefined, so the branch only bought a second enumeration of the same list.


Claude-Session: https://claude.ai/code/session_01K8tEYJFuCQpT9Kwqjd4oDF