### PR TITLE
Show 🗑️ for a pile the mover just emptied, not a bare 0

### DIFF
--- a/src/components/games/pile-splitting-games/board-client.tsx
+++ b/src/components/games/pile-splitting-games/board-client.tsx
@@ -81,16 +81,17 @@ export const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const currentChoiceDescription = (pileId: number) => {
     const pieceCountInPile = board[pileId];
 
-    // A pile is 0 between the bot's `removePile` and its `splitPile`.
-    if (!ctx.isClientMoveAllowed) return pieceCountInPile || '🗑️';
-    if (pileId === removedPileId) {
-      // and likewise between the player's own two moves
-      return pieceCountInPile ? `${pieceCountInPile} → 🗑️` : '🗑️';
-    }
+    // A pile is 0 for the beat between `removePile` and `splitPile` — the
+    // mover's own turn as much as the bot's, since the removal does not end the
+    // turn — and it reads as discarded whatever is selected or hovered meanwhile.
+    if (pieceCountInPile === 0) return '🗑️';
+    if (!ctx.isClientMoveAllowed) return pieceCountInPile;
+    // the pile picked to discard, before the click that dispatches the removal
+    if (pileId === removedPileId) return `${pieceCountInPile} → 🗑️`;
     if (removedPileId === null) {
-      return isHoverPreviewedForRemoval(pileId) ? `${pieceCountInPile} → 🗑️` : pieceCountInPile || '🗑️';
+      return isHoverPreviewedForRemoval(pileId) ? `${pieceCountInPile} → 🗑️` : pieceCountInPile;
     }
-    if (!validHoveredPiece || validHoveredPiece.pileId !== pileId) return pieceCountInPile || '🗑️';
+    if (!validHoveredPiece || validHoveredPiece.pileId !== pileId) return pieceCountInPile;
     return `
       ${pieceCountInPile} → ${validHoveredPiece.pieceId + 1}, ${pieceCountInPile - validHoveredPiece.pieceId - 1}
     `;

--- a/src/components/games/pile-splitting-games/pile-splitter/pile-splitter.tsx
+++ b/src/components/games/pile-splitting-games/pile-splitter/pile-splitter.tsx
@@ -51,9 +51,11 @@ const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const currentChoiceDescription = (pileId: number) => {
     const pieceCountInPile = board[pileId];
 
-    // A pile is 0 between the bot's `removePile` and its `splitPile`.
-    if (!ctx.isClientMoveAllowed) return pieceCountInPile || '🗑️';
-    if (!validHoveredPiece) return pieceCountInPile;
+    // A pile is 0 for the beat between `removePile` and `splitPile` — the
+    // mover's own turn as much as the bot's, since the removal does not end the
+    // turn — and it reads as discarded whatever is hovered meanwhile.
+    if (pieceCountInPile === 0) return '🗑️';
+    if (!ctx.isClientMoveAllowed || !validHoveredPiece) return pieceCountInPile;
     if (validHoveredPiece.pileId !== pileId) return `${pieceCountInPile} → 🗑️`;
 
     const split = validHoveredPiece.pieceId + 1;


### PR DESCRIPTION
#461 claimed to fix `pile-splitter` rendering a bare `0` for a pile just discarded, but it only covered the bot's half. `removePile` does not end the turn, so the mover's own `useDeferredMove` beat hits a different branch of `currentChoiceDescription` and still rendered `0` where the three- and four-pile boards rendered 🗑️.

Both clients now test `pieceCountInPile === 0` once at the top, instead of repeating `|| '🗑️'` per branch and missing one.

- `pile-splitter/pile-splitter.tsx` — the fix.
- `pile-splitting-games/board-client.tsx` — no behaviour change; restructured to the same shape so the two clients read alike.

## Testing

`tsc --noEmit`, `eslint`, and the pile-splitting specs plus the `plays-to-an-end` sweep all pass. No spec covers board interaction, so the mid-turn state was also checked in a browser on `#/game/PileSplitter`: the emptied pile shows 🗑️ for the `stepDelay()` beat, on the player's own turn as well as the bot's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)