### PR TITLE
Add a skill for playing a game in a real browser

### DIFF
--- a/.claude/skills/play-game-in-browser/SKILL.md
+++ b/.claude/skills/play-game-in-browser/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: play-game-in-browser
+description: Launch the dev server and play a game in a real browser with Playwright, to verify a BoardClient or game-parts change. Use whenever board rendering, hover previews, mid-turn state, disabled pieces, theming or anything else visual changed — no spec in this repo covers board interaction.
+---
+
+# Play a game in a browser
+
+## Why this exists
+
+Nothing in the test suite clicks a board. `plays-to-an-end.spec.ts` asserts that
+a match completes and names a winner, `renders.spec.tsx` that a board renders at
+all — both drive the *engine*, not the UI. So every claim about what a player
+sees mid-turn is unverified until someone plays the game.
+
+That gap has already cost a bug. PR #461 claimed to have fixed `pile-splitter`
+showing a bare `0` for a pile it had just emptied, where the three- and
+four-pile boards show 🗑️. Only the bot's half of it was actually fixed:
+`removePile` does not end the turn, so on the mover's own `useDeferredMove` beat
+the label took a different branch and still rendered `0`. Lint, typecheck and
+1890 tests were green the whole time. A single playthrough would have caught it,
+and eventually a user did.
+
+## Start the dev server
+
+```bash
+npm run dev     # port 8012, pinned in vite.config.js
+```
+
+Run it in the background and stop it when you are done.
+
+## Drive it
+
+`drive.mjs` next to this file covers everything up to "a game is running and it
+is my turn" — that part is `strategy-game-factory`'s own chrome and is identical
+for every game. Board clicking is per game and belongs in your script.
+
+Write the script under `$CLAUDE_JOB_DIR/tmp` or another scratch directory, not
+in the repo. Import the helper by absolute path (Playwright resolves from the
+repo root, which the helper handles):
+
+```js
+import { launchGame, sampleDuringBeat, readAll }
+  from '/workspaces/durer-jatekok/.claude/skills/play-game-in-browser/drive.mjs';
+
+const { browser, page } = await launchGame('PileSplitter', { mode: 'vsHuman' });
+
+await page.locator('button.rounded-full:not([disabled])').first().click();
+const headers = await sampleDuringBeat(page, p => readAll(p, 'p.text-xl'));
+
+console.log(headers);            // ["6","🗑️","1","5"]
+await page.screenshot({ path: '/tmp/midturn.png' });
+await browser.close();
+```
+
+`launchGame(gameId, { mode, variant, viewport })`:
+
+- `gameId` is the key in `gameList.ts` (`PileSplitter`, `ChessRook`, …). The app
+  is **hash-routed**: `#/game/<id>`. A bare `/game/<id>` renders the overview
+  instead, silently — an easy half hour to lose.
+- `mode`: `vsComputerFirst` (default), `vsComputerSecond`, `vsHuman`.
+- `variant`: the radio's label text, e.g. `'Teszt'`, `'Teljes'`, `'Okos 🤖'` —
+  needed to reach a specific bot. Mode and variant are `input[type=radio]
+  .sr-only`, so they are driven by clicking the label; both restart the game, so
+  they are set before the game starts.
+- Two-player mode needs a second click (`Kezdek`, which side begins) that vs
+  computer does not. Without it the board renders with every piece `disabled`,
+  which reads exactly like a bug in the code you are testing. `launchGame`
+  throws instead if the game did not start.
+
+The UI is Hungarian by default; the `EN` button in the header switches it, which
+is worth doing if your assertions read better in English.
+
+`sampleDuringBeat(page, read)` polls for 1.6 s. Mid-turn states last one
+`stepDelay()` beat — 750–1250 ms, `strategy-game-factory/engine/timing.ts` — so
+they must be sampled, not awaited: by the time a `waitFor` on the next state
+resolves, the frame you wanted is gone. This is the only way to see the board
+between the two halves of a turn, which is where multi-move games go wrong.
+
+## What to actually look at
+
+**Look at the screenshot.** A blank frame is a failed launch, not a pass. Text
+assertions confirm what you thought to assert; the image shows what you didn't.
+
+Worth a playthrough whenever the diff touches a board:
+
+- **Between the two halves of a turn**, for any game whose turn is more than one
+  move — the mover's own beat *and* the bot's. They take different branches.
+- **Both modes.** `vsHuman` is the one that gets skipped, and it is the only one
+  where a human plays both sides of a turn boundary.
+- **Each variant**, if the bots differ — a `Teszt` bot reaches positions the
+  smart one avoids.
+- **Hover previews**, which no headless test can see at all. Hover state
+  survives clicks that are not moves (picking a pile to discard), so check it
+  after such a click, not only before.
+- **Dark mode** (☀ / ◑ / ☾ in the header) if any colour class changed. Which of
+  two `bg-` utilities wins is Tailwind's emit order, not the order written.
+
+## When you are done
+
+Stop the dev server and delete the scratch script. If you found a bug, the fix
+belongs with a note in the PR that it was found by playing the game — that is
+the only evidence available, since no spec can carry it.

