### PR TITLE
Curated startBoards on a variant, and ?variant= in the URL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,8 @@ verifies the table before writing (see `modified-mill-strategy.cjs`).
 
 | File | Holds | React? |
 |---|---|---|
-| `gameplay.ts` | `Board` type, `generateStartBoard`, `moves`, `Moves`, and the legality / win-detection helpers they use | **never** |
+| `gameplay.ts` | `Board` type, `generateStartBoard` / `startBoards`, `moves`, `Moves`, and the legality / win-detection helpers they use | **never** |
+| `start-boards.ts` | curated `startBoards` lists, once they outgrow `gameplay.ts` (`bacteria`) | **never** |
 | `bot-strategy.ts` | `smartBotStrategy`, `randomBotStrategy` and the search or characterisation behind them | never in practice |
 | `board-client.tsx` | `BoardClient` (split out once the JSX outgrows the game file) | yes |
 | `<game>.tsx` | `rule`, `getPlayerStepDescription`, `variants`, the `strategyGameFactory` call | yes |
@@ -89,6 +90,23 @@ Two rules keep the boundary meaningful rather than nominal:
   (`coins-in-3-piles`'s `isLostForMover`), which keeps it in `gameplay.ts`; that
   is accepted for practice games, where the strategy is readable anyway. A
   **competition** game must not do it — curate its start boards instead.
+
+**Curated start boards.** A variant states its start position either as
+`generateStartBoard` or as `startBoards`, a list the engine picks from at
+random (a clone per pick, so a start board stays owned by the match it starts).
+Prefer the list whenever the positions are enumerable: it is what a competition
+hands out one entry of per attempt (#314), so its **order is part of the
+contract** — append, never reorder — and, unlike a generator, a spec can judge
+every board in it instead of sampling until they have all come up.
+
+Curating is only half of it; a competition board has to be **verified**, since
+the team picks a role and must be able to force the win. `forcedWinnerIndex`
+(`test-utils`) plays the game's own optimal bot against itself and names the
+role that wins, throwing when the playouts disagree — which is either a board
+that is not decisive or a bot that is not optimal. Assert the winning role, not
+merely that the game ends: `coins-in-3-piles` pins 3-5-7 as a replier win, and
+`stones-remove-one-not-twice-from-left` plays every curated board out to
+cross-check the predicate its balance test relies on.
 
 Traffic is expected to remain low — no scalability concerns.
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -61,10 +61,14 @@ export default [
   {
     // A game's gameplay.ts is its framework-free half — the module a future
     // server-authoritative competition mode validates moves with, so it has to
-    // run in plain Node. See issue #313. The .ts half of games/shared/ is
-    // engine-shaped for the same reason; its *-svg.tsx siblings are not matched.
+    // run in plain Node. See issue #313. A start-boards.ts is the same half:
+    // it is the curated data that competition mode hands out, so a server has
+    // to be able to read it without pulling in React. The .ts half of
+    // games/shared/ is engine-shaped for the same reason; its *-svg.tsx
+    // siblings are not matched.
     files: [
       'src/components/games/**/gameplay.ts',
+      'src/components/games/**/start-boards.ts',
       'src/components/games/shared/**/*.ts',
       'src/components/strategy-game-factory/engine/**/*.ts'
     ],

--- a/src/components/CLAUDE.md
+++ b/src/components/CLAUDE.md
@@ -50,10 +50,23 @@ never reorder), and a spec can judge every entry instead of calling the
 generator a few hundred times until they have all come up. Each pick is cloned,
 so a curated board is as freshly owned by its match as a generated one.
 
+**Name the boards, not the list.** A module exports the positions themselves —
+`startBoardOfCategoryA`, `adjacentStartBoards` — and the variant assembles the
+list where it is used: `startBoards: [startBoardOfCategoryA]`. A single position
+stays singular rather than being pluralised into a one-entry export, and the
+name says which position it is instead of restating the field it feeds.
+
 Curated boards want `forcedWinnerIndex` (`test-utils`) in their spec: it plays
 the game's own optimal bot against itself and returns the role that forces the
 win, throwing when playouts disagree. Assert the *role*, not just that the game
 ends — that is the property a competition depends on, since the team's role
+choice is part of its strategy. See `coins-in-3-piles`, and
+`stones-remove-one-not-twice-from-left`, which uses it to cross-check the win
+predicate its own balance test relies on. A game whose bot searches too deeply
+to play out repeatedly verifies its list against a characterisation instead —
+`bacteria` judges every curated board with `deficiency` and an independent
+brute-force solver.
+
 **Variants are addressable in the URL** as `?variant=`, alongside `?lang=` —
 `#/game/CoinsIn3Piles?variant=3-5-7`. The param and the selected variant are
 kept in step both ways: choosing a variant rewrites the param, and a param that
@@ -83,13 +96,6 @@ link — it also keeps that game's tallies and its dashboard rows attached to th
 variant they belong to. Where no id is declared the key is the index, and all
 three only mean anything as long as that game's variant order holds; reordering
 hands a variant the tally of whichever one used to sit at its position.
-
-See `coins-in-3-piles`, and
-`stones-remove-one-not-twice-from-left`, which uses it to cross-check the win
-predicate its own balance test relies on. A game whose bot searches too deeply
-to play out repeatedly verifies its list against a characterisation instead —
-`bacteria` judges every curated board with `deficiency` and an independent
-brute-force solver.
 
 **`moves`** — every move is `{ apply, validate? }`: an optional legality
 predicate paired with an outcome-returning

--- a/src/components/CLAUDE.md
+++ b/src/components/CLAUDE.md
@@ -75,14 +75,14 @@ reordered (`coins-in-3-piles`, `chess-ducks`, `ten-coins`). Ids must be unique,
 and must not read as another variant's index; both throw. Adding ids everywhere
 is not a goal: do it case by case, when a durable link is actually wanted.
 
-The `game-finished` analytics event reports the same key, so a variant reads the
-same in a dashboard as in a link (`variant: '3-5-7'` rather than `variant: 2`).
-Declaring an id therefore improves the analytics for that game too — and for a
-game without one the reported index only means anything as long as the variant
-order holds, which is a second reason to declare ids where the variants matter.
-The per-visitor win/loss counts in `localStorage` are the one thing still keyed
-by index (`stats_<gameId>_<index>`); moving them would reset everyone's counts
-for no gain, since nobody reads that key but the browser that wrote it.
+That key is what a variant is named by everywhere it is named at all: the URL,
+the `game-finished` analytics event (`variant: '3-5-7'` rather than
+`variant: 2`), and the per-visitor win/loss counts in `localStorage`
+(`stats_<gameId>_<variantKey>`). So declaring an id buys more than a durable
+link — it also keeps that game's tallies and its dashboard rows attached to the
+variant they belong to. Where no id is declared the key is the index, and all
+three only mean anything as long as that game's variant order holds; reordering
+hands a variant the tally of whichever one used to sit at its position.
 
 See `coins-in-3-piles`, and
 `stones-remove-one-not-twice-from-left`, which uses it to cross-check the win

--- a/src/components/CLAUDE.md
+++ b/src/components/CLAUDE.md
@@ -31,12 +31,49 @@ strategyGameFactory({
 })
 ```
 
-**`variants`** — array of `{ botStrategy?, generateStartBoard?, label?,
-isDefault? }`. The default variant (marked `isDefault: true`, or the only entry
-if there is just one) must define `generateStartBoard`. If `botStrategy` is
-omitted on a variant, the default variant's `botStrategy` is used as fallback.
-If multiple variants are provided, exactly one must be `isDefault: true`. A
-single-entry array needs no `isDefault` flag.
+**`variants`** — array of `{ id?, botStrategy?, generateStartBoard?,
+startBoards?, label?, isDefault? }`. The default variant (marked
+`isDefault: true`, or the
+only entry if there is just one) must state its start position. If
+`botStrategy` is omitted on a variant, the default variant's `botStrategy` is
+used as fallback. If multiple variants are provided, exactly one must be
+`isDefault: true`. A single-entry array needs no `isDefault` flag.
+
+A variant states that start position **either** as `generateStartBoard`
+(`() => Board`) **or** as `startBoards` (`Board[]`, a curated list the engine
+picks from at random) — declaring both throws, as does an empty list.
+`startBoards` is the declarative form: the engine derives the generator from
+it, so nothing downstream distinguishes the two. Reach for it whenever the
+positions are enumerable rather than sampled — a competition hands out one
+entry per attempt (#314), so the list order is part of the contract (append,
+never reorder), and a spec can judge every entry instead of calling the
+generator a few hundred times until they have all come up. Each pick is cloned,
+so a curated board is as freshly owned by its match as a generated one.
+
+Curated boards want `forcedWinnerIndex` (`test-utils`) in their spec: it plays
+the game's own optimal bot against itself and returns the role that forces the
+win, throwing when playouts disagree. Assert the *role*, not just that the game
+ends — that is the property a competition depends on, since the team's role
+**Variants are addressable in the URL** as `?variant=`, alongside `?lang=` —
+`#/game/CoinsIn3Piles?variant=3-5-7`. The param is read once, on mount, and
+rewritten whenever the variant changes, with the default variant represented by
+the param's *absence* (as `hu` is for `?lang=`). It is deliberately not synced
+back after mount: selecting a variant restarts the game, so a back/forward
+navigation must not be able to discard a game in progress.
+
+`id` is what the param names. It is optional — a variant without one is
+addressed by its index, which is enough for most games — and is worth declaring
+where variants are really separate games and a link should survive them being
+reordered (`coins-in-3-piles`, `chess-ducks`, `ten-coins`). Ids must be unique,
+and must not read as another variant's index; both throw. Adding ids everywhere
+is not a goal: do it case by case, when a durable link is actually wanted.
+
+See `coins-in-3-piles`, and
+`stones-remove-one-not-twice-from-left`, which uses it to cross-check the win
+predicate its own balance test relies on. A game whose bot searches too deeply
+to play out repeatedly verifies its list against a characterisation instead —
+`bacteria` judges every curated board with `deficiency` and an independent
+brute-force solver.
 
 **`moves`** — every move is `{ apply, validate? }`: an optional legality
 predicate paired with an outcome-returning

--- a/src/components/CLAUDE.md
+++ b/src/components/CLAUDE.md
@@ -75,6 +75,15 @@ reordered (`coins-in-3-piles`, `chess-ducks`, `ten-coins`). Ids must be unique,
 and must not read as another variant's index; both throw. Adding ids everywhere
 is not a goal: do it case by case, when a durable link is actually wanted.
 
+The `game-finished` analytics event reports the same key, so a variant reads the
+same in a dashboard as in a link (`variant: '3-5-7'` rather than `variant: 2`).
+Declaring an id therefore improves the analytics for that game too — and for a
+game without one the reported index only means anything as long as the variant
+order holds, which is a second reason to declare ids where the variants matter.
+The per-visitor win/loss counts in `localStorage` are the one thing still keyed
+by index (`stats_<gameId>_<index>`); moving them would reset everyone's counts
+for no gain, since nobody reads that key but the browser that wrote it.
+
 See `coins-in-3-piles`, and
 `stones-remove-one-not-twice-from-left`, which uses it to cross-check the win
 predicate its own balance test relies on. A game whose bot searches too deeply

--- a/src/components/CLAUDE.md
+++ b/src/components/CLAUDE.md
@@ -55,11 +55,18 @@ the game's own optimal bot against itself and returns the role that forces the
 win, throwing when playouts disagree. Assert the *role*, not just that the game
 ends — that is the property a competition depends on, since the team's role
 **Variants are addressable in the URL** as `?variant=`, alongside `?lang=` —
-`#/game/CoinsIn3Piles?variant=3-5-7`. The param is read once, on mount, and
-rewritten whenever the variant changes, with the default variant represented by
-the param's *absence* (as `hu` is for `?lang=`). It is deliberately not synced
-back after mount: selecting a variant restarts the game, so a back/forward
-navigation must not be able to discard a game in progress.
+`#/game/CoinsIn3Piles?variant=3-5-7`. The param and the selected variant are
+kept in step both ways: choosing a variant rewrites the param, and a param that
+changes without a remount is followed. The default variant is the param's
+*absence* (as `hu` is for `?lang=`), so dropping it selects the default; a param
+naming no variant of that game is ignored rather than obeyed.
+
+Following the param matters because of the one case that is easy to miss: the
+app is hash-routed, so navigating to a `?variant=` link for the game **already
+open** remounts nothing. Read once on mount, such a link would change the URL
+and leave the board untouched — which is exactly the link people share. The
+cost is that following it restarts the game, but that is what choosing a variant
+means everywhere else in the UI, so the URL should not be the exception.
 
 `id` is what the param names. It is optional — a variant without one is
 addressed by its index, which is enough for most games — and is worth declaring

--- a/src/components/games/bacteria/bacteria.tsx
+++ b/src/components/games/bacteria/bacteria.tsx
@@ -13,9 +13,9 @@ import {
   type Board
 } from './gameplay';
 import {
-  generateAdjacentStartBoard,
-  generateScatteredStartBoard,
-  generateTestStartBoard
+  adjacentStartBoards,
+  scatteredStartBoards,
+  testStartBoards
 } from './start-boards';
 
 const BacteriaDisplay = ({ count, onGoal, dimmed = false }) => {
@@ -255,19 +255,19 @@ export const Bacteria = strategyGameFactory({
   variants: [
     {
       botStrategy: randomBotStrategy,
-      generateStartBoard: generateTestStartBoard,
+      startBoards: testStartBoards,
       label: { hu: 'Teszt', en: 'Test' }
     },
     {
       botStrategy: smartBotStrategy,
-      generateStartBoard: generateAdjacentStartBoard,
+      startBoards: adjacentStartBoards,
       rule: adjacentRule,
       label: { hu: 'Szomszédos CÉLok', en: 'Adjacent GOALs' },
       isDefault: true
     },
     {
       botStrategy: smartBotStrategy,
-      generateStartBoard: generateScatteredStartBoard,
+      startBoards: scatteredStartBoards,
       rule: scatteredRule,
       label: { hu: 'Szórt CÉLok', en: 'Scattered GOALs' }
     }

--- a/src/components/games/bacteria/bot-strategy.spec.ts
+++ b/src/components/games/bacteria/bot-strategy.spec.ts
@@ -141,7 +141,7 @@ const playAttackerBotVsDefender = (start: Board, maxPlies = 400): 'attacker' | '
 
 describe('smart bot plays the 9x17 game optimally', () => {
   // The real scattered-variant start boards (generateScatteredStartBoard).
-  const boards = scatteredStartBoards();
+  const boards = scatteredStartBoards;
 
   it('has a mix of attacker- and defender-winning start boards', () => {
     const values = boards.map(board => deficiency(board) >= 1);
@@ -191,7 +191,7 @@ describe('smart bot plays the 9x17 game optimally', () => {
 // seed bacteria on rows 0-2, to confirm the shared board-driven bot is also
 // optimal at width 11.
 describe('smart bot plays the 9x11 adjacent-goals game optimally', () => {
-  const boards = adjacentStartBoards();
+  const boards = adjacentStartBoards;
 
   it('has a mix of attacker- and defender-winning start boards', () => {
     const values = boards.map(board => deficiency(board) >= 1);

--- a/src/components/games/bacteria/start-boards.ts
+++ b/src/components/games/bacteria/start-boards.ts
@@ -1,8 +1,8 @@
-import { range, sample } from 'lodash';
+import { range } from 'lodash';
 import type { Board } from './gameplay';
 
 // Curated start boards for the bacteria game. This is the single source of
-// truth: bacteria.tsx samples these for the actual variants, and
+// truth: bacteria.tsx hands these lists to its variants as `startBoards`, and
 // bot-strategy.spec.ts iterates the same boards to prove they stay ~50/50
 // balanced and bot-optimal. Keep it that way — don't copy the data into tests.
 
@@ -48,18 +48,11 @@ const scatteredStartConfigs: { starts: number[], goals: number[] }[] = [
   { starts: [1, 3, 4, 11, 12, 15], goals: [1, 4, 5, 10, 12, 16] }
 ];
 
-// Every curated board, deterministically — for tests that must cover them all.
-export const adjacentStartBoards = (): Board[] =>
+export const adjacentStartBoards: Board[] =
   adjacentStartConfigs.map(({ row, starts, goals }) => buildBoard(11, row, starts, goals));
 
-export const scatteredStartBoards = (): Board[] =>
+export const scatteredStartBoards: Board[] =
   scatteredStartConfigs.map(({ starts, goals }) => buildBoard(17, 0, starts, goals));
 
-// A random curated board — for the actual game variants.
-export const generateAdjacentStartBoard = (): Board => sample(adjacentStartBoards())!;
-
-export const generateScatteredStartBoard = (): Board => sample(scatteredStartBoards())!;
-
 // Test variant covers both sub-games.
-export const generateTestStartBoard = (): Board =>
-  sample([generateAdjacentStartBoard, generateScatteredStartBoard])!();
+export const testStartBoards: Board[] = [...adjacentStartBoards, ...scatteredStartBoards];

--- a/src/components/games/chess-ducks/chess-ducks.tsx
+++ b/src/components/games/chess-ducks/chess-ducks.tsx
@@ -112,11 +112,13 @@ export const ChessDucks = strategyGameFactory({
   gameplay: { moves },
   variants: [
     {
+      id: 'test',
       botStrategy: randomBotStrategy,
       generateStartBoard: generateTestStartBoard,
       label: { hu: 'Teszt', en: 'Test' }
     },
     {
+      id: '4x6',
       botStrategy: smartBotStrategy,
       generateStartBoard: generateStartBoard(4, 6),
       rule: rule(4, 6),
@@ -124,6 +126,7 @@ export const ChessDucks = strategyGameFactory({
       isDefault: true
     },
     {
+      id: '4x7',
       botStrategy: smartBotStrategy,
       generateStartBoard: generateStartBoard(4, 7),
       rule: rule(4, 7),

--- a/src/components/games/coins-in-3-piles/coins-in-3-piles.tsx
+++ b/src/components/games/coins-in-3-piles/coins-in-3-piles.tsx
@@ -2,7 +2,7 @@ import { strategyGameFactory, type StrategyArgs } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { BoardClient } from './board-client';
 import {
-  generateArbitraryStartBoard, fixedStartBoards, generateTestStartBoard, moves,
+  generateArbitraryStartBoard, startBoardOfCategoryA, generateTestStartBoard, moves,
   type Board, type TurnState
 } from './gameplay';
 
@@ -64,7 +64,7 @@ export const CoinsIn3Piles = strategyGameFactory({
     {
       id: '3-5-7',
       botStrategy: smartBotStrategy,
-      startBoards: fixedStartBoards,
+      startBoards: [startBoardOfCategoryA],
       rule: fixedRule,
       label: { hu: '3-5-7 (A)', en: '3-5-7 (A)' }
     },

--- a/src/components/games/coins-in-3-piles/coins-in-3-piles.tsx
+++ b/src/components/games/coins-in-3-piles/coins-in-3-piles.tsx
@@ -2,7 +2,7 @@ import { strategyGameFactory, type StrategyArgs } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { BoardClient } from './board-client';
 import {
-  generateArbitraryStartBoard, generateFixedStartBoard, generateTestStartBoard, moves,
+  generateArbitraryStartBoard, fixedStartBoards, generateTestStartBoard, moves,
   type Board, type TurnState
 } from './gameplay';
 
@@ -56,17 +56,20 @@ export const CoinsIn3Piles = strategyGameFactory({
   gameplay: { moves },
   variants: [
     {
+      id: 'test',
       botStrategy: randomBotStrategy,
       generateStartBoard: generateTestStartBoard,
       label: { hu: 'Teszt', en: 'Test' }
     },
     {
+      id: '3-5-7',
       botStrategy: smartBotStrategy,
-      generateStartBoard: generateFixedStartBoard,
+      startBoards: fixedStartBoards,
       rule: fixedRule,
       label: { hu: '3-5-7 (A)', en: '3-5-7 (A)' }
     },
     {
+      id: 'random',
       botStrategy: smartBotStrategy,
       generateStartBoard: generateArbitraryStartBoard,
       label: { hu: 'Véletlen (B)', en: 'Random (B)' },

--- a/src/components/games/coins-in-3-piles/gameplay.spec.ts
+++ b/src/components/games/coins-in-3-piles/gameplay.spec.ts
@@ -1,5 +1,6 @@
-import { moves, type Board, type TurnState } from './gameplay';
-import { makeCtx } from 'test-utils';
+import { fixedStartBoards, moves, type Board, type TurnState } from './gameplay';
+import { smartBotStrategy } from './bot-strategy';
+import { forcedWinnerIndex, makeCtx } from 'test-utils';
 
 describe('coins-in-3-piles move validators', () => {
   const isRemovalAllowed = (board: Board, turnState: TurnState | null, value: number) =>
@@ -88,5 +89,18 @@ describe('coins-in-3-piles move outcomes', () => {
   it('passing on a non-empty board just ends the turn', () => {
     expect(moves.passAddition.apply([3, 5, 6], { ctx }))
       .toEqual({ nextBoard: [3, 5, 6], nextTurnState: null, isTurnEnd: true });
+  });
+});
+
+// The curated board of the "Fixed" variant. A competition hands out a board
+// like this one and lets the team pick a role, so what has to hold is not just
+// that the game ends but that a *named* role forces the win — here the replier,
+// since 3-5-7 is all-odd and so lost for the mover.
+describe('fixedStartBoards', () => {
+  it('is won by the replier against optimal play', () => {
+    for (const startBoard of fixedStartBoards) {
+      expect(forcedWinnerIndex({ gameplay: { moves }, botStrategy: smartBotStrategy, startBoard }))
+        .toBe(1);
+    }
   });
 });

--- a/src/components/games/coins-in-3-piles/gameplay.spec.ts
+++ b/src/components/games/coins-in-3-piles/gameplay.spec.ts
@@ -1,4 +1,4 @@
-import { fixedStartBoards, moves, type Board, type TurnState } from './gameplay';
+import { startBoardOfCategoryA, moves, type Board, type TurnState } from './gameplay';
 import { smartBotStrategy } from './bot-strategy';
 import { forcedWinnerIndex, makeCtx } from 'test-utils';
 
@@ -92,15 +92,14 @@ describe('coins-in-3-piles move outcomes', () => {
   });
 });
 
-// The curated board of the "Fixed" variant. A competition hands out a board
-// like this one and lets the team pick a role, so what has to hold is not just
-// that the game ends but that a *named* role forces the win — here the replier,
-// since 3-5-7 is all-odd and so lost for the mover.
-describe('fixedStartBoards', () => {
+// A competition hands out a board like this one and lets the team pick a role,
+// so what has to hold is not just that the game ends but that a *named* role
+// forces the win — here the replier, since 3-5-7 is all-odd and so lost for the
+// mover.
+describe('startBoardOfCategoryA', () => {
   it('is won by the replier against optimal play', () => {
-    for (const startBoard of fixedStartBoards) {
-      expect(forcedWinnerIndex({ gameplay: { moves }, botStrategy: smartBotStrategy, startBoard }))
-        .toBe(1);
-    }
+    expect(forcedWinnerIndex({
+      gameplay: { moves }, botStrategy: smartBotStrategy, startBoard: startBoardOfCategoryA
+    })).toBe(1);
   });
 });

--- a/src/components/games/coins-in-3-piles/gameplay.ts
+++ b/src/components/games/coins-in-3-piles/gameplay.ts
@@ -1,4 +1,4 @@
-import { cloneDeep, isEqual, random, sample, sum } from 'lodash';
+import { cloneDeep, isEqual, random, sum } from 'lodash';
 import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
 export type Board = number[]
@@ -33,15 +33,14 @@ const generateLosingStartBoard = (): Board => {
 export const generateArbitraryStartBoard = (): Board =>
   random(0, 1) ? generateWinningStartBoard() : generateLosingStartBoard();
 
-// "Fixed" sub-game (the original "Change 15 coins"): 3×1, 5×2, 7×3.
-export const fixedStartBoards: Board[] = [[3, 5, 7]];
+// Category A's sub-game (the original "Change 15 coins"): 3×1, 5×2, 7×3.
+export const startBoardOfCategoryA: Board = [3, 5, 7];
 
-// Test variant covers both sub-games: a small arbitrary heap, or the fixed 3-5-7 setup.
+// Test variant covers both sub-games: a small arbitrary heap, or the 3-5-7 setup.
 export const generateTestStartBoard = (): Board =>
-  sample([
-    (): Board => [random(0, 2), random(0, 2), random(1, 3)],
-    (): Board => [...fixedStartBoards[0]]
-  ])!();
+  random(0, 1)
+    ? [random(0, 2), random(0, 2), random(1, 3)]
+    : [...startBoardOfCategoryA];
 
 export const moves = {
   removeCoin: {

--- a/src/components/games/coins-in-3-piles/gameplay.ts
+++ b/src/components/games/coins-in-3-piles/gameplay.ts
@@ -34,13 +34,13 @@ export const generateArbitraryStartBoard = (): Board =>
   random(0, 1) ? generateWinningStartBoard() : generateLosingStartBoard();
 
 // "Fixed" sub-game (the original "Change 15 coins"): 3×1, 5×2, 7×3.
-export const generateFixedStartBoard = (): Board => [3, 5, 7];
+export const fixedStartBoards: Board[] = [[3, 5, 7]];
 
 // Test variant covers both sub-games: a small arbitrary heap, or the fixed 3-5-7 setup.
 export const generateTestStartBoard = (): Board =>
   sample([
     (): Board => [random(0, 2), random(0, 2), random(1, 3)],
-    generateFixedStartBoard
+    (): Board => [...fixedStartBoards[0]]
   ])!();
 
 export const moves = {

--- a/src/components/games/stones-remove-one-not-twice-from-left/gameplay.spec.ts
+++ b/src/components/games/stones-remove-one-not-twice-from-left/gameplay.spec.ts
@@ -1,5 +1,5 @@
 import {
-  type Board, boardAfterRemoval, startBoards, testStartBoards, hasNoLegalMove,
+  type Board, boardAfterRemoval, fullStartBoards, testStartBoards, hasNoLegalMove,
   moves, openPiles
 } from './gameplay';
 import { isWinningForMover, smartBotStrategy } from './bot-strategy';
@@ -138,7 +138,7 @@ describe('end of game', () => {
 });
 
 describe.each([
-  ['startBoards', startBoards],
+  ['fullStartBoards', fullStartBoards],
   ['testStartBoards', testStartBoards]
 ] as const)('%s', (_name, boards) => {
   it('starts everyone unrestricted, with both piles stocked', () => {

--- a/src/components/games/stones-remove-one-not-twice-from-left/gameplay.spec.ts
+++ b/src/components/games/stones-remove-one-not-twice-from-left/gameplay.spec.ts
@@ -1,10 +1,9 @@
-import { times, uniqWith, isEqual } from 'lodash';
 import {
-  type Board, boardAfterRemoval, generateStartBoard, generateTestStartBoard, hasNoLegalMove,
+  type Board, boardAfterRemoval, startBoards, testStartBoards, hasNoLegalMove,
   moves, openPiles
 } from './gameplay';
-import { isWinningForMover } from './bot-strategy';
-import { makeCtx, moveValidator } from 'test-utils';
+import { isWinningForMover, smartBotStrategy } from './bot-strategy';
+import { forcedWinnerIndex, makeCtx, moveValidator } from 'test-utils';
 
 // Which pile is open depends on who is taking, so the mover goes into the ctx.
 const isRemovalAllowed = (board: Board, player: number, pileId: number): boolean =>
@@ -138,21 +137,10 @@ describe('end of game', () => {
   });
 });
 
-// Sampling until the whole list has come up also pins that every board in it is
-// reachable — a board never generated could not be judged below.
-const allStartBoards = (generate: () => Board): Board[] =>
-  uniqWith(times(400, generate), isEqual);
-
 describe.each([
-  ['generateStartBoard', generateStartBoard, 7],
-  ['generateTestStartBoard', generateTestStartBoard, 4]
-] as const)('%s', (_name, generate, expectedCount) => {
-  const boards = allStartBoards(generate);
-
-  it('offers the whole list', () => {
-    expect(boards).toHaveLength(expectedCount);
-  });
-
+  ['startBoards', startBoards],
+  ['testStartBoards', testStartBoards]
+] as const)('%s', (_name, boards) => {
   it('starts everyone unrestricted, with both piles stocked', () => {
     for (const startBoard of boards) {
       expect(startBoard.leftRestriction).toEqual([false, false]);
@@ -164,5 +152,18 @@ describe.each([
     const winnable = boards.filter(startBoard => isWinningForMover(startBoard, 0)).length;
     expect(winnable / boards.length).toBeGreaterThan(0.3);
     expect(winnable / boards.length).toBeLessThan(0.7);
+  });
+
+  // The balance check above trusts `isWinningForMover`. Playing each board out
+  // decides the same question the other way — through the real moves and the
+  // real bot — so a wrong predicate and a bot that fails to exploit it cannot
+  // agree their way past both.
+  it('is decisive, and by the role the predicate names', () => {
+    for (const startBoard of boards) {
+      const winner = forcedWinnerIndex({
+        gameplay: { moves }, botStrategy: smartBotStrategy, startBoard
+      });
+      expect(winner).toBe(isWinningForMover(startBoard, 0) ? 0 : 1);
+    }
   });
 });

--- a/src/components/games/stones-remove-one-not-twice-from-left/gameplay.ts
+++ b/src/components/games/stones-remove-one-not-twice-from-left/gameplay.ts
@@ -58,4 +58,4 @@ export const testStartBoards = fromPiles([[3, 4], [4, 3], [3, 3], [4, 4]]);
 
 // Curated so that either role can be the winning one — see gameplay.spec.ts,
 // which judges the whole list rather than a sample of it.
-export const startBoards = fromPiles([[11, 8], [9, 9], [9, 8], [9, 7], [5, 8], [8, 7], [6, 4]]);
+export const fullStartBoards = fromPiles([[11, 8], [9, 9], [9, 8], [9, 7], [5, 8], [8, 7], [6, 4]]);

--- a/src/components/games/stones-remove-one-not-twice-from-left/gameplay.ts
+++ b/src/components/games/stones-remove-one-not-twice-from-left/gameplay.ts
@@ -1,5 +1,4 @@
 import type { Ctx, MoveOutcome } from 'strategy-game-factory';
-import { sample } from 'lodash';
 
 export type Board = { piles: [number, number], leftRestriction: [boolean, boolean] }
 
@@ -52,23 +51,11 @@ export const moves = {
 
 export type Moves = typeof moves;
 
-export const generateTestStartBoard = (): Board => ({
-  piles: sample([[3, 4], [4, 3], [3, 3], [4, 4]]) as [number, number],
-  leftRestriction: [false, false]
-});
+const fromPiles = (pairs: [number, number][]): Board[] =>
+  pairs.map(piles => ({ piles, leftRestriction: [false, false] }));
 
-export const generateStartBoard = (): Board => {
-  const piles = sample([
-    [11, 8],
-    [9, 9],
-    [9, 8],
-    [9, 7],
-    [5, 8],
-    [8, 7],
-    [6, 4]
-  ]) as [number, number]
-  return {
-    piles,
-    leftRestriction: [false, false]
-  };
-}
+export const testStartBoards = fromPiles([[3, 4], [4, 3], [3, 3], [4, 4]]);
+
+// Curated so that either role can be the winning one — see gameplay.spec.ts,
+// which judges the whole list rather than a sample of it.
+export const startBoards = fromPiles([[11, 8], [9, 9], [9, 8], [9, 7], [5, 8], [8, 7], [6, 4]]);

--- a/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
+++ b/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
@@ -1,7 +1,7 @@
 import { strategyGameFactory, type BoardClientProps, GameBoard, useHoverPreview } from 'strategy-game-factory';
 import { range } from 'lodash';
 import { useTranslation } from 'language';
-import { startBoards, testStartBoards, moves, type Board } from './gameplay';
+import { fullStartBoards, testStartBoards, moves, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 const StonePile = ({ count, onClick, disabled, restricted, hovered, hoverProps }) => {
@@ -90,7 +90,7 @@ export const StonesRemoveOneNotTwiceFromLeft = strategyGameFactory({
     },
     {
       botStrategy: smartBotStrategy,
-      startBoards,
+      startBoards: fullStartBoards,
       label: { hu: 'Teljes', en: 'Full' },
       isDefault: true
     }

--- a/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
+++ b/src/components/games/stones-remove-one-not-twice-from-left/stones-remove-one-not-twice-from-left.tsx
@@ -1,7 +1,7 @@
 import { strategyGameFactory, type BoardClientProps, GameBoard, useHoverPreview } from 'strategy-game-factory';
 import { range } from 'lodash';
 import { useTranslation } from 'language';
-import { generateStartBoard, generateTestStartBoard, moves, type Board } from './gameplay';
+import { startBoards, testStartBoards, moves, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 const StonePile = ({ count, onClick, disabled, restricted, hovered, hoverProps }) => {
@@ -85,12 +85,12 @@ export const StonesRemoveOneNotTwiceFromLeft = strategyGameFactory({
   variants: [
     {
       botStrategy: randomBotStrategy,
-      generateStartBoard: generateTestStartBoard,
+      startBoards: testStartBoards,
       label: { hu: 'Teszt', en: 'Test' }
     },
     {
       botStrategy: smartBotStrategy,
-      generateStartBoard,
+      startBoards,
       label: { hu: 'Teljes', en: 'Full' },
       isDefault: true
     }

--- a/src/components/games/ten-coins/ten-coins.tsx
+++ b/src/components/games/ten-coins/ten-coins.tsx
@@ -177,11 +177,13 @@ export const TenCoins = strategyGameFactory({
   gameplay: { moves },
   variants: [
     {
+      id: 'test',
       botStrategy: randomBotStrategy,
       generateStartBoard: generateTestStartBoard,
       label: { hu: 'Teszt', en: 'Test' }
     },
     {
+      id: '4-values',
       botStrategy: smartBotStrategy,
       generateStartBoard: generateStartBoardC,
       rule: ruleFor(4),
@@ -189,6 +191,7 @@ export const TenCoins = strategyGameFactory({
       isDefault: true
     },
     {
+      id: '5-values',
       botStrategy: smartBotStrategy,
       generateStartBoard: generateStartBoardD,
       rule: ruleFor(5),

--- a/src/components/strategy-game-factory/helpers/resolve-variants.spec.ts
+++ b/src/components/strategy-game-factory/helpers/resolve-variants.spec.ts
@@ -24,9 +24,34 @@ describe('resolveVariants', () => {
       .toThrow('exactly one variant must have isDefault: true');
   });
 
-  it('throws when the default variant has no generateStartBoard', () => {
+  it('throws when the default variant has neither generateStartBoard nor startBoards', () => {
     expect(() => resolveVariants([{ botStrategy: () => [] }]))
-      .toThrow('the default variant must define generateStartBoard');
+      .toThrow('the default variant must define generateStartBoard or startBoards');
+  });
+
+  it('throws when a variant defines both generateStartBoard and startBoards', () => {
+    expect(() => resolveVariants([makeVariant({ startBoards: [['a']] })]))
+      .toThrow('a variant defines generateStartBoard or startBoards, not both');
+  });
+
+  it('throws when two variants share an id', () => {
+    const variants = [
+      makeVariant({ id: 'full', isDefault: true }),
+      makeVariant({ id: 'full' })
+    ];
+    expect(() => resolveVariants(variants)).toThrow('variant ids must be unique');
+  });
+
+  // Without an id a variant is addressed by its index, so an id that reads as
+  // another variant's index would make `?variant=` ambiguous.
+  it('throws when an id shadows another variant\'s index', () => {
+    const variants = [makeVariant({ isDefault: true }), makeVariant({ id: '0' })];
+    expect(() => resolveVariants(variants)).toThrow('variant ids must be unique');
+  });
+
+  it('throws when startBoards is empty', () => {
+    expect(() => resolveVariants([{ botStrategy: () => [], startBoards: [] }]))
+      .toThrow('startBoards must be a non-empty array');
   });
 
   it('uses the single variant as default without requiring isDefault', () => {
@@ -79,5 +104,49 @@ describe('resolveVariants', () => {
     const variants = [makeVariant({ botStrategy: undefined })];
     const { resolvedVariants } = resolveVariants(variants);
     expect(resolvedVariants[0].botStrategy).toBeUndefined();
+  });
+
+  describe('startBoards', () => {
+    const curated: Board[] = [['a'], ['b'], ['c']];
+
+    it('derives a generator that only ever returns a curated board', () => {
+      const { resolvedVariants } = resolveVariants([{ botStrategy: () => [], startBoards: curated }]);
+      for (let i = 0; i < 30; i++) {
+        expect(curated).toContainEqual(resolvedVariants[0].generateStartBoard!());
+      }
+    });
+
+    it('reaches every curated board', () => {
+      const { defaultVariant } = resolveVariants([{ botStrategy: () => [], startBoards: curated }]);
+      const seen = new Set(Array.from({ length: 100 }, () => defaultVariant.generateStartBoard!()[0]));
+      expect([...seen].sort()).toEqual(['a', 'b', 'c']);
+    });
+
+    // A generated start board has always been freshly owned by its match; a
+    // curated one has to be too, or a single in-place write would outlive the
+    // game that made it.
+    it('hands out a copy, never the curated board itself', () => {
+      const { defaultVariant } = resolveVariants([{ botStrategy: () => [], startBoards: curated }]);
+      const board = defaultVariant.generateStartBoard!();
+      board.push('mutated');
+      expect(curated.flat()).toEqual(['a', 'b', 'c']);
+    });
+
+    // `Game.variants` is the resolved array, and the catalog sweep resolves it
+    // again — so resolving twice has to mean the same as resolving once.
+    it('survives being resolved a second time', () => {
+      const { resolvedVariants } = resolveVariants([{ botStrategy: () => [], startBoards: curated }]);
+      expect(() => resolveVariants(resolvedVariants)).not.toThrow();
+      const { defaultVariant } = resolveVariants(resolvedVariants);
+      expect(curated).toContainEqual(defaultVariant.generateStartBoard!());
+    });
+
+    it('satisfies the default variant requirement on its own', () => {
+      const variants = [
+        makeVariant(),
+        { isDefault: true, botStrategy: () => [], startBoards: curated }
+      ];
+      expect(() => resolveVariants(variants)).not.toThrow();
+    });
   });
 });

--- a/src/components/strategy-game-factory/helpers/resolve-variants.ts
+++ b/src/components/strategy-game-factory/helpers/resolve-variants.ts
@@ -1,4 +1,27 @@
+import { cloneDeep, sample } from 'lodash';
 import type { VariantInput } from '../types';
+
+// A variant states its start position either as a generator or as a curated
+// list, and everything downstream only ever sees the generator — `startBoards`
+// is the declarative form of `generateStartBoard`, not a second channel.
+//
+// The pick is cloned so that a generator built from a list keeps the guarantee
+// every game is already written against: a start board is freshly owned by the
+// match it starts. Nothing mutates one today, but the list is module-scope data
+// shared by every match, so without the clone one in-place write — which
+// nothing here can detect — would silently corrupt every later game started
+// from that entry, and hand one object to every team of a competition.
+const startBoardGenerator = <TBoard,>({ generateStartBoard, startBoards }: VariantInput<TBoard>) => {
+  if (generateStartBoard) return generateStartBoard;
+  if (!startBoards) return undefined;
+  return () => cloneDeep(sample(startBoards)!);
+};
+
+// How a variant is named in the URL. The index fallback keeps every variant
+// addressable without making `id` a field each game has to fill in; what it
+// cannot survive is that game's variants being reordered.
+export const variantKey = <TBoard,>({ id }: VariantInput<TBoard>, index: number): string =>
+  id ?? String(index);
 
 export const resolveVariants = <TBoard,>(variants: VariantInput<TBoard>[]) => {
   if (!variants || variants.length === 0) {
@@ -7,13 +30,37 @@ export const resolveVariants = <TBoard,>(variants: VariantInput<TBoard>[]) => {
   if (variants.length > 1 && variants.filter(v => v.isDefault).length !== 1) {
     throw new Error('strategyGameFactory: exactly one variant must have isDefault: true');
   }
-  const defaultVariantIndex = Math.max(variants.findIndex(v => v.isDefault), 0);
-  const defaultVariant = variants[defaultVariantIndex];
-  if (!defaultVariant.generateStartBoard) {
-    throw new Error('strategyGameFactory: the default variant must define generateStartBoard');
+  // Checked on the keys rather than the ids, so a declared id that shadows
+  // another variant's index fallback is caught too.
+  const keys = variants.map((variant, index) => variantKey(variant, index));
+  if (new Set(keys).size !== keys.length) {
+    throw new Error('strategyGameFactory: variant ids must be unique');
   }
-  const fallbackBotStrategy = defaultVariant.botStrategy
+  variants.forEach(({ generateStartBoard, startBoards }) => {
+    if (generateStartBoard && startBoards) {
+      throw new Error('strategyGameFactory: a variant defines generateStartBoard or startBoards, not both');
+    }
+    if (startBoards && startBoards.length === 0) {
+      throw new Error('strategyGameFactory: startBoards must be a non-empty array');
+    }
+  });
+  const defaultVariantIndex = Math.max(variants.findIndex(v => v.isDefault), 0);
+  const startBoardGenerators = variants.map(variant => startBoardGenerator(variant));
+  if (!startBoardGenerators[defaultVariantIndex]) {
+    throw new Error('strategyGameFactory: the default variant must define generateStartBoard or startBoards');
+  }
+  const fallbackBotStrategy = variants[defaultVariantIndex].botStrategy
     ?? variants.find(v => v.botStrategy)?.botStrategy;
-  const resolvedVariants = variants.map(v => ({ ...v, botStrategy: v.botStrategy ?? fallbackBotStrategy }));
-  return { defaultVariantIndex, defaultVariant, resolvedVariants };
+  // `startBoards` is dropped rather than carried through: resolving normalises
+  // every variant to one start-board channel, and the resolved array is what
+  // `Game.variants` exposes — which `plays-to-an-end.spec.ts` resolves a second
+  // time, so resolution has to be a no-op on its own output. The curated list
+  // stays readable where a server would take it from anyway: the game's own
+  // React-free module.
+  const resolvedVariants = variants.map(({ startBoards: _startBoards, ...variant }, index) => ({
+    ...variant,
+    botStrategy: variant.botStrategy ?? fallbackBotStrategy,
+    generateStartBoard: startBoardGenerators[index]
+  }));
+  return { defaultVariantIndex, defaultVariant: resolvedVariants[defaultVariantIndex], resolvedVariants };
 };

--- a/src/components/strategy-game-factory/hooks/use-game-stats.spec.ts
+++ b/src/components/strategy-game-factory/hooks/use-game-stats.spec.ts
@@ -2,11 +2,11 @@
 import { renderHook, act } from '@testing-library/react';
 import { useGameStats } from './use-game-stats';
 
-const KEY = 'stats_tictactoe_0';
+const KEY = 'stats_tictactoe_full';
 
-const render = (gameId = 'tictactoe', variantIndex = 0) =>
-  renderHook(({ id, index }) => useGameStats(id, index), {
-    initialProps: { id: gameId, index: variantIndex }
+const render = (gameId = 'tictactoe', variantKey = 'full') =>
+  renderHook(({ id, key }) => useGameStats(id, key), {
+    initialProps: { id: gameId, key: variantKey }
   });
 
 beforeEach(() => localStorage.clear());
@@ -46,26 +46,38 @@ describe('useGameStats', () => {
   // The counters are per game *and* per variant, so switching difficulty has
   // to swap to that variant's tally rather than carry the old one over.
   it('swaps to the other tally when the variant changes, and keeps them apart', () => {
-    localStorage.setItem('stats_tictactoe_0', JSON.stringify({ win: 5, loss: 0 }));
-    localStorage.setItem('stats_tictactoe_1', JSON.stringify({ win: 1, loss: 9 }));
+    localStorage.setItem('stats_tictactoe_full', JSON.stringify({ win: 5, loss: 0 }));
+    localStorage.setItem('stats_tictactoe_test', JSON.stringify({ win: 1, loss: 9 }));
 
     const { result, rerender } = render();
     expect(result.current.stats).toEqual({ win: 5, loss: 0 });
 
-    rerender({ id: 'tictactoe', index: 1 });
+    rerender({ id: 'tictactoe', key: 'test' });
     expect(result.current.stats).toEqual({ win: 1, loss: 9 });
 
     act(() => result.current.recordResult('win'));
-    expect(JSON.parse(localStorage.getItem('stats_tictactoe_1')!)).toEqual({ win: 2, loss: 9 });
+    expect(JSON.parse(localStorage.getItem('stats_tictactoe_test')!)).toEqual({ win: 2, loss: 9 });
     // the other variant's tally is untouched
-    expect(JSON.parse(localStorage.getItem('stats_tictactoe_0')!)).toEqual({ win: 5, loss: 0 });
+    expect(JSON.parse(localStorage.getItem('stats_tictactoe_full')!)).toEqual({ win: 5, loss: 0 });
+  });
+
+  // A game that declares no ids keys its tallies by index, as a string.
+  it('keeps index-keyed tallies apart just the same', () => {
+    localStorage.setItem('stats_tictactoe_0', JSON.stringify({ win: 5, loss: 0 }));
+    localStorage.setItem('stats_tictactoe_1', JSON.stringify({ win: 1, loss: 9 }));
+
+    const { result, rerender } = render('tictactoe', '0');
+    expect(result.current.stats).toEqual({ win: 5, loss: 0 });
+
+    rerender({ id: 'tictactoe', key: '1' });
+    expect(result.current.stats).toEqual({ win: 1, loss: 9 });
   });
 
   it('swaps tallies when the game changes too', () => {
-    localStorage.setItem('stats_chess-ducks_0', JSON.stringify({ win: 7, loss: 7 }));
+    localStorage.setItem('stats_chess-ducks_full', JSON.stringify({ win: 7, loss: 7 }));
 
     const { result, rerender } = render();
-    rerender({ id: 'chess-ducks', index: 0 });
+    rerender({ id: 'chess-ducks', key: 'full' });
 
     expect(result.current.stats).toEqual({ win: 7, loss: 7 });
   });

--- a/src/components/strategy-game-factory/hooks/use-game-stats.ts
+++ b/src/components/strategy-game-factory/hooks/use-game-stats.ts
@@ -12,8 +12,11 @@ const readStats = (key: string): Stats => {
   }
 };
 
-export const useGameStats = (gameId: string, variantIndex: number) => {
-  const storageKey = `stats_${gameId}_${variantIndex}`;
+// Keyed by the variant's key, the same one the URL and the analytics event use
+// — an index would silently hand a variant the tally of whichever one used to
+// sit at its position the next time a game's variants are reordered.
+export const useGameStats = (gameId: string, variantKey: string) => {
+  const storageKey = `stats_${gameId}_${variantKey}`;
 
   // Stamped with the key it was read for, the same shape as
   // useMoveScopedState: switching variant reads the new key during render, so

--- a/src/components/strategy-game-factory/index.ts
+++ b/src/components/strategy-game-factory/index.ts
@@ -6,7 +6,7 @@ export type {
   StrategyArgs, BotStrategy, BotMove, BoardClientProps,
   Variant, VariantInput
 } from './types';
-export { resolveVariants } from './helpers/resolve-variants';
+export { resolveVariants, variantKey } from './helpers/resolve-variants';
 export { runMatch } from './engine/run-match';
 export type { MatchMove, MatchResult } from './engine/run-match';
 export { GameBoard } from './game-parts/game-board';

--- a/src/components/strategy-game-factory/spec-helpers.tsx
+++ b/src/components/strategy-game-factory/spec-helpers.tsx
@@ -6,7 +6,7 @@
 // board that is just a list of strings, a one-move gameplay, and a BoardClient
 // with a single button.
 import { render, fireEvent } from '@testing-library/react';
-import { MemoryRouter, useLocation } from 'react-router';
+import { Link, MemoryRouter, useLocation } from 'react-router';
 import { strategyGameFactory, type StrategyGameConfig } from './strategy-game-factory';
 import type { BoardClientProps, BotStrategy, Gameplay, VariantInput } from './types';
 
@@ -55,15 +55,22 @@ export const ctxAwareConfig = (botStrategy: BotStrategy<Board> = () => []) =>
   makeConfig({ BoardClient: CtxAwareBoardClient, botStrategy });
 
 // The factory both reads and writes `?variant=`, so the harness shows the URL
-// next to the game — the same shape language-context.spec.tsx uses.
-const SearchProbe = () => <span data-testid="search">{useLocation().search}</span>;
+// next to the game — the same shape language-context.spec.tsx uses. The links
+// navigate within the same route, which is what a shared variant link does and
+// the one case that remounts nothing.
+const UrlProbe = () => <>
+  <span data-testid="search">{useLocation().search}</span>
+  <Link data-testid="go-to-gamma" to="/?variant=2">gamma</Link>
+  <Link data-testid="go-to-no-variant" to="/">no variant</Link>
+  <Link data-testid="go-to-nonsense" to="/?variant=nonsense">nonsense</Link>
+</>;
 
 export const renderGame = (config: StrategyGameConfig<Board>, entry = '/') => {
   const Game = strategyGameFactory(config);
   return render(
     <MemoryRouter initialEntries={[entry]}>
       <Game />
-      <SearchProbe />
+      <UrlProbe />
     </MemoryRouter>
   );
 };

--- a/src/components/strategy-game-factory/spec-helpers.tsx
+++ b/src/components/strategy-game-factory/spec-helpers.tsx
@@ -6,7 +6,7 @@
 // board that is just a list of strings, a one-move gameplay, and a BoardClient
 // with a single button.
 import { render, fireEvent } from '@testing-library/react';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter, useLocation } from 'react-router';
 import { strategyGameFactory, type StrategyGameConfig } from './strategy-game-factory';
 import type { BoardClientProps, BotStrategy, Gameplay, VariantInput } from './types';
 
@@ -54,9 +54,18 @@ export const minimalConfig = (gameplay: Gameplay<Board>) => makeConfig({ gamepla
 export const ctxAwareConfig = (botStrategy: BotStrategy<Board> = () => []) =>
   makeConfig({ BoardClient: CtxAwareBoardClient, botStrategy });
 
-export const renderGame = (config: StrategyGameConfig<Board>) => {
+// The factory both reads and writes `?variant=`, so the harness shows the URL
+// next to the game — the same shape language-context.spec.tsx uses.
+const SearchProbe = () => <span data-testid="search">{useLocation().search}</span>;
+
+export const renderGame = (config: StrategyGameConfig<Board>, entry = '/') => {
   const Game = strategyGameFactory(config);
-  return render(<MemoryRouter><Game /></MemoryRouter>);
+  return render(
+    <MemoryRouter initialEntries={[entry]}>
+      <Game />
+      <SearchProbe />
+    </MemoryRouter>
+  );
 };
 
 // Headless UI's PlayerNameSetup is slow on its very first render, enough to

--- a/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
@@ -239,14 +239,40 @@ describe('variant in the URL', () => {
     expect(search(view)).toBe('?lang=en&variant=beta');
   });
 
-  // A variant switch restarts the game, so the param is read once rather than
-  // synced: a later navigation must not be able to wipe a game in progress.
-  it('does not re-read the param after mount', () => {
+  it('writes the param on a variant switch made after another one', () => {
     const view = renderGame(identifiedVariants(), '/?variant=beta');
     fireEvent.click(variantRadio(view, 'Gamma'));
 
     expect(variantRadio(view, 'Gamma').checked).toBe(true);
     expect(search(view)).toBe('?variant=2');
+  });
+
+  // The reason the param is followed rather than read once: a same-route hash
+  // navigation remounts nothing, so a link to a variant of the game already
+  // open would otherwise change the URL and leave the board alone.
+  it('follows the param when it changes without a remount', () => {
+    const view = renderGame(identifiedVariants(), '/?variant=beta');
+    expect(variantRadio(view, 'Beta').checked).toBe(true);
+
+    fireEvent.click(view.getByTestId('go-to-gamma'));
+
+    expect(variantRadio(view, 'Gamma').checked).toBe(true);
+  });
+
+  it('goes back to the default variant when the param is dropped', () => {
+    const view = renderGame(identifiedVariants(), '/?variant=beta');
+
+    fireEvent.click(view.getByTestId('go-to-no-variant'));
+
+    expect(variantRadio(view, 'Alpha').checked).toBe(true);
+  });
+
+  it('stays put when the param names no variant of this game', () => {
+    const view = renderGame(identifiedVariants(), '/?variant=beta');
+
+    fireEvent.click(view.getByTestId('go-to-nonsense'));
+
+    expect(variantRadio(view, 'Beta').checked).toBe(true);
   });
 });
 

--- a/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
@@ -401,6 +401,19 @@ describe('win/loss tracking', () => {
     expect(localStorage.getItem('stats__0')).toBeNull();
   });
 
+  // Keyed by the variant's key, so a game that declares ids keeps its tallies
+  // where reordering its variants cannot shuffle them.
+  it('keys the tally by the variant id when there is one', () => {
+    const variants = [
+      { id: 'alpha', isDefault: true, botStrategy: () => [], generateStartBoard: (): Board => [] }
+    ];
+    const { getByTestId } = renderGame(gameEndingConfig(variants));
+    fireEvent.click(getByTestId('role-btn-0'));
+    fireEvent.click(getByTestId('end-win-btn'));
+
+    expect(JSON.parse(localStorage.getItem('stats__alpha')!)).toEqual({ win: 1, loss: 0 });
+  });
+
   it('accumulates results across multiple games', () => {
     const { getByTestId, unmount } = renderGame(gameEndingConfig());
     fireEvent.click(getByTestId('role-btn-0'));

--- a/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
@@ -185,6 +185,71 @@ describe('variant availability by mode', () => {
   });
 });
 
+describe('variant in the URL', () => {
+  const startBoard = (): Board => ['initial'];
+  const named = (name: string) => ({ hu: name, en: name });
+
+  // Alpha is the default and carries no id, so it is addressed by its index;
+  // Beta names one, the way a variant worth a durable link does.
+  const identifiedVariants = () => makeConfig({
+    variants: [
+      { label: named('Alpha'), isDefault: true, botStrategy: () => [], generateStartBoard: startBoard },
+      { id: 'beta', label: named('Beta'), botStrategy: () => [], generateStartBoard: startBoard },
+      { label: named('Gamma'), botStrategy: () => [], generateStartBoard: startBoard }
+    ]
+  });
+
+  const variantRadio = (view: ReturnType<typeof renderGame>, label: string) =>
+    view.getByLabelText(label) as HTMLInputElement;
+  const search = (view: ReturnType<typeof renderGame>) => view.getByTestId('search').textContent;
+
+  it('starts on the variant the URL names by id', () => {
+    const view = renderGame(identifiedVariants(), '/?variant=beta');
+    expect(variantRadio(view, 'Beta').checked).toBe(true);
+  });
+
+  it('starts on the variant the URL names by index when it declares no id', () => {
+    const view = renderGame(identifiedVariants(), '/?variant=2');
+    expect(variantRadio(view, 'Gamma').checked).toBe(true);
+  });
+
+  it('falls back to the default variant when the URL names an unknown one', () => {
+    const view = renderGame(identifiedVariants(), '/?variant=nonsense');
+    expect(variantRadio(view, 'Alpha').checked).toBe(true);
+  });
+
+  it('writes the chosen variant to the URL', () => {
+    const view = renderGame(identifiedVariants());
+    fireEvent.click(variantRadio(view, 'Beta'));
+
+    expect(search(view)).toBe('?variant=beta');
+  });
+
+  it('drops the param when the default variant is chosen back, as ?lang= does for hu', () => {
+    const view = renderGame(identifiedVariants(), '/?variant=beta');
+    fireEvent.click(variantRadio(view, 'Alpha'));
+
+    expect(search(view)).toBe('');
+  });
+
+  it('leaves other params alone', () => {
+    const view = renderGame(identifiedVariants(), '/?lang=en');
+    fireEvent.click(variantRadio(view, 'Beta'));
+
+    expect(search(view)).toBe('?lang=en&variant=beta');
+  });
+
+  // A variant switch restarts the game, so the param is read once rather than
+  // synced: a later navigation must not be able to wipe a game in progress.
+  it('does not re-read the param after mount', () => {
+    const view = renderGame(identifiedVariants(), '/?variant=beta');
+    fireEvent.click(variantRadio(view, 'Gamma'));
+
+    expect(variantRadio(view, 'Gamma').checked).toBe(true);
+    expect(search(view)).toBe('?variant=2');
+  });
+});
+
 describe('strategyGameFactory endOfTurnMove', () => {
   beforeAll(() => { vi.useFakeTimers(); });
   afterAll(() => { vi.useRealTimers(); });

--- a/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
@@ -5,7 +5,7 @@ import {
   makeConfig, minimalConfig, ctxAwareConfig, renderGame, warmUpPlayerNameSetup,
   MinimalBoardClient, CtxAwareBoardClient, defaultGameplay, type Board
 } from './spec-helpers';
-import type { BoardClientProps, BotMove, BotStrategy, Ctx, Gameplay, StrategyArgs } from './types';
+import type { BoardClientProps, BotMove, BotStrategy, Ctx, Gameplay, StrategyArgs, VariantInput } from './types';
 
 beforeAll(warmUpPlayerNameSetup);
 
@@ -350,7 +350,8 @@ describe('strategyGameFactory endOfTurnMove', () => {
   });
 });
 
-const gameEndingConfig = () => makeConfig({
+const gameEndingConfig = (variants?: VariantInput<Board>[]) => makeConfig({
+  variants,
   BoardClient: ({ board, moves }: BoardClientProps<Board>) => (
     <>
       <button data-testid="end-win-btn" onClick={() => moves.endWin(board)}>win</button>
@@ -506,6 +507,27 @@ describe('umami game-finished event', () => {
     expect(lastEvent()[0]).toBe('game-finished');
     expect(lastEvent()[1]).toMatchObject({ mode: 'vsHuman' });
     expect(lastEvent()[1]).not.toHaveProperty('result');
+  });
+
+  // Reported by the same key the URL uses, so a dashboard row and a shared
+  // link name a variant the same way.
+  const identifiedVariants: VariantInput<Board>[] = [
+    { id: 'alpha', isDefault: true, botStrategy: () => [], generateStartBoard: (): Board => [] },
+    { label: { hu: 'Beta', en: 'Beta' }, botStrategy: () => [], generateStartBoard: (): Board => [] }
+  ];
+
+  it('reports the variant by its id', () => {
+    const { getByTestId } = renderGame(gameEndingConfig(identifiedVariants));
+    fireEvent.click(getByTestId('role-btn-0'));
+    fireEvent.click(getByTestId('end-win-btn'));
+    expect(lastEvent()[1]).toMatchObject({ variant: 'alpha' });
+  });
+
+  it('reports the index for a variant that declares no id', () => {
+    const { getByTestId } = renderGame(gameEndingConfig(identifiedVariants), '/?variant=1');
+    fireEvent.click(getByTestId('role-btn-0'));
+    fireEvent.click(getByTestId('end-win-btn'));
+    expect(lastEvent()[1]).toMatchObject({ variant: '1' });
   });
 });
 

--- a/src/components/strategy-game-factory/strategy-game-factory.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.tsx
@@ -106,7 +106,7 @@ export const strategyGameFactory = <TBoard, TTurnState = unknown>({
     const isHumanVsHumanGame = mode === 'vsHuman';
 
     const gameId = useLocation().pathname.split('/').pop()!;
-    const { stats, recordResult, resetStats } = useGameStats(gameId, selectedVariantIndex);
+    const { stats, recordResult, resetStats } = useGameStats(gameId, variantKeys[selectedVariantIndex]);
 
     useEffect(() => {
       if (!isHumanVsHumanGame && phase === 'play' && currentPlayer === (1 - chosenRoleIndex!)) {

--- a/src/components/strategy-game-factory/strategy-game-factory.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.tsx
@@ -146,7 +146,10 @@ export const strategyGameFactory = <TBoard, TTurnState = unknown>({
       trackEvent('game-finished', {
         game: gameId,
         mode: s.mode,
-        variant: selectedVariantIndex,
+        // The same key the URL uses, so a variant reads the same in a dashboard
+        // as in a link. Games that declare no id still report their index, and
+        // for those the value only means anything as long as the order holds.
+        variant: variantKeys[selectedVariantIndex],
         ...(s.mode === 'vsHuman' ? {} : { result: resolvedWinner === s.chosenRoleIndex ? 'win' : 'loss' })
       });
     };

--- a/src/components/strategy-game-factory/strategy-game-factory.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.tsx
@@ -58,12 +58,15 @@ export const strategyGameFactory = <TBoard, TTurnState = unknown>({
   const Game = () => {
     const { t } = useTranslation();
     const [searchParams, setSearchParams] = useSearchParams();
-    // Read once, on mount. Unlike `?lang=`, this is not kept in sync with later
-    // param changes: selecting a variant restarts the game, so a back/forward
-    // navigation must not be able to throw away a game in progress.
+    // The variant the URL asks for, or the default — which the param's absence
+    // means, the way it means `hu` for `?lang=`. `-1` is a param naming no
+    // variant of this game, which is ignored rather than obeyed.
+    const requestedVariantIndex = (params: URLSearchParams) => {
+      const requested = params.get('variant');
+      return requested === null ? defaultVariantIndex : variantKeys.indexOf(requested);
+    };
     const [selectedVariantIndex, setSelectedVariantIndex] = useState(() => {
-      const requested = searchParams.get('variant');
-      const index = requested === null ? -1 : variantKeys.indexOf(requested);
+      const index = requestedVariantIndex(searchParams);
       return index === -1 ? defaultVariantIndex : index;
     });
     const activeVariant = resolvedVariants[selectedVariantIndex] ?? defaultVariant;
@@ -204,6 +207,28 @@ export const strategyGameFactory = <TBoard, TTurnState = unknown>({
     const setDifficulty = (index: number) => {
       resetGameState({ newVariantIndex: index });
     };
+
+    // A shared `?variant=` link has to work even when it points at the game
+    // already open — a same-route hash navigation remounts nothing, so without
+    // this the URL would change and the board would not. Following it restarts
+    // the game, which is what choosing a variant means everywhere else.
+    //
+    // Guarded on the index rather than run unconditionally: `resetGameState`
+    // writes the param itself, so an unguarded effect would re-enter. An index
+    // of -1 — a param naming no variant of this game — is left alone.
+    //
+    // Deriving this during render is not an option: it has to *restart the
+    // game*, which is an event, not a projection of the URL. `searchParams`
+    // alone in the deps for the same reason the language provider does it —
+    // re-running when the selection changes would fight the write path.
+    /* eslint-disable react-hooks/exhaustive-deps */
+    useEffect(() => {
+      const index = requestedVariantIndex(searchParams);
+      if (index !== -1 && index !== selectedVariantIndex) {
+        resetGameState({ newVariantIndex: index });
+      }
+    }, [searchParams]);
+    /* eslint-enable react-hooks/exhaustive-deps */
 
     const getVariantsForMode = (m: Mode): DisplayVariant[] => {
       const humanVsHuman = m === 'vsHuman';

--- a/src/components/strategy-game-factory/strategy-game-factory.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.tsx
@@ -6,14 +6,14 @@ import { GameSidebar } from './game-parts/game-sidebar/game-sidebar';
 import { GameEndDialog } from './game-parts/game-end-dialog';
 import { mapValues, isEqual } from 'lodash';
 import { useTranslation, type TranslatableNode, type I18nString } from 'language';
-import { useLocation } from 'react-router';
+import { useLocation, useSearchParams } from 'react-router';
 import { useGameStats } from './hooks/use-game-stats';
 import { trackEvent } from '../../tracking';
 import type {
   Mode, Ctx, MoveOutcome, Gameplay, GameMoves, ClientGameMoves, BotStrategy, BotMove,
   BoardClientProps, StrategyArgs, Variant as DisplayVariant, VariantInput
 } from './types';
-import { resolveVariants } from './helpers/resolve-variants';
+import { resolveVariants, variantKey } from './helpers/resolve-variants';
 import { createGameStore, createInitialCoreState } from './engine/store';
 import { buildCtx } from './engine/build-ctx';
 import { asBotMoves, isBotTurnUnfinished, unknownMoveMessage } from './engine/bot-turn';
@@ -53,10 +53,19 @@ export const strategyGameFactory = <TBoard, TTurnState = unknown>({
   const { rule, roleLabels, getPlayerStepDescription } = presentation;
   const { moves, endOfTurnMove } = gameplay;
   const { defaultVariantIndex, defaultVariant, resolvedVariants } = resolveVariants(variants);
+  const variantKeys = resolvedVariants.map((variant, index) => variantKey(variant, index));
 
   const Game = () => {
     const { t } = useTranslation();
-    const [selectedVariantIndex, setSelectedVariantIndex] = useState(defaultVariantIndex);
+    const [searchParams, setSearchParams] = useSearchParams();
+    // Read once, on mount. Unlike `?lang=`, this is not kept in sync with later
+    // param changes: selecting a variant restarts the game, so a back/forward
+    // navigation must not be able to throw away a game in progress.
+    const [selectedVariantIndex, setSelectedVariantIndex] = useState(() => {
+      const requested = searchParams.get('variant');
+      const index = requested === null ? -1 : variantKeys.indexOf(requested);
+      return index === -1 ? defaultVariantIndex : index;
+    });
     const activeVariant = resolvedVariants[selectedVariantIndex] ?? defaultVariant;
     const defaultGenerateStartBoard = defaultVariant.generateStartBoard!;
     const activeGenerateStartBoard = activeVariant.generateStartBoard ?? defaultGenerateStartBoard;
@@ -179,6 +188,14 @@ export const strategyGameFactory = <TBoard, TTurnState = unknown>({
         boardGenerator = defaultGenerateStartBoard;
       }
       setSelectedVariantIndex(finalVariantIndex);
+      // The default variant is the absence of the param, the way `hu` is for
+      // `?lang=`, so a shared link carries a variant only when it says something.
+      setSearchParams(prev => {
+        const next = new URLSearchParams(prev);
+        if (finalVariantIndex === defaultVariantIndex) next.delete('variant');
+        else next.set('variant', variantKeys[finalVariantIndex]);
+        return next;
+      }, { replace: true });
       store.setState(createInitialCoreState(boardGenerator(), newMode));
       setIsGameEndDialogOpen(false);
       setGameUuid(crypto.randomUUID());

--- a/src/components/strategy-game-factory/types.ts
+++ b/src/components/strategy-game-factory/types.ts
@@ -139,9 +139,18 @@ export interface Variant {
 }
 
 export interface VariantInput<TBoard> {
+  // Stable slug this variant is addressable by in the URL (`?variant=3-5-7`).
+  // Optional: a variant without one is addressed by its index, which is enough
+  // for a link that need not outlive a reordering. Declare it where a durable
+  // link matters — the variants that are really separate games.
+  id?: string
   label?: I18nString
   isDefault?: boolean
   generateStartBoard?: () => TBoard
+  // A curated list of start boards, in place of generating one: the variant
+  // plays a random entry. Its order is part of the contract — a competition
+  // hands out `startBoards[attemptIndex]`, so append rather than reorder.
+  startBoards?: TBoard[]
   botStrategy?: BotStrategy<TBoard>
   notAlwaysOptimal?: boolean
   // Optional per-variant rule text. Falls back to `presentation.rule` when

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,4 +1,7 @@
-import type { BotMove, BotStrategy, Ctx, MoveDefinition } from './components/strategy-game-factory';
+import {
+  runMatch,
+  type BotMove, type BotStrategy, type Ctx, type Gameplay, type MoveDefinition
+} from './components/strategy-game-factory';
 import { asBotMoves } from './components/strategy-game-factory/engine/bot-turn';
 
 // Mock `ctx` for testing move functions and bot strategies. A game that pins
@@ -47,4 +50,38 @@ export const playBotMove = <TBoard, TTurnState = unknown>(
 ): TBoard => {
   const { move, args = [] } = botNextMove(strategy({ board, ctx }));
   return moves[move]!.apply(board, { ctx }, ...args).nextBoard;
+};
+
+// Which role can force the win from `startBoard`, read off the game's own
+// optimal bot playing both sides. A curated start board has to be *decisive* —
+// one role wins against best play — which is what makes choosing a role a real
+// decision rather than a coin flip, so this is the assertion a `startBoards`
+// list is worth committing behind.
+//
+// Bots shuffle among equally-optimal moves, so one playout samples one line;
+// several disagreeing means the board is not decisive, or the bot it was
+// verified against is not optimal. Either way the list is not what it claims,
+// so this throws rather than returning a winner nobody can trust.
+export const forcedWinnerIndex = <TBoard, TTurnState = unknown>({
+  gameplay,
+  botStrategy,
+  startBoard,
+  playouts = 5
+}: {
+  gameplay: Gameplay<TBoard, TTurnState>
+  botStrategy: BotStrategy<TBoard>
+  startBoard: TBoard
+  playouts?: number
+}): number => {
+  const winners = new Set(Array.from({ length: playouts }, () => runMatch({
+    gameplay,
+    strategies: [botStrategy, botStrategy],
+    startBoard
+  }).winnerIndex));
+  if (winners.size !== 1) {
+    throw new Error(`forcedWinnerIndex: optimal play reached both outcomes over ${playouts} `
+      + `playouts from ${JSON.stringify(startBoard)} — the board is not decisive, `
+      + 'or the bot is not optimal');
+  }
+  return [...winners][0];
 };

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -53,15 +53,17 @@ export const playBotMove = <TBoard, TTurnState = unknown>(
 };
 
 // Which role can force the win from `startBoard`, read off the game's own
-// optimal bot playing both sides. A curated start board has to be *decisive* —
-// one role wins against best play — which is what makes choosing a role a real
-// decision rather than a coin flip, so this is the assertion a `startBoards`
-// list is worth committing behind.
+// optimal bot playing both sides. Every position of these games has such a
+// role: they are finite, deterministic, perfect-information and cannot end in
+// a draw (`gameEnd` always names a winner), so by Zermelo's theorem one side
+// can always force the win. What a curated board needs asserting is *which*
+// role that is — the team choosing it is the decision a competition is made of.
 //
-// Bots shuffle among equally-optimal moves, so one playout samples one line;
-// several disagreeing means the board is not decisive, or the bot it was
-// verified against is not optimal. Either way the list is not what it claims,
-// so this throws rather than returning a winner nobody can trust.
+// Bots shuffle among equally-optimal moves, so one playout samples one line.
+// Playouts that disagree therefore say nothing about the board: they mean the
+// bot is not optimal, having thrown the win away on some line. That is a bug in
+// the game rather than a fact about the position, so this throws instead of
+// returning a winner nobody can trust.
 export const forcedWinnerIndex = <TBoard, TTurnState = unknown>({
   gameplay,
   botStrategy,
@@ -79,9 +81,9 @@ export const forcedWinnerIndex = <TBoard, TTurnState = unknown>({
     startBoard
   }).winnerIndex));
   if (winners.size !== 1) {
-    throw new Error(`forcedWinnerIndex: optimal play reached both outcomes over ${playouts} `
-      + `playouts from ${JSON.stringify(startBoard)} — the board is not decisive, `
-      + 'or the bot is not optimal');
+    throw new Error(`forcedWinnerIndex: both roles won over ${playouts} playouts from `
+      + `${JSON.stringify(startBoard)} — one of them can force the win, so the bot `
+      + 'is throwing it away on some line and is not optimal');
   }
   return [...winners][0];
 };


### PR DESCRIPTION
Two independent changes. They share `VariantInput`, `resolveVariants` and `coins-in-3-piles.tsx`, so splitting them mid-file would have meant a first commit that doesn't compile — happy to cut the start-boards half onto its own branch if you'd rather review them apart.

## Curated start boards (#314)

A variant now states its start position **either** as `generateStartBoard` **or** as `startBoards: TBoard[]`, a curated list. `resolveVariants` derives the generator from the list, so nothing downstream distinguishes them — `startBoards` is the declarative form, not a second channel.

This is what a competition needs: it hands out `startBoards[attemptIndex]`, so **the list order is part of the contract** (append, never reorder). It also just formalises an idiom ~8 games already hand-rolled. `bacteria`, `stones-remove-one-not-twice-from-left` and `coins-in-3-piles` drop their `sample()` wrappers, and the stones spec no longer has to call its generator 400 times to recover the list it wants to judge.

The naming rule, from review: **name the boards, not the list.** A module exports the positions — `startBoardOfCategoryA`, `adjacentStartBoards`, `fullStartBoards` — and the variant assembles the list where it is used, `startBoards: [startBoardOfCategoryA]`. A single position stays singular rather than being pluralised into a one-entry export.

Each pick is `cloneDeep`d, so a curated board is as freshly owned by its match as a generated one. Nothing mutates a start board today — checked by playing every variant of every game from a deep-frozen board, zero offenders — but the list is module-scope data shared by every match, and the no-mutation rule is enforced by review rather than by types.

**Curating is only half of it.** A competition board's *winning role* is what matters, since the team choosing it is the decision a competition is made of. `forcedWinnerIndex` (`test-utils`) plays a game's own optimal bot against itself and names that role. Every position of these games has one: they are finite, deterministic, perfect-information and cannot draw, so by Zermelo's theorem some side can always force the win — which means playouts that *disagree* say nothing about the board and everything about the bot, namely that it threw the win away on some line. So the helper is really a test of the bot, using the board as the probe. `coins-in-3-piles` pins 3-5-7 as a replier win; the stones spec plays every curated board out to cross-check the predicate its balance test relies on.

`start-boards.ts` joins the React-free ESLint glob — it's the data a competition server reads, and it was covered by none of the existing globs.

## `?variant=` in the URL, and one name for a variant

Variants were the last un-addressable dimension, and #305 — which merged sibling games into variants — quietly removed URLs that used to exist. The param mirrors `?lang=`: the default variant is the param's *absence*, and writes use `replace: true`.

The param is **followed as well as written**. That matters because of one easy-to-miss case: the app is hash-routed, so navigating to a `?variant=` link for the game *already open* remounts nothing. Read once on mount, such a link changed the URL and left the board alone — which is exactly the link people share. Following it restarts the game, but clicking the variant radio already does that, so the URL shouldn't be the exception.

Variants gain an optional stable `id`; without one a variant is addressed by its index, which is enough for most games. Ids are declared only where they earn it — `coins-in-3-piles`, `chess-ducks`, `ten-coins` — rather than swept across the catalog. Duplicate ids, including one shadowing another variant's index, throw.

That key is now the **one name a variant has** everywhere it is named at all — the URL, the `game-finished` analytics event (`variant: '3-5-7'` rather than `variant: 2`), and the stored win/loss tallies (`stats_{gameId}_{variantKey}`). The index was the name that goes wrong quietly: reordering a game's variants hands each one the tally and the dashboard history of whichever variant used to sit at its position, with nothing to notice it.

Two migration notes, both deliberate:
- **Analytics history keeps the old numeric values**, so a chart spanning this change sees `2` and `'2'` as separate series for the games without ids.
- **Stored win/loss counters reset once.** They're per-browser, nothing reads them but the browser that wrote them, and a migration would only carry forward numbers nobody checks against anything.

## Note for review

`resolveVariants` drops `startBoards` from its output so resolution stays a no-op on its own result: `Game.variants` is the resolved array and `plays-to-an-end.spec.ts` resolves it a second time. The catalog sweep caught this — worth a look that dropping it is the right call versus carrying it through.

## Verification

`npm run test` (1914 tests), lint and typecheck green; `coverage:patch` comfortably above the 85% bar (CI is the authority on the exact number).

Played in a real browser: deep-linking by id, the index fallback on a game with no ids (`Bacteria?variant=2` → Scattered GOALs), unknown ids falling back to the default, switching writing the param, choosing the default clearing it, `?lang=` surviving alongside it, a same-route navigation actually changing the variant, and the three converted games starting on curated boards.