--- a/.claude/skills/play-game-in-browser/drive.mjs
+++ b/.claude/skills/play-game-in-browser/drive.mjs
@@ -1,0 +1,64 @@
+// Everything up to "a game is running and it is my turn" is the same for all of
+// the games: it is `strategy-game-factory`'s own chrome, not the game's. That
+// part lives here. Clicking the board itself is per game and belongs in the
+// calling script — a `BoardClient` is exactly the thing these helpers cannot
+// know about.
+//
+// Playwright is a dependency of this repo but nothing imports it (see the "//"
+// note in package.json), so resolve it from the repo root rather than from the
+// caller's directory, which is usually somewhere under /tmp.
+const playwright = new URL('../../../node_modules/playwright/index.mjs', import.meta.url).href;
+
+export const DEV_URL = 'http://localhost:8012';
+
+const START_BUTTON = { vsComputerFirst: 'Kezdő leszek', vsComputerSecond: 'Második leszek' };
+
+// `npm run dev` (port 8012, pinned in vite.config.js) must already be running.
+// The app is hash-routed, so the game id — the key in gameList.ts — goes after
+// the `#`; a bare /game/<id> silently renders the overview instead.
+export const launchGame = async (gameId, { mode = 'vsComputerFirst', variant, viewport } = {}) => {
+  const { chromium } = await import(playwright);
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: viewport ?? { width: 900, height: 1100 } });
+
+  await page.goto(`${DEV_URL}/#/game/${gameId}`);
+  // The role chooser is the shell's pre-game state, so its arrival is what says
+  // the app booted — the board renders before a game is running, too.
+  await page.getByText('Válassz szerepet!').waitFor();
+
+  // Mode and variant are `input[type=radio].sr-only`, so they are driven by
+  // clicking their label text. Both restart the game, hence before the start
+  // button rather than after.
+  if (variant) await page.getByText(variant, { exact: true }).click();
+  if (mode === 'vsHuman') {
+    await page.getByText('🤝 2 játékos').click();
+    // Two-player mode asks which side begins; without this the board renders
+    // but every piece stays disabled.
+    await page.getByRole('button', { name: 'Kezdek' }).first().click();
+  } else {
+    await page.getByRole('button', { name: START_BUTTON[mode] }).click();
+  }
+
+  await page.waitForTimeout(300);
+  const notStarted = await page.getByText(/Válassz szerepet!|^Kezdek$/).count();
+  if (notStarted) throw new Error(`${gameId}: still on the role chooser — the game did not start`);
+
+  return { browser, page };
+};
+
+// Mid-turn states — a pile emptied but not yet split, a bot part-way through a
+// multi-move turn — last one `stepDelay()` beat, 750-1250 ms (see
+// strategy-game-factory/engine/timing.ts). They have to be sampled rather than
+// awaited: a `waitFor` for the state that follows usually resolves after the
+// interesting frame is already gone.
+export const sampleDuringBeat = async (page, read, { ms = 1600, every = 50 } = {}) => {
+  const seen = new Set();
+  for (let elapsed = 0; elapsed < ms; elapsed += every) {
+    for (const value of await read(page)) seen.add(value);
+    await page.waitForTimeout(every);
+  }
+  return [...seen];
+};
+
+export const readAll = async (page, selector) =>
+  Promise.all((await page.locator(selector).all()).map(async el => (await el.textContent()).trim()));


### PR DESCRIPTION
Nothing in the test suite clicks a board. `plays-to-an-end.spec.ts` asserts that
a match completes and names a winner, `renders.spec.tsx` that a board renders at
all — both drive the engine, not the UI. So every claim about what a player sees
*mid-turn* is unverified until someone plays the game.

That gap cost a bug this week. #461 claimed to have fixed `pile-splitter` showing
a bare `0` for a pile it had just emptied, where the three- and four-pile boards
show 🗑️. Only the bot's half was actually fixed: `removePile` does not end the
turn, so on the mover's own `useDeferredMove` beat the label took a different
branch and still rendered `0`. Lint, typecheck and 1890 tests were green the
whole time, and a user found it. (Fix on `fix-emptied-pile-glyph`.)

### What is in here

`drive.mjs` covers everything up to "a game is running and it is my turn". That
part is `strategy-game-factory`'s own chrome and is identical for every game,
while clicking a board is per game and stays in the calling script — a
`BoardClient` is exactly what these helpers cannot know about.

It is also the half that is annoying to rediscover:

- the app is **hash-routed**, and a bare `/game/<id>` renders the overview
  silently rather than erroring;
- Playwright is a dependency that nothing imports, so it has to be resolved from
  the repo root;
- mode and variant are `input[type=radio].sr-only`, driven by clicking the label
  text, and both restart the game;
- two-player mode needs a second click naming who begins — without it the board
  renders with every piece `disabled`, which reads exactly like a bug in the code
  under test. `launchGame` throws instead of handing back a dead board.

`sampleDuringBeat` polls rather than awaits, because mid-turn states last one
`stepDelay()` beat (750–1250 ms): a `waitFor` on the state that follows resolves
after the frame worth looking at is gone. That is the blind spot the bare `0` hid
in.

`SKILL.md` documents the recipe and what is worth checking on a board change —
the mid-turn beat for the mover *and* the bot, `vsHuman` mode, each variant,
hover state after a click that is not a move, and dark mode when colour classes
change.

### Verification

`launchGame` was run against `PileSplitter`, `PileSplitter4`, `ChessRook` and
`PlusOneTwoThree`, across `vsComputerFirst` / `vsComputerSecond` / `vsHuman` and
with a variant selected; the `SKILL.md` example was run verbatim and printed the
output it documents. No `src/` change, so no test or coverage impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)