### PR TITLE
Migrate every fixed start board to startBoards

### DIFF
--- a/src/components/CLAUDE.md
+++ b/src/components/CLAUDE.md
@@ -50,6 +50,16 @@ never reorder), and a spec can judge every entry instead of calling the
 generator a few hundred times until they have all come up. Each pick is cloned,
 so a curated board is as freshly owned by its match as a generated one.
 
+The commonest case is a list of one: a game that always starts from the same
+position — an empty board, a full deck, a rook in the corner — writes
+`startBoards: [emptyBoard]` rather than wrapping that constant in a function
+nobody varies. `generateStartBoard` is then what it says: for positions that are
+actually *generated*, by sampling or rejection.
+
+A spec that steps such a board forward needs its own copy — `startBoards` is
+module-scope data shared by every match, and only the engine clones on the way
+in. The converted games keep a one-line `freshStartBoard()` helper for that.
+
 Curated boards want `forcedWinnerIndex` (`test-utils`) in their spec: it plays
 the game's own optimal bot against itself and returns the role that forces the
 win, throwing when playouts disagree. Assert the *role*, not just that the game

--- a/src/components/games/amor-and-cupido/amor-and-cupido.tsx
+++ b/src/components/games/amor-and-cupido/amor-and-cupido.tsx
@@ -1,5 +1,5 @@
 import { strategyGameFactory } from 'strategy-game-factory';
-import { generateStartBoard, moves } from './gameplay';
+import { startBoards, moves } from './gameplay';
 import { smartBotStrategy } from './bot-strategy';
 import { BoardClient } from './board-client';
 
@@ -31,6 +31,6 @@ export const AmorAndCupido = strategyGameFactory({
   gameplay: { moves },
   variants: [{
     botStrategy: smartBotStrategy,
-    generateStartBoard
+    startBoards
   }]
 });

--- a/src/components/games/amor-and-cupido/amor-and-cupido.tsx
+++ b/src/components/games/amor-and-cupido/amor-and-cupido.tsx
@@ -1,5 +1,5 @@
 import { strategyGameFactory } from 'strategy-game-factory';
-import { startBoards, moves } from './gameplay';
+import { startBoard, moves } from './gameplay';
 import { smartBotStrategy } from './bot-strategy';
 import { BoardClient } from './board-client';
 
@@ -31,6 +31,6 @@ export const AmorAndCupido = strategyGameFactory({
   gameplay: { moves },
   variants: [{
     botStrategy: smartBotStrategy,
-    startBoards
+    startBoards: [startBoard]
   }]
 });

--- a/src/components/games/amor-and-cupido/bot-strategy.spec.ts
+++ b/src/components/games/amor-and-cupido/bot-strategy.spec.ts
@@ -1,10 +1,15 @@
-import { edgeIndex, generateStartBoard } from './gameplay';
+import { cloneDeep } from 'lodash';
+import { edgeIndex, startBoards } from './gameplay';
 import { makeCtx } from 'test-utils';
 import { getBotScore, smartBotStrategy } from './bot-strategy';
 
+// `startBoards` is shared module data; a spec that steps a board forward
+// needs its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoards[0]);
+
 describe('optimal solver (negamax)', () => {
   it('recognises an immediate winning position', () => {
-    const board = generateStartBoard();
+    const board = freshStartBoard();
     board[edgeIndex[0][1]] = 0;
     board[edgeIndex[0][2]] = 0;
     // Player 0 to move can close triangle {0,1,2}.
@@ -14,7 +19,7 @@ describe('optimal solver (negamax)', () => {
 
 describe('smartBotStrategy', () => {
   it('blocks an immediate threat even from a losing position', () => {
-    const board = generateStartBoard();
+    const board = freshStartBoard();
     // Opponent (player 0) owns two edges of triangle {0,1,2}; bot (player 1)
     // is to move and is losing, but must claim edge 1-2 to avoid losing now.
     board[edgeIndex[0][1]] = 0;

--- a/src/components/games/amor-and-cupido/bot-strategy.spec.ts
+++ b/src/components/games/amor-and-cupido/bot-strategy.spec.ts
@@ -1,11 +1,11 @@
 import { cloneDeep } from 'lodash';
-import { edgeIndex, startBoards } from './gameplay';
+import { edgeIndex, startBoard } from './gameplay';
 import { makeCtx } from 'test-utils';
 import { getBotScore, smartBotStrategy } from './bot-strategy';
 
-// `startBoards` is shared module data; a spec that steps a board forward
-// needs its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoards[0]);
+// `startBoard` is shared module data; a spec that steps a board forward needs
+// its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoard);
 
 describe('optimal solver (negamax)', () => {
   it('recognises an immediate winning position', () => {

--- a/src/components/games/amor-and-cupido/bot-strategy.spec.ts
+++ b/src/components/games/amor-and-cupido/bot-strategy.spec.ts
@@ -1,15 +1,10 @@
-import { cloneDeep } from 'lodash';
 import { edgeIndex, startBoard } from './gameplay';
 import { makeCtx } from 'test-utils';
 import { getBotScore, smartBotStrategy } from './bot-strategy';
 
-// `startBoard` is shared module data; a spec that steps a board forward needs
-// its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoard);
-
 describe('optimal solver (negamax)', () => {
   it('recognises an immediate winning position', () => {
-    const board = freshStartBoard();
+    const board = startBoard;
     board[edgeIndex[0][1]] = 0;
     board[edgeIndex[0][2]] = 0;
     // Player 0 to move can close triangle {0,1,2}.
@@ -19,7 +14,7 @@ describe('optimal solver (negamax)', () => {
 
 describe('smartBotStrategy', () => {
   it('blocks an immediate threat even from a losing position', () => {
-    const board = freshStartBoard();
+    const board = startBoard;
     // Opponent (player 0) owns two edges of triangle {0,1,2}; bot (player 1)
     // is to move and is losing, but must claim edge 1-2 to avoid losing now.
     board[edgeIndex[0][1]] = 0;

--- a/src/components/games/amor-and-cupido/gameplay.spec.ts
+++ b/src/components/games/amor-and-cupido/gameplay.spec.ts
@@ -5,15 +5,15 @@ import {
   completesTriangle,
   edgeIndex,
   findWinningTriangle,
-  startBoards,
+  startBoard,
   getAllowedMoves,
   moves
 } from './gameplay';
 import { makeCtx, moveValidator } from 'test-utils';
 
-// `startBoards` is shared module data; a spec that steps a board forward
-// needs its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoards[0]);
+// `startBoard` is shared module data; a spec that steps a board forward needs
+// its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoard);
 
 const isClaimAllowed = moveValidator(moves.claimEdge);
 

--- a/src/components/games/amor-and-cupido/gameplay.spec.ts
+++ b/src/components/games/amor-and-cupido/gameplay.spec.ts
@@ -11,8 +11,7 @@ import {
 } from './gameplay';
 import { makeCtx, moveValidator } from 'test-utils';
 
-// `startBoard` is shared module data; a spec that steps a board forward needs
-// its own copy, the way the engine takes one per match.
+// This spec steps the board forward, so it needs its own copy of the shared one.
 const freshStartBoard = () => cloneDeep(startBoard);
 
 const isClaimAllowed = moveValidator(moves.claimEdge);

--- a/src/components/games/amor-and-cupido/gameplay.spec.ts
+++ b/src/components/games/amor-and-cupido/gameplay.spec.ts
@@ -1,14 +1,19 @@
+import { cloneDeep } from 'lodash';
 import {
   EDGES,
   TRIANGLES,
   completesTriangle,
   edgeIndex,
   findWinningTriangle,
-  generateStartBoard,
+  startBoards,
   getAllowedMoves,
   moves
 } from './gameplay';
 import { makeCtx, moveValidator } from 'test-utils';
+
+// `startBoards` is shared module data; a spec that steps a board forward
+// needs its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoards[0]);
 
 const isClaimAllowed = moveValidator(moves.claimEdge);
 
@@ -19,7 +24,7 @@ describe('helpers geometry', () => {
   });
 
   it('lists every empty edge as an allowed move', () => {
-    const board = generateStartBoard();
+    const board = freshStartBoard();
     expect(getAllowedMoves(board)).toHaveLength(15);
     board[edgeIndex[0][1]] = 0;
     board[edgeIndex[0][2]] = 1;
@@ -32,7 +37,7 @@ describe('helpers geometry', () => {
 
 describe('completesTriangle', () => {
   it('detects when a move closes a same-colour triangle', () => {
-    const board = generateStartBoard();
+    const board = freshStartBoard();
     board[edgeIndex[0][1]] = 0;
     board[edgeIndex[0][2]] = 0;
     // Closing edge 1-2 finishes triangle {0,1,2} for player 0.
@@ -40,7 +45,7 @@ describe('completesTriangle', () => {
   });
 
   it('does not fire when the partner edges belong to the other player', () => {
-    const board = generateStartBoard();
+    const board = freshStartBoard();
     board[edgeIndex[0][1]] = 1;
     board[edgeIndex[0][2]] = 1;
     expect(completesTriangle(board, 0, edgeIndex[1][2])).toBe(false);
@@ -51,7 +56,7 @@ describe('completesTriangle', () => {
 
 describe('findWinningTriangle', () => {
   it('returns the three edges of a completed triangle', () => {
-    const board = generateStartBoard();
+    const board = freshStartBoard();
     // Use a non-first triangle {3,4,5} and add a stray player-0 edge that lies in
     // earlier triangles, so a `some`-instead-of-`every` regression would return the
     // wrong (earlier) triangle rather than the actually completed one.
@@ -68,12 +73,12 @@ describe('findWinningTriangle', () => {
 
 describe('isClaimAllowed', () => {
   it('accepts a pair nobody has claimed', () => {
-    expect(isClaimAllowed(generateStartBoard(), 0)).toBe(true);
-    expect(isClaimAllowed(generateStartBoard(), 14)).toBe(true);
+    expect(isClaimAllowed(freshStartBoard(), 0)).toBe(true);
+    expect(isClaimAllowed(freshStartBoard(), 14)).toBe(true);
   });
 
   it('refuses a pair either player already owns', () => {
-    const board = generateStartBoard();
+    const board = freshStartBoard();
     board[3] = 0;
     board[7] = 1;
     expect(isClaimAllowed(board, 3)).toBe(false);
@@ -81,13 +86,13 @@ describe('isClaimAllowed', () => {
   });
 
   it('refuses a pair that does not exist', () => {
-    expect(isClaimAllowed(generateStartBoard(), -1)).toBe(false);
-    expect(isClaimAllowed(generateStartBoard(), 15)).toBe(false);
-    expect(isClaimAllowed(generateStartBoard(), 1.5)).toBe(false);
+    expect(isClaimAllowed(freshStartBoard(), -1)).toBe(false);
+    expect(isClaimAllowed(freshStartBoard(), 15)).toBe(false);
+    expect(isClaimAllowed(freshStartBoard(), 1.5)).toBe(false);
   });
 
   it('accepts exactly the edges the generator lists', () => {
-    const board = generateStartBoard();
+    const board = freshStartBoard();
     board[2] = 0;
     board[5] = 1;
     const listed = new Set(getAllowedMoves(board));
@@ -104,7 +109,7 @@ const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) }
 describe('end of game', () => {
   it.each([0, 1])('ends for the mover (player %i) on completing a triangle', player => {
     const [e0, e1, e2] = TRIANGLES[0];
-    const board = generateStartBoard();
+    const board = freshStartBoard();
     board[e0] = player;
     board[e1] = player;
     expect(completesTriangle(board, player, e2)).toBe(true);
@@ -116,7 +121,7 @@ describe('end of game', () => {
 
   it('does not end on a triangle the opponent would complete', () => {
     const [e0, e1, e2] = TRIANGLES[0];
-    const board = generateStartBoard();
+    const board = freshStartBoard();
     board[e0] = 1;
     board[e1] = 1;
     // player 0 taking the third edge blocks the triangle rather than making one
@@ -126,7 +131,7 @@ describe('end of game', () => {
   });
 
   it('passes the turn on an ordinary claim', () => {
-    const outcome = moves.claimEdge.apply(generateStartBoard(), asPlayer(0), 0);
+    const outcome = moves.claimEdge.apply(freshStartBoard(), asPlayer(0), 0);
     expect(outcome.gameEnd).toBeUndefined();
     expect(outcome.isTurnEnd).toBe(true);
   });

--- a/src/components/games/amor-and-cupido/gameplay.ts
+++ b/src/components/games/amor-and-cupido/gameplay.ts
@@ -36,7 +36,7 @@ for (let a = 0; a < VERTEX_COUNT; a++) {
 const trianglesByEdge: [number, number, number][][] =
   EDGES.map((_, e) => TRIANGLES.filter(tri => tri.includes(e)));
 
-export const generateStartBoard = (): Board => new Array(EDGES.length).fill(null);
+export const startBoards: Board[] = [new Array(EDGES.length).fill(null)];
 
 export const getAllowedMoves = (board: Board): number[] =>
   board.flatMap((owner, e) => (owner === null ? [e] : []));

--- a/src/components/games/amor-and-cupido/gameplay.ts
+++ b/src/components/games/amor-and-cupido/gameplay.ts
@@ -36,7 +36,7 @@ for (let a = 0; a < VERTEX_COUNT; a++) {
 const trianglesByEdge: [number, number, number][][] =
   EDGES.map((_, e) => TRIANGLES.filter(tri => tri.includes(e)));
 
-export const startBoards: Board[] = [new Array(EDGES.length).fill(null)];
+export const startBoard: Board = new Array(EDGES.length).fill(null);
 
 export const getAllowedMoves = (board: Board): number[] =>
   board.flatMap((owner, e) => (owner === null ? [e] : []));

--- a/src/components/games/architect-and-bandits/architect-and-bandits-a/architect-and-bandits-a.tsx
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-a/architect-and-bandits-a.tsx
@@ -2,7 +2,7 @@ import { strategyGameFactory } from 'strategy-game-factory';
 import { ARCHITECT } from '../gameplay';
 import { makeBoardClient } from '../board-client';
 import { smartBotStrategy } from './bot-strategy';
-import { startBoards, moves, KM_PER_DAY } from './gameplay';
+import { startBoard, moves, KM_PER_DAY } from './gameplay';
 
 const BoardClient = makeBoardClient(KM_PER_DAY);
 
@@ -64,6 +64,6 @@ export const ArchitectAndBandits = strategyGameFactory({
   gameplay: { moves, endOfTurnMove: 'startNextDay' },
   variants: [{
     botStrategy: smartBotStrategy,
-    startBoards
+    startBoards: [startBoard]
   }]
 });

--- a/src/components/games/architect-and-bandits/architect-and-bandits-a/architect-and-bandits-a.tsx
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-a/architect-and-bandits-a.tsx
@@ -2,7 +2,7 @@ import { strategyGameFactory } from 'strategy-game-factory';
 import { ARCHITECT } from '../gameplay';
 import { makeBoardClient } from '../board-client';
 import { smartBotStrategy } from './bot-strategy';
-import { generateStartBoard, moves, KM_PER_DAY } from './gameplay';
+import { startBoards, moves, KM_PER_DAY } from './gameplay';
 
 const BoardClient = makeBoardClient(KM_PER_DAY);
 
@@ -64,6 +64,6 @@ export const ArchitectAndBandits = strategyGameFactory({
   gameplay: { moves, endOfTurnMove: 'startNextDay' },
   variants: [{
     botStrategy: smartBotStrategy,
-    generateStartBoard
+    startBoards
   }]
 });

--- a/src/components/games/architect-and-bandits/architect-and-bandits-a/gameplay.spec.ts
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-a/gameplay.spec.ts
@@ -1,6 +1,11 @@
-import { generateStartBoard, moves } from './gameplay';
+import { cloneDeep } from 'lodash';
+import { startBoards, moves } from './gameplay';
 import { ARCHITECT, BANDITS, KM_PER_EDGE, type Board } from '../gameplay';
 import { makeCtx } from 'test-utils';
+
+// `startBoards` is shared module data; a spec that steps a board forward
+// needs its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoards[0]);
 
 // After the fourth day the architect wins exactly when every vertex carries a
 // tower.
@@ -75,7 +80,7 @@ describe('architect-and-bandits-a tower building', () => {
   });
 
   it('starts day 1 with a tower already on the architect\'s vertex', () => {
-    const board = generateStartBoard();
+    const board = freshStartBoard();
     expect(board.towers).toHaveLength(VERTEX_COUNT);
     expect(board.architectPosition).toBe(0);
     expect(board.towers[0]).toBe(true);

--- a/src/components/games/architect-and-bandits/architect-and-bandits-a/gameplay.spec.ts
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-a/gameplay.spec.ts
@@ -1,11 +1,6 @@
-import { cloneDeep } from 'lodash';
 import { startBoard, moves } from './gameplay';
 import { ARCHITECT, BANDITS, KM_PER_EDGE, type Board } from '../gameplay';
 import { makeCtx } from 'test-utils';
-
-// `startBoard` is shared module data; a spec that steps a board forward needs
-// its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoard);
 
 // After the fourth day the architect wins exactly when every vertex carries a
 // tower.
@@ -80,7 +75,7 @@ describe('architect-and-bandits-a tower building', () => {
   });
 
   it('starts day 1 with a tower already on the architect\'s vertex', () => {
-    const board = freshStartBoard();
+    const board = startBoard;
     expect(board.towers).toHaveLength(VERTEX_COUNT);
     expect(board.architectPosition).toBe(0);
     expect(board.towers[0]).toBe(true);

--- a/src/components/games/architect-and-bandits/architect-and-bandits-a/gameplay.spec.ts
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-a/gameplay.spec.ts
@@ -1,11 +1,11 @@
 import { cloneDeep } from 'lodash';
-import { startBoards, moves } from './gameplay';
+import { startBoard, moves } from './gameplay';
 import { ARCHITECT, BANDITS, KM_PER_EDGE, type Board } from '../gameplay';
 import { makeCtx } from 'test-utils';
 
-// `startBoards` is shared module data; a spec that steps a board forward
-// needs its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoards[0]);
+// `startBoard` is shared module data; a spec that steps a board forward needs
+// its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoard);
 
 // After the fourth day the architect wins exactly when every vertex carries a
 // tower.

--- a/src/components/games/architect-and-bandits/architect-and-bandits-a/gameplay.ts
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-a/gameplay.ts
@@ -1,11 +1,11 @@
-import { makeMoves, makeStartBoard } from '../gameplay';
+import { makeMoves, makeStartBoard, type Board } from '../gameplay';
 
 export const VERTEX_COUNT = 8;
 
 // The architect may walk this far along the wall each day.
 export const KM_PER_DAY = 40;
 
-export const generateStartBoard = makeStartBoard(VERTEX_COUNT);
+export const startBoards: Board[] = [makeStartBoard(VERTEX_COUNT)];
 
 export const moves = makeMoves(KM_PER_DAY);
 

--- a/src/components/games/architect-and-bandits/architect-and-bandits-a/gameplay.ts
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-a/gameplay.ts
@@ -5,7 +5,7 @@ export const VERTEX_COUNT = 8;
 // The architect may walk this far along the wall each day.
 export const KM_PER_DAY = 40;
 
-export const startBoards: Board[] = [makeStartBoard(VERTEX_COUNT)];
+export const startBoard: Board = makeStartBoard(VERTEX_COUNT);
 
 export const moves = makeMoves(KM_PER_DAY);
 

--- a/src/components/games/architect-and-bandits/architect-and-bandits-b/architect-and-bandits-b.tsx
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-b/architect-and-bandits-b.tsx
@@ -2,7 +2,7 @@ import { strategyGameFactory } from 'strategy-game-factory';
 import { ARCHITECT } from '../gameplay';
 import { makeBoardClient } from '../board-client';
 import { smartBotStrategy } from './bot-strategy';
-import { startBoards, moves, KM_PER_DAY } from './gameplay';
+import { startBoard, moves, KM_PER_DAY } from './gameplay';
 
 const BoardClient = makeBoardClient(KM_PER_DAY);
 
@@ -64,6 +64,6 @@ export const ArchitectAndBanditsB = strategyGameFactory({
   gameplay: { moves, endOfTurnMove: 'startNextDay' },
   variants: [{
     botStrategy: smartBotStrategy,
-    startBoards
+    startBoards: [startBoard]
   }]
 });

--- a/src/components/games/architect-and-bandits/architect-and-bandits-b/architect-and-bandits-b.tsx
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-b/architect-and-bandits-b.tsx
@@ -2,7 +2,7 @@ import { strategyGameFactory } from 'strategy-game-factory';
 import { ARCHITECT } from '../gameplay';
 import { makeBoardClient } from '../board-client';
 import { smartBotStrategy } from './bot-strategy';
-import { generateStartBoard, moves, KM_PER_DAY } from './gameplay';
+import { startBoards, moves, KM_PER_DAY } from './gameplay';
 
 const BoardClient = makeBoardClient(KM_PER_DAY);
 
@@ -64,6 +64,6 @@ export const ArchitectAndBanditsB = strategyGameFactory({
   gameplay: { moves, endOfTurnMove: 'startNextDay' },
   variants: [{
     botStrategy: smartBotStrategy,
-    generateStartBoard
+    startBoards
   }]
 });

--- a/src/components/games/architect-and-bandits/architect-and-bandits-b/gameplay.spec.ts
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-b/gameplay.spec.ts
@@ -1,6 +1,11 @@
-import { generateStartBoard, moves } from './gameplay';
+import { cloneDeep } from 'lodash';
+import { startBoards, moves } from './gameplay';
 import { ARCHITECT, BANDITS, KM_PER_EDGE, type Board } from '../gameplay';
 import { makeCtx } from 'test-utils';
+
+// `startBoards` is shared module data; a spec that steps a board forward
+// needs its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoards[0]);
 
 // After the fourth day the architect wins exactly when every vertex carries a
 // tower.
@@ -75,7 +80,7 @@ describe('architect-and-bandits-b tower building', () => {
   });
 
   it('starts day 1 with a tower already on the architect\'s vertex', () => {
-    const board = generateStartBoard();
+    const board = freshStartBoard();
     expect(board.towers).toHaveLength(VERTEX_COUNT);
     expect(board.architectPosition).toBe(0);
     expect(board.towers[0]).toBe(true);

--- a/src/components/games/architect-and-bandits/architect-and-bandits-b/gameplay.spec.ts
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-b/gameplay.spec.ts
@@ -1,11 +1,6 @@
-import { cloneDeep } from 'lodash';
 import { startBoard, moves } from './gameplay';
 import { ARCHITECT, BANDITS, KM_PER_EDGE, type Board } from '../gameplay';
 import { makeCtx } from 'test-utils';
-
-// `startBoard` is shared module data; a spec that steps a board forward needs
-// its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoard);
 
 // After the fourth day the architect wins exactly when every vertex carries a
 // tower.
@@ -80,7 +75,7 @@ describe('architect-and-bandits-b tower building', () => {
   });
 
   it('starts day 1 with a tower already on the architect\'s vertex', () => {
-    const board = freshStartBoard();
+    const board = startBoard;
     expect(board.towers).toHaveLength(VERTEX_COUNT);
     expect(board.architectPosition).toBe(0);
     expect(board.towers[0]).toBe(true);

--- a/src/components/games/architect-and-bandits/architect-and-bandits-b/gameplay.spec.ts
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-b/gameplay.spec.ts
@@ -1,11 +1,11 @@
 import { cloneDeep } from 'lodash';
-import { startBoards, moves } from './gameplay';
+import { startBoard, moves } from './gameplay';
 import { ARCHITECT, BANDITS, KM_PER_EDGE, type Board } from '../gameplay';
 import { makeCtx } from 'test-utils';
 
-// `startBoards` is shared module data; a spec that steps a board forward
-// needs its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoards[0]);
+// `startBoard` is shared module data; a spec that steps a board forward needs
+// its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoard);
 
 // After the fourth day the architect wins exactly when every vertex carries a
 // tower.

--- a/src/components/games/architect-and-bandits/architect-and-bandits-b/gameplay.ts
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-b/gameplay.ts
@@ -1,11 +1,11 @@
-import { makeMoves, makeStartBoard } from '../gameplay';
+import { makeMoves, makeStartBoard, type Board } from '../gameplay';
 
 export const VERTEX_COUNT = 10;
 
 // The architect may walk this far along the wall each day.
 export const KM_PER_DAY = 50;
 
-export const generateStartBoard = makeStartBoard(VERTEX_COUNT);
+export const startBoards: Board[] = [makeStartBoard(VERTEX_COUNT)];
 
 export const moves = makeMoves(KM_PER_DAY);
 

--- a/src/components/games/architect-and-bandits/architect-and-bandits-b/gameplay.ts
+++ b/src/components/games/architect-and-bandits/architect-and-bandits-b/gameplay.ts
@@ -5,7 +5,7 @@ export const VERTEX_COUNT = 10;
 // The architect may walk this far along the wall each day.
 export const KM_PER_DAY = 50;
 
-export const startBoards: Board[] = [makeStartBoard(VERTEX_COUNT)];
+export const startBoard: Board = makeStartBoard(VERTEX_COUNT);
 
 export const moves = makeMoves(KM_PER_DAY);
 

--- a/src/components/games/architect-and-bandits/gameplay.ts
+++ b/src/components/games/architect-and-bandits/gameplay.ts
@@ -24,7 +24,7 @@ export const isArchitectStepAllowed = (board: Board, targetVertex: number, kmPer
   return gap === 1 || gap === board.towers.length - 1; // neighbours, wrapping round
 };
 
-export const makeStartBoard = (vertexCount: number) => (): Board => {
+export const makeStartBoard = (vertexCount: number): Board => {
   const towers = Array(vertexCount).fill(false);
   /*
   Workaround to have a tower at the start of day 1, as startOfTurnMove or

--- a/src/components/games/chess-bishops/bot-strategy.spec.ts
+++ b/src/components/games/chess-bishops/bot-strategy.spec.ts
@@ -1,11 +1,11 @@
 import lodash, { cloneDeep } from 'lodash';
 import { smartBotStrategy } from './bot-strategy';
-import { startBoards, BISHOP, markForbiddenFields, type Board, type Field } from './gameplay'
+import { startBoard, BISHOP, markForbiddenFields, type Board, type Field } from './gameplay'
 import { botNextMoveArgs, makeCtx } from 'test-utils';
 
-// `startBoards` is shared module data; a spec that steps a board forward
-// needs its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoards[0]);
+// `startBoard` is shared module data; a spec that steps a board forward needs
+// its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoard);
 
 const smartBotPlacement = (board: Board): Field =>
   botNextMoveArgs(smartBotStrategy({ board, ctx: makeCtx() }))[0];

--- a/src/components/games/chess-bishops/bot-strategy.spec.ts
+++ b/src/components/games/chess-bishops/bot-strategy.spec.ts
@@ -1,7 +1,11 @@
-import lodash from 'lodash';
+import lodash, { cloneDeep } from 'lodash';
 import { smartBotStrategy } from './bot-strategy';
-import { generateStartBoard, BISHOP, markForbiddenFields, type Board, type Field } from './gameplay'
+import { startBoards, BISHOP, markForbiddenFields, type Board, type Field } from './gameplay'
 import { botNextMoveArgs, makeCtx } from 'test-utils';
+
+// `startBoards` is shared module data; a spec that steps a board forward
+// needs its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoards[0]);
 
 const smartBotPlacement = (board: Board): Field =>
   botNextMoveArgs(smartBotStrategy({ board, ctx: makeCtx() }))[0];
@@ -15,7 +19,7 @@ describe('test bishop strategy', () => {
     it('places 2nd bishop at the horizontal mirror position when horizontal axis is chosen', () => {
       // random(0, 1) === 1 selects the horizontal axis
       vi.spyOn(lodash, 'random').mockReturnValue(1);
-      const board = generateStartBoard();
+      const board = freshStartBoard();
       markForbiddenFields(board, { row: 1, col: 5 });
       board[1][5] = BISHOP;
       const res = smartBotPlacement(board);
@@ -25,7 +29,7 @@ describe('test bishop strategy', () => {
     it('places 2nd bishop at the vertical mirror position when vertical axis is chosen', () => {
       // random(0, 1) === 0 selects the vertical axis
       vi.spyOn(lodash, 'random').mockReturnValue(0);
-      const board = generateStartBoard();
+      const board = freshStartBoard();
       markForbiddenFields(board, { row: 1, col: 5 });
       board[1][5] = BISHOP;
       const res = smartBotPlacement(board);
@@ -33,7 +37,7 @@ describe('test bishop strategy', () => {
     });
 
     it('places 4th bishop at a mirror position according to chosen axis', () => {
-      const board = generateStartBoard();
+      const board = freshStartBoard();
       markForbiddenFields(board, { row: 1, col: 5 });
       board[1][5] = BISHOP;
       const move2 = smartBotPlacement(board);

--- a/src/components/games/chess-bishops/bot-strategy.spec.ts
+++ b/src/components/games/chess-bishops/bot-strategy.spec.ts
@@ -3,8 +3,7 @@ import { smartBotStrategy } from './bot-strategy';
 import { startBoard, BISHOP, markForbiddenFields, type Board, type Field } from './gameplay'
 import { botNextMoveArgs, makeCtx } from 'test-utils';
 
-// `startBoard` is shared module data; a spec that steps a board forward needs
-// its own copy, the way the engine takes one per match.
+// This spec steps the board forward, so it needs its own copy of the shared one.
 const freshStartBoard = () => cloneDeep(startBoard);
 
 const smartBotPlacement = (board: Board): Field =>

--- a/src/components/games/chess-bishops/chess-bishops.tsx
+++ b/src/components/games/chess-bishops/chess-bishops.tsx
@@ -2,7 +2,7 @@ import { range, isEqual } from 'lodash';
 import { strategyGameFactory, type BoardClientProps, GameBoard, useHoverPreview } from 'strategy-game-factory';
 import { ChessBishopSvg } from './chess-bishop-svg';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
-import { BISHOP, FORBIDDEN, startBoards, moves, type Board, type Field } from './gameplay';
+import { BISHOP, FORBIDDEN, startBoard, moves, type Board, type Field } from './gameplay';
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { value: validHoveredField, hoverProps } = useHoverPreview<Field>(ctx.moveCount);
@@ -95,6 +95,6 @@ export const ChessBishops = strategyGameFactory({
   gameplay: { moves },
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
-    { botStrategy: smartBotStrategy, startBoards, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
+    { botStrategy: smartBotStrategy, startBoards: [startBoard], label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/chess-bishops/chess-bishops.tsx
+++ b/src/components/games/chess-bishops/chess-bishops.tsx
@@ -2,7 +2,7 @@ import { range, isEqual } from 'lodash';
 import { strategyGameFactory, type BoardClientProps, GameBoard, useHoverPreview } from 'strategy-game-factory';
 import { ChessBishopSvg } from './chess-bishop-svg';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
-import { BISHOP, FORBIDDEN, generateStartBoard, moves, type Board, type Field } from './gameplay';
+import { BISHOP, FORBIDDEN, startBoards, moves, type Board, type Field } from './gameplay';
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { value: validHoveredField, hoverProps } = useHoverPreview<Field>(ctx.moveCount);
@@ -95,6 +95,6 @@ export const ChessBishops = strategyGameFactory({
   gameplay: { moves },
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
-    { botStrategy: smartBotStrategy, generateStartBoard, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
+    { botStrategy: smartBotStrategy, startBoards, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/chess-bishops/gameplay.spec.ts
+++ b/src/components/games/chess-bishops/gameplay.spec.ts
@@ -1,14 +1,9 @@
-import { cloneDeep } from 'lodash';
 import { FORBIDDEN, startBoard, getAllowedMoves, markForbiddenFields, moves } from './gameplay';
 import { makeCtx } from 'test-utils';
 
-// `startBoard` is shared module data; a spec that steps a board forward needs
-// its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoard);
-
 describe('markForbiddenFields', () => {
   it('should mark forbidden fields', () => {
-    const board = freshStartBoard();
+    const board = startBoard;
     markForbiddenFields(board, { row: 2, col: 3 });
     const expectedBoard = [
       [null     , FORBIDDEN, null     , null  , null     , FORBIDDEN, null     , null     ],
@@ -31,7 +26,7 @@ const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) }
 
 describe('end of game', () => {
   it('ends exactly on the placement that saturates the board', () => {
-    let board = freshStartBoard();
+    let board = startBoard;
     let player = 0;
     let outcome = moves.placeBishop.apply(board, asPlayer(player), getAllowedMoves(board)[0]);
 

--- a/src/components/games/chess-bishops/gameplay.spec.ts
+++ b/src/components/games/chess-bishops/gameplay.spec.ts
@@ -1,10 +1,10 @@
 import { cloneDeep } from 'lodash';
-import { FORBIDDEN, startBoards, getAllowedMoves, markForbiddenFields, moves } from './gameplay';
+import { FORBIDDEN, startBoard, getAllowedMoves, markForbiddenFields, moves } from './gameplay';
 import { makeCtx } from 'test-utils';
 
-// `startBoards` is shared module data; a spec that steps a board forward
-// needs its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoards[0]);
+// `startBoard` is shared module data; a spec that steps a board forward needs
+// its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoard);
 
 describe('markForbiddenFields', () => {
   it('should mark forbidden fields', () => {

--- a/src/components/games/chess-bishops/gameplay.spec.ts
+++ b/src/components/games/chess-bishops/gameplay.spec.ts
@@ -1,9 +1,14 @@
-import { FORBIDDEN, generateStartBoard, getAllowedMoves, markForbiddenFields, moves } from './gameplay';
+import { cloneDeep } from 'lodash';
+import { FORBIDDEN, startBoards, getAllowedMoves, markForbiddenFields, moves } from './gameplay';
 import { makeCtx } from 'test-utils';
+
+// `startBoards` is shared module data; a spec that steps a board forward
+// needs its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoards[0]);
 
 describe('markForbiddenFields', () => {
   it('should mark forbidden fields', () => {
-    const board = generateStartBoard();
+    const board = freshStartBoard();
     markForbiddenFields(board, { row: 2, col: 3 });
     const expectedBoard = [
       [null     , FORBIDDEN, null     , null  , null     , FORBIDDEN, null     , null     ],
@@ -26,7 +31,7 @@ const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) }
 
 describe('end of game', () => {
   it('ends exactly on the placement that saturates the board', () => {
-    let board = generateStartBoard();
+    let board = freshStartBoard();
     let player = 0;
     let outcome = moves.placeBishop.apply(board, asPlayer(player), getAllowedMoves(board)[0]);
 

--- a/src/components/games/chess-bishops/gameplay.ts
+++ b/src/components/games/chess-bishops/gameplay.ts
@@ -8,9 +8,7 @@ export type CellValue = null | typeof BISHOP | typeof FORBIDDEN;
 export type Board = CellValue[][];
 export type Field = { row: number; col: number };
 
-export const generateStartBoard = (): Board => {
-  return range(0, 8).map(() => range(0, 8).map(() => null));
-};
+export const startBoards: Board[] = [range(0, 8).map(() => range(0, 8).map(() => null))];
 
 export const boardIndices: Field[] = flatMap(range(0, 8), row => range(0, 8).map(col => ({ row, col })));
 

--- a/src/components/games/chess-bishops/gameplay.ts
+++ b/src/components/games/chess-bishops/gameplay.ts
@@ -8,7 +8,7 @@ export type CellValue = null | typeof BISHOP | typeof FORBIDDEN;
 export type Board = CellValue[][];
 export type Field = { row: number; col: number };
 
-export const startBoards: Board[] = [range(0, 8).map(() => range(0, 8).map(() => null))];
+export const startBoard: Board = range(0, 8).map(() => range(0, 8).map(() => null));
 
 export const boardIndices: Field[] = flatMap(range(0, 8), row => range(0, 8).map(col => ({ row, col })));
 

--- a/src/components/games/chess-ducks/chess-ducks.tsx
+++ b/src/components/games/chess-ducks/chess-ducks.tsx
@@ -1,5 +1,5 @@
 import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
-import { range, sample } from 'lodash';
+import { range } from 'lodash';
 import { DuckSvg } from './rubber-duck-svg';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import {
@@ -10,9 +10,8 @@ import {
   type Field
 } from './gameplay';
 
-const generateStartBoard = (ROWS: number, COLS: number) => (): Board => {
-  return range(0, ROWS).map(() => range(0, COLS).map(() => null));
-};
+const startBoard = (ROWS: number, COLS: number): Board =>
+  range(0, ROWS).map(() => range(0, COLS).map(() => null));
 
 // Board-driven: reads its dimensions from the board, so it renders any size.
 const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
@@ -100,8 +99,7 @@ const getPlayerStepDescription = () => ({
 });
 
 // Test variant covers both sub-games: a 4 × 6 or a 4 × 7 board.
-const generateTestStartBoard = (): Board =>
-  sample([generateStartBoard(4, 6), generateStartBoard(4, 7)])!();
+const testStartBoards: Board[] = [startBoard(4, 6), startBoard(4, 7)];
 
 export const ChessDucks = strategyGameFactory({
   presentation: {
@@ -114,13 +112,13 @@ export const ChessDucks = strategyGameFactory({
     {
       id: 'test',
       botStrategy: randomBotStrategy,
-      generateStartBoard: generateTestStartBoard,
+      startBoards: testStartBoards,
       label: { hu: 'Teszt', en: 'Test' }
     },
     {
       id: '4x6',
       botStrategy: smartBotStrategy,
-      generateStartBoard: generateStartBoard(4, 6),
+      startBoards: [startBoard(4, 6)],
       rule: rule(4, 6),
       label: { hu: '4×6', en: '4×6' },
       isDefault: true
@@ -128,7 +126,7 @@ export const ChessDucks = strategyGameFactory({
     {
       id: '4x7',
       botStrategy: smartBotStrategy,
-      generateStartBoard: generateStartBoard(4, 7),
+      startBoards: [startBoard(4, 7)],
       rule: rule(4, 7),
       label: { hu: '4×7', en: '4×7' }
     }

--- a/src/components/games/chess-rook/bot-strategy.spec.ts
+++ b/src/components/games/chess-rook/bot-strategy.spec.ts
@@ -1,7 +1,11 @@
 import { smartBotStrategy } from './bot-strategy';
-import { generateStartBoard, markVisitedFields, type Board, type Field } from './gameplay';
+import { startBoards, markVisitedFields, type Board, type Field } from './gameplay';
 import { botNextMoveArgs, makeCtx } from 'test-utils';
 import { isEqual, cloneDeep } from 'lodash';
+
+// `startBoards` is shared module data; a spec that steps a board forward
+// needs its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoards[0]);
 
 const smartBotTarget = (board: Board): Field =>
   botNextMoveArgs(smartBotStrategy({ board, ctx: makeCtx() }))[0];
@@ -9,7 +13,7 @@ const smartBotTarget = (board: Board): Field =>
 describe('chess rook', () => {
   describe('smartBotStrategy', () => {
     it('should move to end of row or column as a first step', () => {
-      const rookPosition = smartBotTarget(generateStartBoard());
+      const rookPosition = smartBotTarget(freshStartBoard());
       expect(
         isEqual(rookPosition, { row: 0, col: 7 }) ||
         isEqual(rookPosition, { row: 7, col: 0 })
@@ -17,7 +21,7 @@ describe('chess rook', () => {
     });
 
     it('should create a narrow rectangle if possible', () => {
-      const board = generateStartBoard();
+      const board = freshStartBoard();
 
       const nextBoard = cloneDeep(board);
       markVisitedFields(nextBoard, nextBoard.rookPosition, { row: 0, col: 5 });

--- a/src/components/games/chess-rook/bot-strategy.spec.ts
+++ b/src/components/games/chess-rook/bot-strategy.spec.ts
@@ -1,11 +1,11 @@
 import { smartBotStrategy } from './bot-strategy';
-import { startBoards, markVisitedFields, type Board, type Field } from './gameplay';
+import { startBoard, markVisitedFields, type Board, type Field } from './gameplay';
 import { botNextMoveArgs, makeCtx } from 'test-utils';
 import { isEqual, cloneDeep } from 'lodash';
 
-// `startBoards` is shared module data; a spec that steps a board forward
-// needs its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoards[0]);
+// `startBoard` is shared module data; a spec that steps a board forward needs
+// its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoard);
 
 const smartBotTarget = (board: Board): Field =>
   botNextMoveArgs(smartBotStrategy({ board, ctx: makeCtx() }))[0];

--- a/src/components/games/chess-rook/bot-strategy.spec.ts
+++ b/src/components/games/chess-rook/bot-strategy.spec.ts
@@ -1,11 +1,7 @@
 import { smartBotStrategy } from './bot-strategy';
 import { startBoard, markVisitedFields, type Board, type Field } from './gameplay';
 import { botNextMoveArgs, makeCtx } from 'test-utils';
-import { isEqual, cloneDeep } from 'lodash';
-
-// `startBoard` is shared module data; a spec that steps a board forward needs
-// its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoard);
+import { cloneDeep, isEqual } from 'lodash';
 
 const smartBotTarget = (board: Board): Field =>
   botNextMoveArgs(smartBotStrategy({ board, ctx: makeCtx() }))[0];
@@ -13,7 +9,7 @@ const smartBotTarget = (board: Board): Field =>
 describe('chess rook', () => {
   describe('smartBotStrategy', () => {
     it('should move to end of row or column as a first step', () => {
-      const rookPosition = smartBotTarget(freshStartBoard());
+      const rookPosition = smartBotTarget(startBoard);
       expect(
         isEqual(rookPosition, { row: 0, col: 7 }) ||
         isEqual(rookPosition, { row: 7, col: 0 })
@@ -21,7 +17,7 @@ describe('chess rook', () => {
     });
 
     it('should create a narrow rectangle if possible', () => {
-      const board = freshStartBoard();
+      const board = startBoard;
 
       const nextBoard = cloneDeep(board);
       markVisitedFields(nextBoard, nextBoard.rookPosition, { row: 0, col: 5 });

--- a/src/components/games/chess-rook/chess-rook.tsx
+++ b/src/components/games/chess-rook/chess-rook.tsx
@@ -1,7 +1,7 @@
 import { range } from 'lodash';
 import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
-import { generateStartBoard, moves, type Board, type Field } from './gameplay';
+import { startBoards, moves, type Board, type Field } from './gameplay';
 import { RookSvg } from '../shared/rook-svg';
 
 const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
@@ -75,6 +75,6 @@ export const ChessRook = strategyGameFactory({
   gameplay: { moves },
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
-    { botStrategy: smartBotStrategy, generateStartBoard, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
+    { botStrategy: smartBotStrategy, startBoards, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/chess-rook/chess-rook.tsx
+++ b/src/components/games/chess-rook/chess-rook.tsx
@@ -1,7 +1,7 @@
 import { range } from 'lodash';
 import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
-import { startBoards, moves, type Board, type Field } from './gameplay';
+import { startBoard, moves, type Board, type Field } from './gameplay';
 import { RookSvg } from '../shared/rook-svg';
 
 const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
@@ -75,6 +75,6 @@ export const ChessRook = strategyGameFactory({
   gameplay: { moves },
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
-    { botStrategy: smartBotStrategy, startBoards, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
+    { botStrategy: smartBotStrategy, startBoards: [startBoard], label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/chess-rook/gameplay.spec.ts
+++ b/src/components/games/chess-rook/gameplay.spec.ts
@@ -2,8 +2,7 @@ import { cloneDeep } from 'lodash';
 import { startBoard, getAllowedMoves, markVisitedFields, moves } from './gameplay';
 import { makeCtx } from 'test-utils';
 
-// `startBoard` is shared module data; a spec that steps a board forward needs
-// its own copy, the way the engine takes one per match.
+// This spec steps the board forward, so it needs its own copy of the shared one.
 const freshStartBoard = () => cloneDeep(startBoard);
 
 describe('markVisitedFields', () => {

--- a/src/components/games/chess-rook/gameplay.spec.ts
+++ b/src/components/games/chess-rook/gameplay.spec.ts
@@ -1,9 +1,14 @@
-import { generateStartBoard, getAllowedMoves, markVisitedFields, moves } from './gameplay';
+import { cloneDeep } from 'lodash';
+import { startBoards, getAllowedMoves, markVisitedFields, moves } from './gameplay';
 import { makeCtx } from 'test-utils';
+
+// `startBoards` is shared module data; a spec that steps a board forward
+// needs its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoards[0]);
 
 describe('markVisitedFields', () => {
   it('should mark visited fields', () => {
-    const board = generateStartBoard();
+    const board = freshStartBoard();
     markVisitedFields(board, { row: 0, col: 0 }, { row: 6, col: 0 });
     expect(board.chessBoard[0][0]).toEqual('visited');
     expect(board.chessBoard[1][0]).toEqual('visited');
@@ -14,7 +19,7 @@ describe('markVisitedFields', () => {
 
 describe('getAllowedMoves', () => {
   it('should return right and down moves from starting position', () => {
-    const board = generateStartBoard();
+    const board = freshStartBoard();
     const moves = getAllowedMoves(board);
     expect(moves).toHaveLength(14);
     expect(moves).toEqual(expect.arrayContaining([
@@ -24,7 +29,7 @@ describe('getAllowedMoves', () => {
   });
 
   it('should be blocked by visited squares', () => {
-    const board = generateStartBoard();
+    const board = freshStartBoard();
     markVisitedFields(board, { row: 0, col: 0 }, { row: 0, col: 3 });
     board.chessBoard[0][3] = 'rook';
     board.rookPosition = { row: 0, col: 3 };
@@ -41,7 +46,7 @@ describe('getAllowedMoves', () => {
   });
 
   it('should return no moves when all paths are blocked', () => {
-    const board = generateStartBoard();
+    const board = freshStartBoard();
     board.chessBoard[0][1] = 'visited';
     board.chessBoard[1][0] = 'visited';
 
@@ -55,7 +60,7 @@ const asPlayer = (currentPlayer: number) => ({ ctx: makeCtx({ currentPlayer }) }
 
 describe('end of game', () => {
   it('ends exactly on the move that strands the rook', () => {
-    let board = generateStartBoard();
+    let board = freshStartBoard();
     let player = 0;
     let outcome = moves.moveRook.apply(board, asPlayer(player), getAllowedMoves(board)[0]);
 

--- a/src/components/games/chess-rook/gameplay.spec.ts
+++ b/src/components/games/chess-rook/gameplay.spec.ts
@@ -1,10 +1,10 @@
 import { cloneDeep } from 'lodash';
-import { startBoards, getAllowedMoves, markVisitedFields, moves } from './gameplay';
+import { startBoard, getAllowedMoves, markVisitedFields, moves } from './gameplay';
 import { makeCtx } from 'test-utils';
 
-// `startBoards` is shared module data; a spec that steps a board forward
-// needs its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoards[0]);
+// `startBoard` is shared module data; a spec that steps a board forward needs
+// its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoard);
 
 describe('markVisitedFields', () => {
   it('should mark visited fields', () => {

--- a/src/components/games/chess-rook/gameplay.ts
+++ b/src/components/games/chess-rook/gameplay.ts
@@ -5,14 +5,11 @@ export type CellValue = null | 'rook' | 'visited';
 export type Field = { row: number; col: number };
 export type Board = { chessBoard: CellValue[][]; rookPosition: Field };
 
-export const generateStartBoard = (): Board => {
-  const board = range(0, 8).map(() => range(0, 8).map((): CellValue => null));
-  board[0][0] = 'rook';
-  return {
-    chessBoard: board,
-    rookPosition: { row: 0, col: 0 }
-  };
-};
+export const startBoards: Board[] = [{
+  chessBoard: range(0, 8).map(row =>
+    range(0, 8).map((col): CellValue => (row === 0 && col === 0 ? 'rook' : null))),
+  rookPosition: { row: 0, col: 0 }
+}];
 
 export const getAllowedMoves = (board: Board): Field[] => {
   const { row, col } = board.rookPosition;

--- a/src/components/games/chess-rook/gameplay.ts
+++ b/src/components/games/chess-rook/gameplay.ts
@@ -5,11 +5,11 @@ export type CellValue = null | 'rook' | 'visited';
 export type Field = { row: number; col: number };
 export type Board = { chessBoard: CellValue[][]; rookPosition: Field };
 
-export const startBoards: Board[] = [{
-  chessBoard: range(0, 8).map(row =>
-    range(0, 8).map((col): CellValue => (row === 0 && col === 0 ? 'rook' : null))),
-  rookPosition: { row: 0, col: 0 }
-}];
+export const startBoard: Board = {
+chessBoard: range(0, 8).map(row =>
+  range(0, 8).map((col): CellValue => (row === 0 && col === 0 ? 'rook' : null))),
+rookPosition: { row: 0, col: 0 }
+};
 
 export const getAllowedMoves = (board: Board): Field[] => {
   const { row, col } = board.rookPosition;

--- a/src/components/games/cube-coloring/bot-strategy.spec.ts
+++ b/src/components/games/cube-coloring/bot-strategy.spec.ts
@@ -1,11 +1,11 @@
 import { range, uniq, cloneDeep } from 'lodash';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
-import { colors, startBoards, isAllowedStep, moves, type Board } from './gameplay';
+import { colors, startBoard, isAllowedStep, moves, type Board } from './gameplay';
 import { botNextMoveArgs, makeCtx, moveValidator } from 'test-utils';
 
-// `startBoards` is shared module data; a spec that steps a board forward
-// needs its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoards[0]);
+// `startBoard` is shared module data; a spec that steps a board forward needs
+// its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoard);
 
 type Step = { vertex: number; color: string };
 

--- a/src/components/games/cube-coloring/bot-strategy.spec.ts
+++ b/src/components/games/cube-coloring/bot-strategy.spec.ts
@@ -3,8 +3,7 @@ import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 import { colors, startBoard, isAllowedStep, moves, type Board } from './gameplay';
 import { botNextMoveArgs, makeCtx, moveValidator } from 'test-utils';
 
-// `startBoard` is shared module data; a spec that steps a board forward needs
-// its own copy, the way the engine takes one per match.
+// This spec steps the board forward, so it needs its own copy of the shared one.
 const freshStartBoard = () => cloneDeep(startBoard);
 
 type Step = { vertex: number; color: string };

--- a/src/components/games/cube-coloring/bot-strategy.spec.ts
+++ b/src/components/games/cube-coloring/bot-strategy.spec.ts
@@ -1,12 +1,16 @@
-import { range, uniq } from 'lodash';
+import { range, uniq, cloneDeep } from 'lodash';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
-import { colors, generateStartBoard, isAllowedStep, moves, type Board } from './gameplay';
+import { colors, startBoards, isAllowedStep, moves, type Board } from './gameplay';
 import { botNextMoveArgs, makeCtx, moveValidator } from 'test-utils';
+
+// `startBoards` is shared module data; a spec that steps a board forward
+// needs its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoards[0]);
 
 type Step = { vertex: number; color: string };
 
 const boardWith = (colored: Record<number, string>): Board => {
-  const board = generateStartBoard();
+  const board = freshStartBoard();
   Object.entries(colored).forEach(([vertex, color]) => { board[Number(vertex)] = color; });
   return board;
 };
@@ -26,7 +30,7 @@ const stepNamed = (board: Board, seat: { chosenRoleIndex: number }): Step =>
 // strategies, and neither is a search.
 describe('smartBotStrategy as the first player', () => {
   it('opens on the main diagonal, taking both its ends before anything else', () => {
-    const seen = uniq(range(40).map(() => stepNamed(generateStartBoard(), asBotFirst).vertex));
+    const seen = uniq(range(40).map(() => stepNamed(freshStartBoard(), asBotFirst).vertex));
     expect(seen.sort()).toEqual([2, 4]);
   });
 
@@ -88,7 +92,7 @@ describe('smartBotStrategy as the second player', () => {
 describe('legality from either seat', () => {
   it('only ever names a colouring the game accepts', () => {
     const boards = [
-      generateStartBoard(),
+      freshStartBoard(),
       boardWith({ 2: 'red' }),
       boardWith({ 0: 'red' }),
       boardWith({ 1: 'red', 3: 'blue' }),

--- a/src/components/games/cube-coloring/cube-coloring.tsx
+++ b/src/components/games/cube-coloring/cube-coloring.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { range, map } from 'lodash';
 import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
-import { generateStartBoard, edges, moves, type Board } from './gameplay';
+import { startBoards, edges, moves, type Board } from './gameplay';
 import { useTranslation } from 'language';
 
 // Screen position of each node; the drawn skeleton (see `edges` in gameplay)
@@ -165,6 +165,6 @@ export const CubeColoring = strategyGameFactory({
   gameplay: { moves },
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
-    { botStrategy: smartBotStrategy, generateStartBoard, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
+    { botStrategy: smartBotStrategy, startBoards, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/cube-coloring/cube-coloring.tsx
+++ b/src/components/games/cube-coloring/cube-coloring.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { range, map } from 'lodash';
 import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
-import { startBoards, edges, moves, type Board } from './gameplay';
+import { startBoard, edges, moves, type Board } from './gameplay';
 import { useTranslation } from 'language';
 
 // Screen position of each node; the drawn skeleton (see `edges` in gameplay)
@@ -165,6 +165,6 @@ export const CubeColoring = strategyGameFactory({
   gameplay: { moves },
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
-    { botStrategy: smartBotStrategy, startBoards, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
+    { botStrategy: smartBotStrategy, startBoards: [startBoard], label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/cube-coloring/gameplay.spec.ts
+++ b/src/components/games/cube-coloring/gameplay.spec.ts
@@ -2,8 +2,7 @@ import { cloneDeep } from 'lodash';
 import { startBoard, moves, neighbours, type Board } from './gameplay';
 import { makeCtx, moveValidator } from 'test-utils';
 
-// `startBoard` is shared module data; a spec that steps a board forward needs
-// its own copy, the way the engine takes one per match.
+// This spec steps the board forward, so it needs its own copy of the shared one.
 const freshStartBoard = () => cloneDeep(startBoard);
 
 const isAllowedStep = (board: Board, vertex: number, color: string | null): boolean =>

--- a/src/components/games/cube-coloring/gameplay.spec.ts
+++ b/src/components/games/cube-coloring/gameplay.spec.ts
@@ -1,11 +1,16 @@
-import { generateStartBoard, moves, neighbours, type Board } from './gameplay';
+import { cloneDeep } from 'lodash';
+import { startBoards, moves, neighbours, type Board } from './gameplay';
 import { makeCtx, moveValidator } from 'test-utils';
+
+// `startBoards` is shared module data; a spec that steps a board forward
+// needs its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoards[0]);
 
 const isAllowedStep = (board: Board, vertex: number, color: string | null): boolean =>
   moveValidator(moves.colorVertex)(board, { vertex, color });
 
 describe('cube-coloring isAllowedStep', () => {
-  const empty = (): Board => generateStartBoard();
+  const empty = (): Board => freshStartBoard();
 
   it('allows colouring an uncoloured vertex on an empty board', () => {
     expect(isAllowedStep(empty(), 0, 'red')).toBe(true);
@@ -67,7 +72,7 @@ describe('end of game', () => {
 
   it('passes the turn while a colour still fits somewhere', () => {
     const outcome = moves.colorVertex.apply(
-      generateStartBoard(), meta, { vertex: 0, color: 'red' }
+      freshStartBoard(), meta, { vertex: 0, color: 'red' }
     );
     expect(outcome.nextBoard).toEqual(['red', '', '', '', '', '', '', '']);
     expect(outcome.gameEnd).toBeUndefined();

--- a/src/components/games/cube-coloring/gameplay.spec.ts
+++ b/src/components/games/cube-coloring/gameplay.spec.ts
@@ -1,10 +1,10 @@
 import { cloneDeep } from 'lodash';
-import { startBoards, moves, neighbours, type Board } from './gameplay';
+import { startBoard, moves, neighbours, type Board } from './gameplay';
 import { makeCtx, moveValidator } from 'test-utils';
 
-// `startBoards` is shared module data; a spec that steps a board forward
-// needs its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoards[0]);
+// `startBoard` is shared module data; a spec that steps a board forward needs
+// its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoard);
 
 const isAllowedStep = (board: Board, vertex: number, color: string | null): boolean =>
   moveValidator(moves.colorVertex)(board, { vertex, color });

--- a/src/components/games/cube-coloring/gameplay.ts
+++ b/src/components/games/cube-coloring/gameplay.ts
@@ -3,7 +3,7 @@ import type { MoveOutcome } from 'strategy-game-factory';
 
 export type Board = string[]
 
-export const startBoards: Board[] = [Array(8).fill('')];
+export const startBoard: Board = Array(8).fill('');
 export const isColored = (board: Board, i: number) => board[i] !== '';
 
 // The logic-side palette; `nodeColors` in cube-coloring.tsx adds the styling.

--- a/src/components/games/cube-coloring/gameplay.ts
+++ b/src/components/games/cube-coloring/gameplay.ts
@@ -3,7 +3,7 @@ import type { MoveOutcome } from 'strategy-game-factory';
 
 export type Board = string[]
 
-export const generateStartBoard = (): Board => Array(8).fill('');
+export const startBoards: Board[] = [Array(8).fill('')];
 export const isColored = (board: Board, i: number) => board[i] !== '';
 
 // The logic-side palette; `nodeColors` in cube-coloring.tsx adds the styling.

--- a/src/components/games/distinct-squares/two-times-two/bot-strategy.spec.ts
+++ b/src/components/games/distinct-squares/two-times-two/bot-strategy.spec.ts
@@ -1,11 +1,11 @@
 import { isEqual, cloneDeep } from 'lodash';
 import { runMatch, type MatchResult } from 'strategy-game-factory';
-import { type Board, startBoards, moves } from './gameplay';
+import { type Board, startBoard, moves } from './gameplay';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 
-// `startBoards` is shared module data; a spec that steps a board forward
-// needs its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoards[0]);
+// `startBoard` is shared module data; a spec that steps a board forward needs
+// its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoard);
 
 // Six squares are placed in all, and only the final board decides: player 1
 // wins if the four counts end up all distinct (0,1,2,3), player 0 otherwise.

--- a/src/components/games/distinct-squares/two-times-two/bot-strategy.spec.ts
+++ b/src/components/games/distinct-squares/two-times-two/bot-strategy.spec.ts
@@ -1,11 +1,7 @@
-import { isEqual, cloneDeep } from 'lodash';
+import { isEqual } from 'lodash';
 import { runMatch, type MatchResult } from 'strategy-game-factory';
 import { type Board, startBoard, moves } from './gameplay';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
-
-// `startBoard` is shared module data; a spec that steps a board forward needs
-// its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoard);
 
 // Six squares are placed in all, and only the final board decides: player 1
 // wins if the four counts end up all distinct (0,1,2,3), player 0 otherwise.
@@ -29,13 +25,13 @@ describe('smartBotStrategy', () => {
   // the bot never loses the win later.
   it('wins as the first player from the start board, against a random opponent', () => {
     for (let trial = 0; trial < 60; trial++) {
-      expect(play(freshStartBoard(), [smartBotStrategy, randomBotStrategy]).winnerIndex).toBe(0);
+      expect(play(startBoard, [smartBotStrategy, randomBotStrategy]).winnerIndex).toBe(0);
     }
   });
 
   it('wins as the first player even against optimal play', () => {
     for (let trial = 0; trial < 20; trial++) {
-      expect(play(freshStartBoard(), [smartBotStrategy, smartBotStrategy]).winnerIndex).toBe(0);
+      expect(play(startBoard, [smartBotStrategy, smartBotStrategy]).winnerIndex).toBe(0);
     }
   });
 
@@ -65,7 +61,7 @@ describe('smartBotStrategy', () => {
 describe('randomBotStrategy', () => {
   it('only ever names squares that exist', () => {
     for (let trial = 0; trial < 40; trial++) {
-      const { history } = play(freshStartBoard(), [randomBotStrategy, randomBotStrategy]);
+      const { history } = play(startBoard, [randomBotStrategy, randomBotStrategy]);
       for (const { args } of history) {
         expect(args[0]).toBeTypeOf('number');
         expect(args[0] as number).toBeGreaterThanOrEqual(0);

--- a/src/components/games/distinct-squares/two-times-two/bot-strategy.spec.ts
+++ b/src/components/games/distinct-squares/two-times-two/bot-strategy.spec.ts
@@ -1,7 +1,11 @@
-import { isEqual } from 'lodash';
+import { isEqual, cloneDeep } from 'lodash';
 import { runMatch, type MatchResult } from 'strategy-game-factory';
-import { type Board, generateStartBoard, moves } from './gameplay';
+import { type Board, startBoards, moves } from './gameplay';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
+
+// `startBoards` is shared module data; a spec that steps a board forward
+// needs its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoards[0]);
 
 // Six squares are placed in all, and only the final board decides: player 1
 // wins if the four counts end up all distinct (0,1,2,3), player 0 otherwise.
@@ -25,13 +29,13 @@ describe('smartBotStrategy', () => {
   // the bot never loses the win later.
   it('wins as the first player from the start board, against a random opponent', () => {
     for (let trial = 0; trial < 60; trial++) {
-      expect(play(generateStartBoard(), [smartBotStrategy, randomBotStrategy]).winnerIndex).toBe(0);
+      expect(play(freshStartBoard(), [smartBotStrategy, randomBotStrategy]).winnerIndex).toBe(0);
     }
   });
 
   it('wins as the first player even against optimal play', () => {
     for (let trial = 0; trial < 20; trial++) {
-      expect(play(generateStartBoard(), [smartBotStrategy, smartBotStrategy]).winnerIndex).toBe(0);
+      expect(play(freshStartBoard(), [smartBotStrategy, smartBotStrategy]).winnerIndex).toBe(0);
     }
   });
 
@@ -61,7 +65,7 @@ describe('smartBotStrategy', () => {
 describe('randomBotStrategy', () => {
   it('only ever names squares that exist', () => {
     for (let trial = 0; trial < 40; trial++) {
-      const { history } = play(generateStartBoard(), [randomBotStrategy, randomBotStrategy]);
+      const { history } = play(freshStartBoard(), [randomBotStrategy, randomBotStrategy]);
       for (const { args } of history) {
         expect(args[0]).toBeTypeOf('number');
         expect(args[0] as number).toBeGreaterThanOrEqual(0);

--- a/src/components/games/distinct-squares/two-times-two/gameplay.ts
+++ b/src/components/games/distinct-squares/two-times-two/gameplay.ts
@@ -4,7 +4,7 @@ import { isPlacementAllowed } from '../gameplay';
 
 export type Board = number[]
 
-export const startBoards: Board[] = [[0, 0, 0, 0]];
+export const startBoard: Board = [0, 0, 0, 0];
 
 export const moves = {
   addPiece: {

--- a/src/components/games/distinct-squares/two-times-two/gameplay.ts
+++ b/src/components/games/distinct-squares/two-times-two/gameplay.ts
@@ -4,7 +4,7 @@ import { isPlacementAllowed } from '../gameplay';
 
 export type Board = number[]
 
-export const generateStartBoard = (): Board => [0, 0, 0, 0];
+export const startBoards: Board[] = [[0, 0, 0, 0]];
 
 export const moves = {
   addPiece: {

--- a/src/components/games/distinct-squares/two-times-two/two-times-two.tsx
+++ b/src/components/games/distinct-squares/two-times-two/two-times-two.tsx
@@ -1,7 +1,7 @@
 import { range } from 'lodash';
 import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
-import { startBoards, moves, type Board } from './gameplay';
+import { startBoard, moves, type Board } from './gameplay';
 
 const BoardClient = ({ board, moves }: BoardClientProps<Board>) => (
   <GameBoard>
@@ -58,6 +58,6 @@ export const TwoTimesTwo = strategyGameFactory({
   gameplay: { moves },
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
-    { botStrategy: smartBotStrategy, startBoards, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
+    { botStrategy: smartBotStrategy, startBoards: [startBoard], label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/distinct-squares/two-times-two/two-times-two.tsx
+++ b/src/components/games/distinct-squares/two-times-two/two-times-two.tsx
@@ -1,7 +1,7 @@
 import { range } from 'lodash';
 import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
-import { generateStartBoard, moves, type Board } from './gameplay';
+import { startBoards, moves, type Board } from './gameplay';
 
 const BoardClient = ({ board, moves }: BoardClientProps<Board>) => (
   <GameBoard>
@@ -58,6 +58,6 @@ export const TwoTimesTwo = strategyGameFactory({
   gameplay: { moves },
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
-    { botStrategy: smartBotStrategy, generateStartBoard, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
+    { botStrategy: smartBotStrategy, startBoards, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/dominoes-4x4/dominoes-4x4.tsx
+++ b/src/components/games/dominoes-4x4/dominoes-4x4.tsx
@@ -174,7 +174,7 @@ export const Dominoes4x4 = strategyGameFactory({
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
     {
       botStrategy: smartBotStrategy,
-      generateStartBoard: () => [],
+      startBoards: [[]],
       label: { hu: 'Teljes', en: 'Full' },
       isDefault: true
     }

--- a/src/components/games/dominoes-on-chessboard/dominoes-on-chessboard.tsx
+++ b/src/components/games/dominoes-on-chessboard/dominoes-on-chessboard.tsx
@@ -157,7 +157,7 @@ export const DominoesOnChessboard = strategyGameFactory({
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
     {
       botStrategy: smartBotStrategy,
-      generateStartBoard: () => [],
+      startBoards: [[]],
       label: { hu: 'Teljes', en: 'Full' },
       isDefault: true,
       notAlwaysOptimal: true

--- a/src/components/games/five-connected-fields/five-connected-fields.tsx
+++ b/src/components/games/five-connected-fields/five-connected-fields.tsx
@@ -1,5 +1,5 @@
 import { strategyGameFactory } from 'strategy-game-factory';
-import { generateStartBoard, moves } from './gameplay';
+import { startBoards, moves } from './gameplay';
 import { smartBotStrategy } from './bot-strategy';
 import { BoardClient } from './board-client';
 
@@ -30,5 +30,5 @@ export const FiveConnectedFields = strategyGameFactory({
   },
   BoardClient,
   gameplay: { moves },
-  variants: [{ botStrategy: smartBotStrategy, generateStartBoard }]
+  variants: [{ botStrategy: smartBotStrategy, startBoards }]
 });

--- a/src/components/games/five-connected-fields/five-connected-fields.tsx
+++ b/src/components/games/five-connected-fields/five-connected-fields.tsx
@@ -1,5 +1,5 @@
 import { strategyGameFactory } from 'strategy-game-factory';
-import { startBoards, moves } from './gameplay';
+import { startBoard, moves } from './gameplay';
 import { smartBotStrategy } from './bot-strategy';
 import { BoardClient } from './board-client';
 
@@ -30,5 +30,5 @@ export const FiveConnectedFields = strategyGameFactory({
   },
   BoardClient,
   gameplay: { moves },
-  variants: [{ botStrategy: smartBotStrategy, startBoards }]
+  variants: [{ botStrategy: smartBotStrategy, startBoards: [startBoard] }]
 });

--- a/src/components/games/five-connected-fields/gameplay.ts
+++ b/src/components/games/five-connected-fields/gameplay.ts
@@ -31,7 +31,7 @@ export const legalNodes = (board: Board): number[] =>
 export const hasAnyMove = (board: Board): boolean =>
   legalNodes(board).length > 0;
 
-export const startBoards: Board[] = [[0, 0, 0, 0, 0]];
+export const startBoard: Board = [0, 0, 0, 0, 0];
 
 export const moves = {
   placeCoin: {

--- a/src/components/games/five-connected-fields/gameplay.ts
+++ b/src/components/games/five-connected-fields/gameplay.ts
@@ -31,7 +31,7 @@ export const legalNodes = (board: Board): number[] =>
 export const hasAnyMove = (board: Board): boolean =>
   legalNodes(board).length > 0;
 
-export const generateStartBoard = (): Board => [0, 0, 0, 0, 0];
+export const startBoards: Board[] = [[0, 0, 0, 0, 0]];
 
 export const moves = {
   placeCoin: {

--- a/src/components/games/five-five-card/bot-strategy.spec.ts
+++ b/src/components/games/five-five-card/bot-strategy.spec.ts
@@ -1,11 +1,6 @@
-import { cloneDeep } from 'lodash';
 import { runMatch, type MatchResult } from 'strategy-game-factory';
 import { type Board, startBoard, moves } from './gameplay';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
-
-// `startBoard` is shared module data; a spec that steps a board forward needs
-// its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoard);
 
 // Each player takes cards from the *other* hand, so over the eight moves each
 // side decides which single card its opponent is left with. The second player
@@ -15,7 +10,7 @@ type Bot = typeof smartBotStrategy
 const play = (startBoard: Board, strategies: [Bot, Bot]): MatchResult<Board> =>
   runMatch({ gameplay: { moves }, strategies, startBoard });
 
-const START = freshStartBoard();
+const START = startBoard;
 
 // Solved offline against the real getWinnerIndex: the opening is a second-player
 // win, and so is every position still holding four cards a side — the first

--- a/src/components/games/five-five-card/bot-strategy.spec.ts
+++ b/src/components/games/five-five-card/bot-strategy.spec.ts
@@ -1,11 +1,11 @@
 import { cloneDeep } from 'lodash';
 import { runMatch, type MatchResult } from 'strategy-game-factory';
-import { type Board, startBoards, moves } from './gameplay';
+import { type Board, startBoard, moves } from './gameplay';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 
-// `startBoards` is shared module data; a spec that steps a board forward
-// needs its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoards[0]);
+// `startBoard` is shared module data; a spec that steps a board forward needs
+// its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoard);
 
 // Each player takes cards from the *other* hand, so over the eight moves each
 // side decides which single card its opponent is left with. The second player

--- a/src/components/games/five-five-card/bot-strategy.spec.ts
+++ b/src/components/games/five-five-card/bot-strategy.spec.ts
@@ -1,6 +1,11 @@
+import { cloneDeep } from 'lodash';
 import { runMatch, type MatchResult } from 'strategy-game-factory';
-import { type Board, generateStartBoard, moves } from './gameplay';
+import { type Board, startBoards, moves } from './gameplay';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
+
+// `startBoards` is shared module data; a spec that steps a board forward
+// needs its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoards[0]);
 
 // Each player takes cards from the *other* hand, so over the eight moves each
 // side decides which single card its opponent is left with. The second player
@@ -10,7 +15,7 @@ type Bot = typeof smartBotStrategy
 const play = (startBoard: Board, strategies: [Bot, Bot]): MatchResult<Board> =>
   runMatch({ gameplay: { moves }, strategies, startBoard });
 
-const START = generateStartBoard();
+const START = freshStartBoard();
 
 // Solved offline against the real getWinnerIndex: the opening is a second-player
 // win, and so is every position still holding four cards a side — the first

--- a/src/components/games/five-five-card/five-five-card.tsx
+++ b/src/components/games/five-five-card/five-five-card.tsx
@@ -1,7 +1,7 @@
 import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { useTranslation } from 'language';
-import { CARDS, startBoards, moves, type Board } from './gameplay';
+import { CARDS, startBoard, moves, type Board } from './gameplay';
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
@@ -71,7 +71,7 @@ export const FiveFiveCard = strategyGameFactory({
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
     {
       botStrategy: smartBotStrategy,
-      startBoards,
+      startBoards: [startBoard],
       label: { hu: 'Teljes', en: 'Full' },
       isDefault: true
     }

--- a/src/components/games/five-five-card/five-five-card.tsx
+++ b/src/components/games/five-five-card/five-five-card.tsx
@@ -1,7 +1,7 @@
 import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { useTranslation } from 'language';
-import { CARDS, generateStartBoard, moves, type Board } from './gameplay';
+import { CARDS, startBoards, moves, type Board } from './gameplay';
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { t } = useTranslation();
@@ -71,7 +71,7 @@ export const FiveFiveCard = strategyGameFactory({
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
     {
       botStrategy: smartBotStrategy,
-      generateStartBoard,
+      startBoards,
       label: { hu: 'Teljes', en: 'Full' },
       isDefault: true
     }

--- a/src/components/games/five-five-card/gameplay.ts
+++ b/src/components/games/five-five-card/gameplay.ts
@@ -7,7 +7,7 @@ export type Card = typeof CARDS[number]
 // The cards each player still holds, in `CARDS` order.
 export type Board = [Card[], Card[]]
 
-export const generateStartBoard = (): Board => [[...CARDS], [...CARDS]];
+export const startBoards: Board[] = [[[...CARDS], [...CARDS]]];
 
 // The board taking `card` leaves behind. A move takes from the *other* hand, so
 // `player` is the mover; the bot's look-ahead plays the same function forward.

--- a/src/components/games/five-five-card/gameplay.ts
+++ b/src/components/games/five-five-card/gameplay.ts
@@ -7,7 +7,7 @@ export type Card = typeof CARDS[number]
 // The cards each player still holds, in `CARDS` order.
 export type Board = [Card[], Card[]]
 
-export const startBoards: Board[] = [[[...CARDS], [...CARDS]]];
+export const startBoard: Board = [[...CARDS], [...CARDS]];
 
 // The board taking `card` leaves behind. A move takes from the *other* hand, so
 // `player` is the mover; the bot's look-ahead plays the same function forward.

--- a/src/components/games/four-connected-fields/four-connected-fields.tsx
+++ b/src/components/games/four-connected-fields/four-connected-fields.tsx
@@ -42,7 +42,7 @@ export const FourConnectedFields = strategyGameFactory({
     },
     {
       botStrategy: smartBotStrategy,
-      generateStartBoard: (): Board => [0, 0, 0, 0],
+      startBoards: [[0, 0, 0, 0]],
       label: { hu: 'Teljes', en: 'Full' },
       isDefault: true
     }

--- a/src/components/games/latin-square-filling/bot-strategy.spec.ts
+++ b/src/components/games/latin-square-filling/bot-strategy.spec.ts
@@ -6,7 +6,7 @@ import {
 } from './bot-strategy';
 import {
   applyMove,
-  startBoards,
+  startBoard,
   isFull,
   isTerminal,
   legalMoves,
@@ -17,9 +17,9 @@ import {
 } from './gameplay';
 import { moveValidator } from 'test-utils';
 
-// `startBoards` is shared module data; a spec that steps a board forward
-// needs its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoards[0]);
+// `startBoard` is shared module data; a spec that steps a board forward needs
+// its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoard);
 
 const isLegalPlacement = moveValidator(moves.placeDigit);
 

--- a/src/components/games/latin-square-filling/bot-strategy.spec.ts
+++ b/src/components/games/latin-square-filling/bot-strategy.spec.ts
@@ -1,4 +1,3 @@
-import { cloneDeep } from 'lodash';
 import {
   getRandomBotStep,
   getSmartBotStep,
@@ -17,10 +16,6 @@ import {
 } from './gameplay';
 import { moveValidator } from 'test-utils';
 
-// `startBoard` is shared module data; a spec that steps a board forward needs
-// its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoard);
-
 const isLegalPlacement = moveValidator(moves.placeDigit);
 
 describe('latin-square-filling bot', () => {
@@ -28,7 +23,7 @@ describe('latin-square-filling bot', () => {
 const playGame = (
   step0: (b: Board) => Move,
   step1: (b: Board) => Move,
-  start: Board = freshStartBoard()
+  start: Board = startBoard
 ): number => {
   let board = start;
   // safety bound: at most 9 placements
@@ -44,7 +39,7 @@ const playGame = (
 
   describe('optimal winner (minimax)', () => {
     it('is a forced first-player win from the empty board', () => {
-      expect(optimalWinner(freshStartBoard())).toBe(0);
+      expect(optimalWinner(startBoard)).toBe(0);
     });
 
     it('credits a completed Latin square to the first player', () => {
@@ -52,7 +47,7 @@ const playGame = (
     });
 
     it('every legal first move preserves the first player win', () => {
-      const start = freshStartBoard();
+      const start = startBoard;
       for (const move of legalMoves(start)) {
         expect(optimalWinner(applyMove(start, move))).toBe(0);
       }
@@ -92,7 +87,7 @@ const playGame = (
       // predicted by the minimax value — for both winning and losing sides.
       const positions: Board[] = [];
       for (let i = 0; i < 60; i++) {
-        let board = freshStartBoard();
+        let board = startBoard;
         while (!isTerminal(board)) {
           positions.push([...board]);
           board = applyMove(board, getRandomBotStep(board));

--- a/src/components/games/latin-square-filling/bot-strategy.spec.ts
+++ b/src/components/games/latin-square-filling/bot-strategy.spec.ts
@@ -1,3 +1,4 @@
+import { cloneDeep } from 'lodash';
 import {
   getRandomBotStep,
   getSmartBotStep,
@@ -5,7 +6,7 @@ import {
 } from './bot-strategy';
 import {
   applyMove,
-  generateStartBoard,
+  startBoards,
   isFull,
   isTerminal,
   legalMoves,
@@ -16,6 +17,10 @@ import {
 } from './gameplay';
 import { moveValidator } from 'test-utils';
 
+// `startBoards` is shared module data; a spec that steps a board forward
+// needs its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoards[0]);
+
 const isLegalPlacement = moveValidator(moves.placeDigit);
 
 describe('latin-square-filling bot', () => {
@@ -23,7 +28,7 @@ describe('latin-square-filling bot', () => {
 const playGame = (
   step0: (b: Board) => Move,
   step1: (b: Board) => Move,
-  start: Board = generateStartBoard()
+  start: Board = freshStartBoard()
 ): number => {
   let board = start;
   // safety bound: at most 9 placements
@@ -39,7 +44,7 @@ const playGame = (
 
   describe('optimal winner (minimax)', () => {
     it('is a forced first-player win from the empty board', () => {
-      expect(optimalWinner(generateStartBoard())).toBe(0);
+      expect(optimalWinner(freshStartBoard())).toBe(0);
     });
 
     it('credits a completed Latin square to the first player', () => {
@@ -47,7 +52,7 @@ const playGame = (
     });
 
     it('every legal first move preserves the first player win', () => {
-      const start = generateStartBoard();
+      const start = freshStartBoard();
       for (const move of legalMoves(start)) {
         expect(optimalWinner(applyMove(start, move))).toBe(0);
       }
@@ -87,7 +92,7 @@ const playGame = (
       // predicted by the minimax value — for both winning and losing sides.
       const positions: Board[] = [];
       for (let i = 0; i < 60; i++) {
-        let board = generateStartBoard();
+        let board = freshStartBoard();
         while (!isTerminal(board)) {
           positions.push([...board]);
           board = applyMove(board, getRandomBotStep(board));

--- a/src/components/games/latin-square-filling/gameplay.spec.ts
+++ b/src/components/games/latin-square-filling/gameplay.spec.ts
@@ -1,4 +1,3 @@
-import { cloneDeep } from 'lodash';
 import {
   applyMove,
   startBoard,
@@ -11,10 +10,6 @@ import {
   type Board
 } from './gameplay';
 import { makeCtx, moveValidator } from 'test-utils';
-
-// `startBoard` is shared module data; a spec that steps a board forward needs
-// its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoard);
 
 const isLegalPlacement = moveValidator(moves.placeDigit);
 
@@ -56,7 +51,7 @@ describe('latin-square-filling gameplay', () => {
 
   describe('turn bookkeeping', () => {
     it('player 0 moves on even fill counts, player 1 on odd', () => {
-      expect(playerToMove(freshStartBoard())).toBe(0);
+      expect(playerToMove(startBoard)).toBe(0);
       expect(playerToMove([1, 0, 0, 0, 0, 0, 0, 0, 0])).toBe(1);
       expect(playerToMove([1, 2, 0, 0, 0, 0, 0, 0, 0])).toBe(0);
     });
@@ -71,21 +66,21 @@ describe('latin-square-filling gameplay', () => {
 
 describe('isLegalPlacement argument checks', () => {
   it('refuses a digit outside 1..3', () => {
-    const board = freshStartBoard();
+    const board = startBoard;
     expect(isLegalPlacement(board, 0, 0)).toBe(false);
     expect(isLegalPlacement(board, 0, 4)).toBe(false);
     expect(isLegalPlacement(board, 0, 1.5)).toBe(false);
   });
 
   it('refuses a cell outside the 3x3 grid', () => {
-    const board = freshStartBoard();
+    const board = startBoard;
     expect(isLegalPlacement(board, -1, 1)).toBe(false);
     expect(isLegalPlacement(board, 9, 1)).toBe(false);
     expect(isLegalPlacement(board, 0.5, 1)).toBe(false);
   });
 
   it('accepts exactly the moves the generator lists', () => {
-    const board = applyMove(applyMove(freshStartBoard(), { cell: 0, digit: 1 }), { cell: 4, digit: 2 });
+    const board = applyMove(applyMove(startBoard, { cell: 0, digit: 1 }), { cell: 4, digit: 2 });
     const listed = new Set(legalMoves(board).map(m => `${m.cell},${m.digit}`));
     for (let cell = 0; cell < 9; cell++) {
       for (const digit of [1, 2, 3]) {

--- a/src/components/games/latin-square-filling/gameplay.spec.ts
+++ b/src/components/games/latin-square-filling/gameplay.spec.ts
@@ -1,7 +1,7 @@
 import { cloneDeep } from 'lodash';
 import {
   applyMove,
-  startBoards,
+  startBoard,
   isFull,
   isTerminal,
   legalDigits,
@@ -12,9 +12,9 @@ import {
 } from './gameplay';
 import { makeCtx, moveValidator } from 'test-utils';
 
-// `startBoards` is shared module data; a spec that steps a board forward
-// needs its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoards[0]);
+// `startBoard` is shared module data; a spec that steps a board forward needs
+// its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoard);
 
 const isLegalPlacement = moveValidator(moves.placeDigit);
 

--- a/src/components/games/latin-square-filling/gameplay.spec.ts
+++ b/src/components/games/latin-square-filling/gameplay.spec.ts
@@ -1,6 +1,7 @@
+import { cloneDeep } from 'lodash';
 import {
   applyMove,
-  generateStartBoard,
+  startBoards,
   isFull,
   isTerminal,
   legalDigits,
@@ -10,6 +11,10 @@ import {
   type Board
 } from './gameplay';
 import { makeCtx, moveValidator } from 'test-utils';
+
+// `startBoards` is shared module data; a spec that steps a board forward
+// needs its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoards[0]);
 
 const isLegalPlacement = moveValidator(moves.placeDigit);
 
@@ -51,7 +56,7 @@ describe('latin-square-filling gameplay', () => {
 
   describe('turn bookkeeping', () => {
     it('player 0 moves on even fill counts, player 1 on odd', () => {
-      expect(playerToMove(generateStartBoard())).toBe(0);
+      expect(playerToMove(freshStartBoard())).toBe(0);
       expect(playerToMove([1, 0, 0, 0, 0, 0, 0, 0, 0])).toBe(1);
       expect(playerToMove([1, 2, 0, 0, 0, 0, 0, 0, 0])).toBe(0);
     });
@@ -66,21 +71,21 @@ describe('latin-square-filling gameplay', () => {
 
 describe('isLegalPlacement argument checks', () => {
   it('refuses a digit outside 1..3', () => {
-    const board = generateStartBoard();
+    const board = freshStartBoard();
     expect(isLegalPlacement(board, 0, 0)).toBe(false);
     expect(isLegalPlacement(board, 0, 4)).toBe(false);
     expect(isLegalPlacement(board, 0, 1.5)).toBe(false);
   });
 
   it('refuses a cell outside the 3x3 grid', () => {
-    const board = generateStartBoard();
+    const board = freshStartBoard();
     expect(isLegalPlacement(board, -1, 1)).toBe(false);
     expect(isLegalPlacement(board, 9, 1)).toBe(false);
     expect(isLegalPlacement(board, 0.5, 1)).toBe(false);
   });
 
   it('accepts exactly the moves the generator lists', () => {
-    const board = applyMove(applyMove(generateStartBoard(), { cell: 0, digit: 1 }), { cell: 4, digit: 2 });
+    const board = applyMove(applyMove(freshStartBoard(), { cell: 0, digit: 1 }), { cell: 4, digit: 2 });
     const listed = new Set(legalMoves(board).map(m => `${m.cell},${m.digit}`));
     for (let cell = 0; cell < 9; cell++) {
       for (const digit of [1, 2, 3]) {

--- a/src/components/games/latin-square-filling/gameplay.ts
+++ b/src/components/games/latin-square-filling/gameplay.ts
@@ -7,7 +7,7 @@ export type Move = { cell: number; digit: number };
 const rowOf = (cell: number): number => Math.floor(cell / 3);
 const colOf = (cell: number): number => cell % 3;
 
-export const startBoards: Board[] = [Array(9).fill(0)];
+export const startBoard: Board = Array(9).fill(0);
 
 export const isFull = (board: Board): boolean => board.every(v => v !== 0);
 

--- a/src/components/games/latin-square-filling/gameplay.ts
+++ b/src/components/games/latin-square-filling/gameplay.ts
@@ -7,7 +7,7 @@ export type Move = { cell: number; digit: number };
 const rowOf = (cell: number): number => Math.floor(cell / 3);
 const colOf = (cell: number): number => cell % 3;
 
-export const generateStartBoard = (): Board => Array(9).fill(0);
+export const startBoards: Board[] = [Array(9).fill(0)];
 
 export const isFull = (board: Board): boolean => board.every(v => v !== 0);
 

--- a/src/components/games/latin-square-filling/latin-square-filling.tsx
+++ b/src/components/games/latin-square-filling/latin-square-filling.tsx
@@ -2,7 +2,7 @@ import {
   strategyGameFactory, useMoveScopedState, type BoardClientProps, type Ctx, GameBoard
 } from 'strategy-game-factory';
 import { useTranslation } from 'language';
-import { startBoards, moves, type Board } from './gameplay';
+import { startBoard, moves, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
@@ -133,12 +133,12 @@ export const LatinSquareFilling = strategyGameFactory({
   variants: [
     {
       botStrategy: randomBotStrategy,
-      startBoards,
+      startBoards: [startBoard],
       label: { hu: 'Teszt', en: 'Test' }
     },
     {
       botStrategy: smartBotStrategy,
-      startBoards,
+      startBoards: [startBoard],
       label: { hu: 'Teljes', en: 'Full' },
       isDefault: true
     }

--- a/src/components/games/latin-square-filling/latin-square-filling.tsx
+++ b/src/components/games/latin-square-filling/latin-square-filling.tsx
@@ -2,7 +2,7 @@ import {
   strategyGameFactory, useMoveScopedState, type BoardClientProps, type Ctx, GameBoard
 } from 'strategy-game-factory';
 import { useTranslation } from 'language';
-import { generateStartBoard, moves, type Board } from './gameplay';
+import { startBoards, moves, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
@@ -133,12 +133,12 @@ export const LatinSquareFilling = strategyGameFactory({
   variants: [
     {
       botStrategy: randomBotStrategy,
-      generateStartBoard,
+      startBoards,
       label: { hu: 'Teszt', en: 'Test' }
     },
     {
       botStrategy: smartBotStrategy,
-      generateStartBoard,
+      startBoards,
       label: { hu: 'Teljes', en: 'Full' },
       isDefault: true
     }

--- a/src/components/games/magic-box/magic-box-a/magic-box-a.tsx
+++ b/src/components/games/magic-box/magic-box-a/magic-box-a.tsx
@@ -50,7 +50,7 @@ export const MagicBox = strategyGameFactory({
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
     {
       botStrategy: smartBotStrategy,
-      generateStartBoard: generateEmptyBoard,
+      startBoards: [generateEmptyBoard()],
       label: { hu: 'Teljes', en: 'Full' },
       isDefault: true
     }

--- a/src/components/games/magic-box/magic-box-b/magic-box-b.tsx
+++ b/src/components/games/magic-box/magic-box-b/magic-box-b.tsx
@@ -54,7 +54,7 @@ export const MagicBoxB = strategyGameFactory({
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
     {
       botStrategy: smartBotStrategy,
-      generateStartBoard: generateEmptyBoard,
+      startBoards: [generateEmptyBoard()],
       label: { hu: 'Teljes', en: 'Full' },
       isDefault: true
     }

--- a/src/components/games/modified-mill/modified-mill.tsx
+++ b/src/components/games/modified-mill/modified-mill.tsx
@@ -42,7 +42,7 @@ export const ModifiedMill = strategyGameFactory({
       // second player (the losing side) it plays best-effort and may not always
       // punish a mistake — hence notAlwaysOptimal.
       botStrategy: smartBotStrategy,
-      generateStartBoard: generateEmptyBoard,
+      startBoards: [generateEmptyBoard()],
       label: { hu: 'Teljes', en: 'Full' },
       isDefault: true,
       notAlwaysOptimal: true

--- a/src/components/games/number-covering/number-covering.tsx
+++ b/src/components/games/number-covering/number-covering.tsx
@@ -76,14 +76,14 @@ export const NumberCovering = strategyGameFactory({
     },
     {
       botStrategy: smartBotStrategy,
-      generateStartBoard: () => range(1, 9),
+      startBoards: [range(1, 9)],
       rule: makeRule(8),
       label: { hu: '8 szám', en: '8 numbers' },
       isDefault: true
     },
     {
       botStrategy: smartBotStrategy,
-      generateStartBoard: () => range(1, 11),
+      startBoards: [range(1, 11)],
       rule: makeRule(10),
       label: { hu: '10 szám', en: '10 numbers' }
     }

--- a/src/components/games/polynomial-building/polynomial-building.tsx
+++ b/src/components/games/polynomial-building/polynomial-building.tsx
@@ -52,7 +52,7 @@ export const PolynomialBuilding = strategyGameFactory({
     },
     {
       botStrategy: smartBotStrategy,
-      generateStartBoard: (): Board => ({ a: null, b: null, c: null }),
+      startBoards: [{ a: null, b: null, c: null }],
       label: { hu: 'Teljes', en: 'Full' },
       isDefault: true
     }

--- a/src/components/games/rock-paper-scissor/bot-strategy.spec.ts
+++ b/src/components/games/rock-paper-scissor/bot-strategy.spec.ts
@@ -1,11 +1,6 @@
-import { cloneDeep } from 'lodash';
 import { smartBotStrategy } from './bot-strategy';
 import { CARDS, startBoard, moves, type Board, type Card } from './gameplay';
 import { botNextMoveArgs, makeCtx, moveValidator } from 'test-utils';
-
-// `startBoard` is shared module data; a spec that steps a board forward needs
-// its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoard);
 
 const smartBotRemoval = (board: Board, currentPlayer: number): Card =>
   botNextMoveArgs(smartBotStrategy({ board, ctx: makeCtx({ currentPlayer }) }))[0];
@@ -42,7 +37,7 @@ const optimalWinner = (board: Board, player: number): number => {
   return winner;
 };
 
-const START = freshStartBoard();
+const START = startBoard;
 
 // Every position reachable from the start, paired with the player to move.
 const reachablePositions = (): { board: Board; player: number }[] => {

--- a/src/components/games/rock-paper-scissor/bot-strategy.spec.ts
+++ b/src/components/games/rock-paper-scissor/bot-strategy.spec.ts
@@ -1,11 +1,11 @@
 import { cloneDeep } from 'lodash';
 import { smartBotStrategy } from './bot-strategy';
-import { CARDS, startBoards, moves, type Board, type Card } from './gameplay';
+import { CARDS, startBoard, moves, type Board, type Card } from './gameplay';
 import { botNextMoveArgs, makeCtx, moveValidator } from 'test-utils';
 
-// `startBoards` is shared module data; a spec that steps a board forward
-// needs its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoards[0]);
+// `startBoard` is shared module data; a spec that steps a board forward needs
+// its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoard);
 
 const smartBotRemoval = (board: Board, currentPlayer: number): Card =>
   botNextMoveArgs(smartBotStrategy({ board, ctx: makeCtx({ currentPlayer }) }))[0];

--- a/src/components/games/rock-paper-scissor/bot-strategy.spec.ts
+++ b/src/components/games/rock-paper-scissor/bot-strategy.spec.ts
@@ -1,6 +1,11 @@
+import { cloneDeep } from 'lodash';
 import { smartBotStrategy } from './bot-strategy';
-import { CARDS, generateStartBoard, moves, type Board, type Card } from './gameplay';
+import { CARDS, startBoards, moves, type Board, type Card } from './gameplay';
 import { botNextMoveArgs, makeCtx, moveValidator } from 'test-utils';
+
+// `startBoards` is shared module data; a spec that steps a board forward
+// needs its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoards[0]);
 
 const smartBotRemoval = (board: Board, currentPlayer: number): Card =>
   botNextMoveArgs(smartBotStrategy({ board, ctx: makeCtx({ currentPlayer }) }))[0];
@@ -37,7 +42,7 @@ const optimalWinner = (board: Board, player: number): number => {
   return winner;
 };
 
-const START = generateStartBoard();
+const START = freshStartBoard();
 
 // Every position reachable from the start, paired with the player to move.
 const reachablePositions = (): { board: Board; player: number }[] => {

--- a/src/components/games/rock-paper-scissor/gameplay.ts
+++ b/src/components/games/rock-paper-scissor/gameplay.ts
@@ -7,7 +7,7 @@ export type Card = typeof CARDS[number]
 // The cards each player still holds, in `CARDS` order.
 export type Board = [Card[], Card[]]
 
-export const startBoards: Board[] = [[[...CARDS], [...CARDS]]];
+export const startBoard: Board = [[...CARDS], [...CARDS]];
 
 const BEATS: Record<Card, Card> = { rock: 'scissor', paper: 'rock', scissor: 'paper' };
 

--- a/src/components/games/rock-paper-scissor/gameplay.ts
+++ b/src/components/games/rock-paper-scissor/gameplay.ts
@@ -7,7 +7,7 @@ export type Card = typeof CARDS[number]
 // The cards each player still holds, in `CARDS` order.
 export type Board = [Card[], Card[]]
 
-export const generateStartBoard = (): Board => [[...CARDS], [...CARDS]];
+export const startBoards: Board[] = [[[...CARDS], [...CARDS]]];
 
 const BEATS: Record<Card, Card> = { rock: 'scissor', paper: 'rock', scissor: 'paper' };
 

--- a/src/components/games/rock-paper-scissor/rock-paper-scissor.tsx
+++ b/src/components/games/rock-paper-scissor/rock-paper-scissor.tsx
@@ -5,7 +5,7 @@ import { RockSvg } from './symbols/rock-svg';
 import { PaperSvg } from './symbols/paper-svg';
 import { ScissorSvg } from '../shared/scissor-svg';
 import { useTranslation } from 'language';
-import { CARDS, generateStartBoard, moves, type Board, type Card } from './gameplay';
+import { CARDS, startBoards, moves, type Board, type Card } from './gameplay';
 
 const cardSvgs: Record<Card, FC> = {
   rock: RockSvg,
@@ -73,6 +73,6 @@ export const RockPaperScissor = strategyGameFactory({
   BoardClient,
   gameplay: { moves },
   variants: [
-    { botStrategy: smartBotStrategy, generateStartBoard }
+    { botStrategy: smartBotStrategy, startBoards }
   ]
 });

--- a/src/components/games/rock-paper-scissor/rock-paper-scissor.tsx
+++ b/src/components/games/rock-paper-scissor/rock-paper-scissor.tsx
@@ -5,7 +5,7 @@ import { RockSvg } from './symbols/rock-svg';
 import { PaperSvg } from './symbols/paper-svg';
 import { ScissorSvg } from '../shared/scissor-svg';
 import { useTranslation } from 'language';
-import { CARDS, startBoards, moves, type Board, type Card } from './gameplay';
+import { CARDS, startBoard, moves, type Board, type Card } from './gameplay';
 
 const cardSvgs: Record<Card, FC> = {
   rock: RockSvg,
@@ -73,6 +73,6 @@ export const RockPaperScissor = strategyGameFactory({
   BoardClient,
   gameplay: { moves },
   variants: [
-    { botStrategy: smartBotStrategy, startBoards }
+    { botStrategy: smartBotStrategy, startBoards: [startBoard] }
   ]
 });

--- a/src/components/games/shark-chase/shark-4-by-4/gameplay.ts
+++ b/src/components/games/shark-chase/shark-4-by-4/gameplay.ts
@@ -11,14 +11,12 @@ export const isGameEnd = (board: Board): boolean =>
 export const getWinnerIndex = (board: Board): number =>
   board.submarines[board.shark] >= 1 ? 0 : 1;
 
-export const generateStartBoard = (): Board => {
-  return {
-    submarines: [0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0],
-    shark: 12,
-    turn: 1,
-    sharkMovesInTurn: 0
-  };
-};
+export const startBoards: Board[] = [{
+  submarines: [0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+  shark: 12,
+  turn: 1,
+  sharkMovesInTurn: 0
+}];
 
 export const moves = {
   moveSubmarine: {

--- a/src/components/games/shark-chase/shark-4-by-4/gameplay.ts
+++ b/src/components/games/shark-chase/shark-4-by-4/gameplay.ts
@@ -11,12 +11,12 @@ export const isGameEnd = (board: Board): boolean =>
 export const getWinnerIndex = (board: Board): number =>
   board.submarines[board.shark] >= 1 ? 0 : 1;
 
-export const startBoards: Board[] = [{
-  submarines: [0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0],
-  shark: 12,
-  turn: 1,
-  sharkMovesInTurn: 0
-}];
+export const startBoard: Board = {
+submarines: [0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+shark: 12,
+turn: 1,
+sharkMovesInTurn: 0
+};
 
 export const moves = {
   moveSubmarine: {

--- a/src/components/games/shark-chase/shark-4-by-4/shark-chase.tsx
+++ b/src/components/games/shark-chase/shark-4-by-4/shark-chase.tsx
@@ -2,7 +2,7 @@ import { strategyGameFactory, type Ctx } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { makeBoardClient } from '../board-client';
 import { type Board } from '../gameplay';
-import { startBoards, moves, MAX_TURN } from './gameplay';
+import { startBoard, moves, MAX_TURN } from './gameplay';
 
 const BoardClient = makeBoardClient(MAX_TURN);
 
@@ -71,6 +71,6 @@ export const SharkChase4 = strategyGameFactory({
   gameplay: { moves },
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
-    { botStrategy: smartBotStrategy, startBoards, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
+    { botStrategy: smartBotStrategy, startBoards: [startBoard], label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/shark-chase/shark-4-by-4/shark-chase.tsx
+++ b/src/components/games/shark-chase/shark-4-by-4/shark-chase.tsx
@@ -2,7 +2,7 @@ import { strategyGameFactory, type Ctx } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { makeBoardClient } from '../board-client';
 import { type Board } from '../gameplay';
-import { generateStartBoard, moves, MAX_TURN } from './gameplay';
+import { startBoards, moves, MAX_TURN } from './gameplay';
 
 const BoardClient = makeBoardClient(MAX_TURN);
 
@@ -71,6 +71,6 @@ export const SharkChase4 = strategyGameFactory({
   gameplay: { moves },
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
-    { botStrategy: smartBotStrategy, generateStartBoard, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
+    { botStrategy: smartBotStrategy, startBoards, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/shark-chase/shark-5-by-5/gameplay.ts
+++ b/src/components/games/shark-chase/shark-5-by-5/gameplay.ts
@@ -11,20 +11,18 @@ export const isGameEnd = (board: Board): boolean =>
 export const getWinnerIndex = (board: Board): number =>
   board.submarines[board.shark] >= 1 ? 0 : 1;
 
-export const generateStartBoard = (): Board => {
-  return {
-    submarines: [
-      [0, 0, 0, 1, 1],
-      [0, 0, 0, 1, 1],
-      [0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0]
-    ].flat(),
-    shark: 20,
-    turn: 1,
-    sharkMovesInTurn: 0
-  };
-};
+export const startBoards: Board[] = [{
+  submarines: [
+    [0, 0, 0, 1, 1],
+    [0, 0, 0, 1, 1],
+    [0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0]
+  ].flat(),
+  shark: 20,
+  turn: 1,
+  sharkMovesInTurn: 0
+}];
 
 export const moves = {
   moveSubmarine: {

--- a/src/components/games/shark-chase/shark-5-by-5/gameplay.ts
+++ b/src/components/games/shark-chase/shark-5-by-5/gameplay.ts
@@ -11,18 +11,18 @@ export const isGameEnd = (board: Board): boolean =>
 export const getWinnerIndex = (board: Board): number =>
   board.submarines[board.shark] >= 1 ? 0 : 1;
 
-export const startBoards: Board[] = [{
-  submarines: [
-    [0, 0, 0, 1, 1],
-    [0, 0, 0, 1, 1],
-    [0, 0, 0, 0, 0],
-    [0, 0, 0, 0, 0],
-    [0, 0, 0, 0, 0]
-  ].flat(),
-  shark: 20,
-  turn: 1,
-  sharkMovesInTurn: 0
-}];
+export const startBoard: Board = {
+submarines: [
+  [0, 0, 0, 1, 1],
+  [0, 0, 0, 1, 1],
+  [0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0]
+].flat(),
+shark: 20,
+turn: 1,
+sharkMovesInTurn: 0
+};
 
 export const moves = {
   moveSubmarine: {

--- a/src/components/games/shark-chase/shark-5-by-5/shark-chase.tsx
+++ b/src/components/games/shark-chase/shark-5-by-5/shark-chase.tsx
@@ -2,7 +2,7 @@ import { strategyGameFactory, type Ctx } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { makeBoardClient } from '../board-client';
 import { type Board } from '../gameplay';
-import { startBoards, moves, MAX_TURN } from './gameplay';
+import { startBoard, moves, MAX_TURN } from './gameplay';
 
 const BoardClient = makeBoardClient(MAX_TURN);
 
@@ -71,6 +71,6 @@ export const SharkChase5 = strategyGameFactory({
   gameplay: { moves },
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
-    { botStrategy: smartBotStrategy, startBoards, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
+    { botStrategy: smartBotStrategy, startBoards: [startBoard], label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/shark-chase/shark-5-by-5/shark-chase.tsx
+++ b/src/components/games/shark-chase/shark-5-by-5/shark-chase.tsx
@@ -2,7 +2,7 @@ import { strategyGameFactory, type Ctx } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
 import { makeBoardClient } from '../board-client';
 import { type Board } from '../gameplay';
-import { generateStartBoard, moves, MAX_TURN } from './gameplay';
+import { startBoards, moves, MAX_TURN } from './gameplay';
 
 const BoardClient = makeBoardClient(MAX_TURN);
 
@@ -71,6 +71,6 @@ export const SharkChase5 = strategyGameFactory({
   gameplay: { moves },
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
-    { botStrategy: smartBotStrategy, generateStartBoard, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
+    { botStrategy: smartBotStrategy, startBoards, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/single-number-increase/increment-or-double/increment-or-double.tsx
+++ b/src/components/games/single-number-increase/increment-or-double/increment-or-double.tsx
@@ -57,5 +57,5 @@ export const IncrementOrDouble = strategyGameFactory({
   },
   BoardClient,
   gameplay: { moves },
-  variants: [{ botStrategy: smartBotStrategy, generateStartBoard: () => 0 }]
+  variants: [{ botStrategy: smartBotStrategy, startBoards: [0] }]
 });

--- a/src/components/games/single-number-increase/plus-one-two-three/plus-one-two-three.tsx
+++ b/src/components/games/single-number-increase/plus-one-two-three/plus-one-two-three.tsx
@@ -49,5 +49,5 @@ export const PlusOneTwoThree = strategyGameFactory({
   },
   BoardClient,
   gameplay: { moves },
-  variants: [{ botStrategy: smartBotStrategy, generateStartBoard: () => 0 }]
+  variants: [{ botStrategy: smartBotStrategy, startBoards: [0] }]
 });

--- a/src/components/games/sum-fifteen/bot-strategy.spec.ts
+++ b/src/components/games/sum-fifteen/bot-strategy.spec.ts
@@ -3,15 +3,15 @@ import { chooseSmartMove, chooseTestMove, winnerOptimal } from './bot-strategy';
 import {
   currentPlayerFromOwner,
   freeNumbers,
-  startBoards,
+  startBoard,
   hasSum15,
   numbersOwnedBy,
   type Owner
 } from './gameplay';
 
-// `startBoards` is shared module data; a spec that steps a board forward
-// needs its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoards[0]);
+// `startBoard` is shared module data; a spec that steps a board forward needs
+// its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoard);
 
 describe('winnerOptimal', () => {
   it('declares the second player the winner from the empty board (optimal play is a draw)', () => {

--- a/src/components/games/sum-fifteen/bot-strategy.spec.ts
+++ b/src/components/games/sum-fifteen/bot-strategy.spec.ts
@@ -1,17 +1,21 @@
-import { range } from 'lodash';
+import { range, cloneDeep } from 'lodash';
 import { chooseSmartMove, chooseTestMove, winnerOptimal } from './bot-strategy';
 import {
   currentPlayerFromOwner,
   freeNumbers,
-  generateStartBoard,
+  startBoards,
   hasSum15,
   numbersOwnedBy,
   type Owner
 } from './gameplay';
 
+// `startBoards` is shared module data; a spec that steps a board forward
+// needs its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoards[0]);
+
 describe('winnerOptimal', () => {
   it('declares the second player the winner from the empty board (optimal play is a draw)', () => {
-    expect(winnerOptimal(generateStartBoard().owner)).toBe(1);
+    expect(winnerOptimal(freshStartBoard().owner)).toBe(1);
   });
 
   it('lets the current player win when a triple summing to 15 is one move away', () => {
@@ -26,7 +30,7 @@ describe('winnerOptimal', () => {
 // Play out full games; assert the smart bot never loses as the second player,
 // which — since the game has no draws in the players' favour — means it wins.
 const playSmartBotVsRandom = (botPlayer: 0 | 1, rng: () => number): 0 | 1 => {
-  let owner: Owner = generateStartBoard().owner;
+  let owner: Owner = freshStartBoard().owner;
   while (true) {
     const cp = currentPlayerFromOwner(owner);
     const move = cp === botPlayer

--- a/src/components/games/sum-fifteen/bot-strategy.spec.ts
+++ b/src/components/games/sum-fifteen/bot-strategy.spec.ts
@@ -1,4 +1,4 @@
-import { range, cloneDeep } from 'lodash';
+import { range } from 'lodash';
 import { chooseSmartMove, chooseTestMove, winnerOptimal } from './bot-strategy';
 import {
   currentPlayerFromOwner,
@@ -9,13 +9,9 @@ import {
   type Owner
 } from './gameplay';
 
-// `startBoard` is shared module data; a spec that steps a board forward needs
-// its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoard);
-
 describe('winnerOptimal', () => {
   it('declares the second player the winner from the empty board (optimal play is a draw)', () => {
-    expect(winnerOptimal(freshStartBoard().owner)).toBe(1);
+    expect(winnerOptimal(startBoard.owner)).toBe(1);
   });
 
   it('lets the current player win when a triple summing to 15 is one move away', () => {
@@ -30,7 +26,7 @@ describe('winnerOptimal', () => {
 // Play out full games; assert the smart bot never loses as the second player,
 // which — since the game has no draws in the players' favour — means it wins.
 const playSmartBotVsRandom = (botPlayer: 0 | 1, rng: () => number): 0 | 1 => {
-  let owner: Owner = freshStartBoard().owner;
+  let owner: Owner = startBoard.owner;
   while (true) {
     const cp = currentPlayerFromOwner(owner);
     const move = cp === botPlayer

--- a/src/components/games/sum-fifteen/gameplay.ts
+++ b/src/components/games/sum-fifteen/gameplay.ts
@@ -7,7 +7,7 @@ export type Board = { owner: Owner }
 
 export const allNumbers = [1, 2, 3, 4, 5, 6, 7, 8, 9];
 
-export const generateStartBoard = (): Board => ({ owner: Array(9).fill(null) });
+export const startBoards: Board[] = [{ owner: Array(9).fill(null) }];
 
 export const numbersOwnedBy = (owner: Owner, player: 0 | 1): number[] =>
   allNumbers.filter(n => owner[n - 1] === player);

--- a/src/components/games/sum-fifteen/gameplay.ts
+++ b/src/components/games/sum-fifteen/gameplay.ts
@@ -7,7 +7,7 @@ export type Board = { owner: Owner }
 
 export const allNumbers = [1, 2, 3, 4, 5, 6, 7, 8, 9];
 
-export const startBoards: Board[] = [{ owner: Array(9).fill(null) }];
+export const startBoard: Board = { owner: Array(9).fill(null) };
 
 export const numbersOwnedBy = (owner: Owner, player: 0 | 1): number[] =>
   allNumbers.filter(n => owner[n - 1] === player);

--- a/src/components/games/sum-fifteen/sum-fifteen.tsx
+++ b/src/components/games/sum-fifteen/sum-fifteen.tsx
@@ -1,6 +1,6 @@
 import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { useTranslation } from 'language';
-import { allNumbers, findWinningTriple, generateStartBoard, moves, numbersOwnedBy, type Board } from './gameplay';
+import { allNumbers, findWinningTriple, startBoards, moves, numbersOwnedBy, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 const ownedLabel = (owner: Board['owner'], player: 0 | 1): string => {
@@ -103,7 +103,7 @@ export const SumFifteen = strategyGameFactory({
     },
     {
       botStrategy: smartBotStrategy,
-      generateStartBoard,
+      startBoards,
       label: { hu: 'Teljes', en: 'Full' },
       isDefault: true
     }

--- a/src/components/games/sum-fifteen/sum-fifteen.tsx
+++ b/src/components/games/sum-fifteen/sum-fifteen.tsx
@@ -1,6 +1,6 @@
 import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { useTranslation } from 'language';
-import { allNumbers, findWinningTriple, startBoards, moves, numbersOwnedBy, type Board } from './gameplay';
+import { allNumbers, findWinningTriple, startBoard, moves, numbersOwnedBy, type Board } from './gameplay';
 import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 const ownedLabel = (owner: Board['owner'], player: 0 | 1): string => {
@@ -103,7 +103,7 @@ export const SumFifteen = strategyGameFactory({
     },
     {
       botStrategy: smartBotStrategy,
-      startBoards,
+      startBoards: [startBoard],
       label: { hu: 'Teljes', en: 'Full' },
       isDefault: true
     }

--- a/src/components/games/ten-digit-number/ten-digit-number.tsx
+++ b/src/components/games/ten-digit-number/ten-digit-number.tsx
@@ -92,7 +92,7 @@ export const TenDigitNumber = strategyGameFactory({
     },
     {
       botStrategy: smartBotStrategy,
-      generateStartBoard: () => ({ digits: [], sumMod9: 0 }),
+      startBoards: [{ digits: [], sumMod9: 0 }],
       label: { hu: 'Teljes', en: 'Full' },
       isDefault: true
     }

--- a/src/components/games/thief-sheriff-mean/gameplay.ts
+++ b/src/components/games/thief-sheriff-mean/gameplay.ts
@@ -35,7 +35,7 @@ export const getUntakenCards = (board: Board, total: number) => {
 export const isCardAvailable = (board: Board, total: number, index: number): boolean =>
   getUntakenCards(board, total).includes(index);
 
-export const startBoards: Board[] = [{
-  cards: [[], []],
-  numTurns: 0
-}]
+export const startBoard: Board = {
+cards: [[], []],
+numTurns: 0
+};

--- a/src/components/games/thief-sheriff-mean/gameplay.ts
+++ b/src/components/games/thief-sheriff-mean/gameplay.ts
@@ -35,9 +35,7 @@ export const getUntakenCards = (board: Board, total: number) => {
 export const isCardAvailable = (board: Board, total: number, index: number): boolean =>
   getUntakenCards(board, total).includes(index);
 
-export const generateStartBoard = (): Board => {
-  return {
-    cards: [[], []],
-    numTurns: 0
-  };
-}
+export const startBoards: Board[] = [{
+  cards: [[], []],
+  numTurns: 0
+}]

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/bot-strategy.spec.ts
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/bot-strategy.spec.ts
@@ -1,10 +1,15 @@
+import { cloneDeep } from 'lodash';
 import { getBotCard, getBotScore } from './bot-strategy';
-import { Sheriff, Thief, generateStartBoard, type Board } from '../gameplay';
+import { Sheriff, Thief, startBoards, type Board } from '../gameplay';
+
+// `startBoards` is shared module data; a spec that steps a board forward
+// needs its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoards[0]);
 
 describe('thief-sheriff-mean-7 smart bot', () => {
   describe('as Sheriff', () => {
     it('wins from the starting position', () => {
-      expect(getBotScore(generateStartBoard(), Sheriff)).toBe(1);
+      expect(getBotScore(freshStartBoard(), Sheriff)).toBe(1);
     });
 
     it('picks 4 when holding [5] and Thief holds [2] — the unique winning second move', () => {

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/bot-strategy.spec.ts
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/bot-strategy.spec.ts
@@ -1,10 +1,10 @@
 import { cloneDeep } from 'lodash';
 import { getBotCard, getBotScore } from './bot-strategy';
-import { Sheriff, Thief, startBoards, type Board } from '../gameplay';
+import { Sheriff, Thief, startBoard, type Board } from '../gameplay';
 
-// `startBoards` is shared module data; a spec that steps a board forward
-// needs its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoards[0]);
+// `startBoard` is shared module data; a spec that steps a board forward needs
+// its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoard);
 
 describe('thief-sheriff-mean-7 smart bot', () => {
   describe('as Sheriff', () => {

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/bot-strategy.spec.ts
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/bot-strategy.spec.ts
@@ -1,15 +1,10 @@
-import { cloneDeep } from 'lodash';
 import { getBotCard, getBotScore } from './bot-strategy';
 import { Sheriff, Thief, startBoard, type Board } from '../gameplay';
-
-// `startBoard` is shared module data; a spec that steps a board forward needs
-// its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoard);
 
 describe('thief-sheriff-mean-7 smart bot', () => {
   describe('as Sheriff', () => {
     it('wins from the starting position', () => {
-      expect(getBotScore(freshStartBoard(), Sheriff)).toBe(1);
+      expect(getBotScore(startBoard, Sheriff)).toBe(1);
     });
 
     it('picks 4 when holding [5] and Thief holds [2] — the unique winning second move', () => {

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/thief-sheriff-mean-7.tsx
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/thief-sheriff-mean-7.tsx
@@ -1,6 +1,6 @@
 import { strategyGameFactory } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
-import { generateStartBoard } from '../gameplay';
+import { startBoards } from '../gameplay';
 import { makeBoardClient } from '../board-client';
 import { moves, CARD_COUNT } from './gameplay';
 
@@ -47,6 +47,6 @@ export const ThiefSheriffMean7 = strategyGameFactory({
   gameplay: { moves },
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
-    { botStrategy: smartBotStrategy, generateStartBoard, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
+    { botStrategy: smartBotStrategy, startBoards, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/thief-sheriff-mean-7.tsx
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-7/thief-sheriff-mean-7.tsx
@@ -1,6 +1,6 @@
 import { strategyGameFactory } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
-import { startBoards } from '../gameplay';
+import { startBoard } from '../gameplay';
 import { makeBoardClient } from '../board-client';
 import { moves, CARD_COUNT } from './gameplay';
 
@@ -47,6 +47,6 @@ export const ThiefSheriffMean7 = strategyGameFactory({
   gameplay: { moves },
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
-    { botStrategy: smartBotStrategy, startBoards, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
+    { botStrategy: smartBotStrategy, startBoards: [startBoard], label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/bot-strategy.spec.ts
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/bot-strategy.spec.ts
@@ -1,19 +1,14 @@
-import { cloneDeep } from 'lodash';
 import { getBotCard, getBotScore } from './bot-strategy';
 import { Sheriff, Thief, startBoard, type Board } from '../gameplay';
-
-// `startBoard` is shared module data; a spec that steps a board forward needs
-// its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoard);
 
 describe('thief-sheriff-mean-9 smart bot', () => {
   describe('as Sheriff', () => {
     it('wins from the starting position', () => {
-      expect(getBotScore(freshStartBoard(), Sheriff)).toBe(1);
+      expect(getBotScore(startBoard, Sheriff)).toBe(1);
     });
 
     it('picks 5 as the unique winning opening move', () => {
-      expect(getBotCard(freshStartBoard(), Sheriff)).toBe(5);
+      expect(getBotCard(startBoard, Sheriff)).toBe(5);
     });
 
     it('picks 4 when Thief took a card from {1,2,3,6}', () => {

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/bot-strategy.spec.ts
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/bot-strategy.spec.ts
@@ -1,10 +1,10 @@
 import { cloneDeep } from 'lodash';
 import { getBotCard, getBotScore } from './bot-strategy';
-import { Sheriff, Thief, startBoards, type Board } from '../gameplay';
+import { Sheriff, Thief, startBoard, type Board } from '../gameplay';
 
-// `startBoards` is shared module data; a spec that steps a board forward
-// needs its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoards[0]);
+// `startBoard` is shared module data; a spec that steps a board forward needs
+// its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoard);
 
 describe('thief-sheriff-mean-9 smart bot', () => {
   describe('as Sheriff', () => {

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/bot-strategy.spec.ts
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/bot-strategy.spec.ts
@@ -1,14 +1,19 @@
+import { cloneDeep } from 'lodash';
 import { getBotCard, getBotScore } from './bot-strategy';
-import { Sheriff, Thief, generateStartBoard, type Board } from '../gameplay';
+import { Sheriff, Thief, startBoards, type Board } from '../gameplay';
+
+// `startBoards` is shared module data; a spec that steps a board forward
+// needs its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoards[0]);
 
 describe('thief-sheriff-mean-9 smart bot', () => {
   describe('as Sheriff', () => {
     it('wins from the starting position', () => {
-      expect(getBotScore(generateStartBoard(), Sheriff)).toBe(1);
+      expect(getBotScore(freshStartBoard(), Sheriff)).toBe(1);
     });
 
     it('picks 5 as the unique winning opening move', () => {
-      expect(getBotCard(generateStartBoard(), Sheriff)).toBe(5);
+      expect(getBotCard(freshStartBoard(), Sheriff)).toBe(5);
     });
 
     it('picks 4 when Thief took a card from {1,2,3,6}', () => {

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/thief-sheriff-mean-9.tsx
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/thief-sheriff-mean-9.tsx
@@ -1,6 +1,6 @@
 import { strategyGameFactory } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
-import { startBoards } from '../gameplay';
+import { startBoard } from '../gameplay';
 import { makeBoardClient } from '../board-client';
 import { moves, CARD_COUNT } from './gameplay';
 
@@ -36,6 +36,6 @@ export const ThiefSheriffMean9 = strategyGameFactory({
   gameplay: { moves },
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
-    { botStrategy: smartBotStrategy, startBoards, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
+    { botStrategy: smartBotStrategy, startBoards: [startBoard], label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/thief-sheriff-mean-9.tsx
+++ b/src/components/games/thief-sheriff-mean/thief-sheriff-mean-9/thief-sheriff-mean-9.tsx
@@ -1,6 +1,6 @@
 import { strategyGameFactory } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
-import { generateStartBoard } from '../gameplay';
+import { startBoards } from '../gameplay';
 import { makeBoardClient } from '../board-client';
 import { moves, CARD_COUNT } from './gameplay';
 
@@ -36,6 +36,6 @@ export const ThiefSheriffMean9 = strategyGameFactory({
   gameplay: { moves },
   variants: [
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
-    { botStrategy: smartBotStrategy, generateStartBoard, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
+    { botStrategy: smartBotStrategy, startBoards, label: { hu: 'Teljes', en: 'Full' }, isDefault: true }
   ]
 });

--- a/src/components/games/tictactoe-alikes/anti-tictactoe/anti-tictactoe.tsx
+++ b/src/components/games/tictactoe-alikes/anti-tictactoe/anti-tictactoe.tsx
@@ -31,7 +31,7 @@ export const AntiTicTacToe = strategyGameFactory({
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
     {
       botStrategy: smartBotStrategy,
-      generateStartBoard: generateEmptyTicTacToeBoard,
+      startBoards: [generateEmptyTicTacToeBoard()],
       label: { hu: 'Teljes', en: 'Full' },
       isDefault: true
     }

--- a/src/components/games/tictactoe-alikes/tictactoe-doublestart/tictactoe-doublestart.tsx
+++ b/src/components/games/tictactoe-alikes/tictactoe-doublestart/tictactoe-doublestart.tsx
@@ -45,7 +45,7 @@ export const TicTacToeDoubleStart = strategyGameFactory({
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
     {
       botStrategy: smartBotStrategy,
-      generateStartBoard: generateEmptyTicTacToeBoard,
+      startBoards: [generateEmptyTicTacToeBoard()],
       label: { hu: 'Teljes', en: 'Full' },
       isDefault: true
     }

--- a/src/components/games/tictactoe-alikes/tictactoe/tictactoe.tsx
+++ b/src/components/games/tictactoe-alikes/tictactoe/tictactoe.tsx
@@ -95,7 +95,7 @@ export const TicTacToe = strategyGameFactory({
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
     {
       botStrategy: smartBotStrategy,
-      generateStartBoard: generateEmptyTicTacToeBoard,
+      startBoards: [generateEmptyTicTacToeBoard()],
       label: { hu: 'Teljes', en: 'Full' },
       isDefault: true
     }

--- a/src/components/games/totem-poles/triangular-grid-ropes-10/triangular-grid-ropes-10.tsx
+++ b/src/components/games/totem-poles/triangular-grid-ropes-10/triangular-grid-ropes-10.tsx
@@ -136,7 +136,7 @@ export const TriangularGridRopes = strategyGameFactory({
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
     {
       botStrategy: smartBotStrategy,
-      generateStartBoard: (): Board => [],
+      startBoards: [[]],
       label: { hu: 'Teljes', en: 'Full' },
       isDefault: true
     }

--- a/src/components/games/totem-poles/triangular-grid-ropes-15/triangular-grid-ropes-15.tsx
+++ b/src/components/games/totem-poles/triangular-grid-ropes-15/triangular-grid-ropes-15.tsx
@@ -136,7 +136,7 @@ export const TriangularGridRopes15 = strategyGameFactory({
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
     {
       botStrategy: smartBotStrategy,
-      generateStartBoard: (): Board => [],
+      startBoards: [[]],
       label: { hu: 'Teljes', en: 'Full' },
       isDefault: true
     }

--- a/src/components/games/triangle-circle-game/gameplay.spec.ts
+++ b/src/components/games/triangle-circle-game/gameplay.spec.ts
@@ -7,7 +7,7 @@ import {
   applyShade,
   freeEdges,
   freeTriangles,
-  startBoards,
+  startBoard,
   isCircleWin,
   isLineWin,
   isWinningShade,
@@ -19,9 +19,9 @@ import {
 } from './gameplay';
 import { makeCtx, moveValidator } from 'test-utils';
 
-// `startBoards` is shared module data; a spec that steps a board forward
-// needs its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoards[0]);
+// `startBoard` is shared module data; a spec that steps a board forward needs
+// its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoard);
 
 const isShadeAllowed = moveValidator(moves.shadeEdge, makeCtx({ currentPlayer: LINE }));
 const isCirclePlacementAllowed = moveValidator(moves.placeCircle, makeCtx({ currentPlayer: CIRCLE }));

--- a/src/components/games/triangle-circle-game/gameplay.spec.ts
+++ b/src/components/games/triangle-circle-game/gameplay.spec.ts
@@ -1,3 +1,4 @@
+import { cloneDeep } from 'lodash';
 import { EDGES, TRIANGLES, TRIANGLE_COUNT } from './geometry';
 import {
   CIRCLE,
@@ -6,7 +7,7 @@ import {
   applyShade,
   freeEdges,
   freeTriangles,
-  generateStartBoard,
+  startBoards,
   isCircleWin,
   isLineWin,
   isWinningShade,
@@ -18,12 +19,16 @@ import {
 } from './gameplay';
 import { makeCtx, moveValidator } from 'test-utils';
 
+// `startBoards` is shared module data; a spec that steps a board forward
+// needs its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoards[0]);
+
 const isShadeAllowed = moveValidator(moves.shadeEdge, makeCtx({ currentPlayer: LINE }));
 const isCirclePlacementAllowed = moveValidator(moves.placeCircle, makeCtx({ currentPlayer: CIRCLE }));
 
 // Shade the three edges of a triangle on a fresh board.
 const boardWithFullTriangle = (t: number): Board => {
-  let board = generateStartBoard();
+  let board = freshStartBoard();
   for (const e of TRIANGLES[t].edgeIds) board = applyShade(board, e);
   return board;
 };
@@ -34,7 +39,7 @@ const preThreatSetup = () => {
   const edge = EDGES.find(e => e.triangleIds.length === 2)!;
   const [t1, t2] = edge.triangleIds;
   const otherEdge = (t: number) => TRIANGLES[t].edgeIds.find(e => e !== edge.id)!;
-  let board = generateStartBoard();
+  let board = freshStartBoard();
   board = applyShade(board, otherEdge(t1));
   board = applyShade(board, otherEdge(t2));
   return { board, edge: edge.id, t1, t2 };
@@ -42,7 +47,7 @@ const preThreatSetup = () => {
 
 describe('start board', () => {
   it('has no shaded edges and no circles', () => {
-    const board = generateStartBoard();
+    const board = freshStartBoard();
     expect(board.edges).toHaveLength(63);
     expect(board.circles).toHaveLength(36);
     expect(board.edges.some(Boolean)).toBe(false);
@@ -65,7 +70,7 @@ describe('win detection', () => {
   });
 
   it('circle wins only once every triangle is circled', () => {
-    let board = generateStartBoard();
+    let board = freshStartBoard();
     expect(isCircleWin(board)).toBe(false);
     board = { edges: board.edges, circles: new Array(36).fill(true) };
     expect(isCircleWin(board)).toBe(true);
@@ -74,7 +79,7 @@ describe('win detection', () => {
   it('a nearly-complete circle board is not yet a win', () => {
     const circles = new Array(36).fill(true);
     circles[17] = false;
-    expect(isCircleWin({ edges: generateStartBoard().edges, circles })).toBe(false);
+    expect(isCircleWin({ edges: freshStartBoard().edges, circles })).toBe(false);
   });
 });
 
@@ -82,7 +87,7 @@ describe('threat vocabulary', () => {
   it('isWinningShade is true exactly for the third edge of an un-circled 2-edge triangle', () => {
     const t = 5;
     const [e0, e1, e2] = TRIANGLES[t].edgeIds;
-    let board = generateStartBoard();
+    let board = freshStartBoard();
     board = applyShade(board, e0);
     board = applyShade(board, e1);
     expect(isWinningShade(board, e2)).toBe(true);
@@ -93,7 +98,7 @@ describe('threat vocabulary', () => {
   it('a 2-edge un-circled triangle is a live threat; circling it clears the threat', () => {
     const t = 5;
     const [e0, e1] = TRIANGLES[t].edgeIds;
-    let board = applyShade(applyShade(generateStartBoard(), e0), e1);
+    let board = applyShade(applyShade(freshStartBoard(), e0), e1);
     expect(liveThreats(board)).toContain(t);
     board = applyCircle(board, t);
     expect(liveThreats(board)).not.toContain(t);
@@ -110,7 +115,7 @@ describe('threat vocabulary', () => {
   });
 
   it('allows shading a free edge and refuses an already shaded or non-existent one', () => {
-    const board = applyShade(generateStartBoard(), 3);
+    const board = applyShade(freshStartBoard(), 3);
     expect(isShadeAllowed(board, 4)).toBe(true);
     expect(isShadeAllowed(board, 3)).toBe(false);
     expect(isShadeAllowed(board, -1)).toBe(false);
@@ -118,7 +123,7 @@ describe('threat vocabulary', () => {
   });
 
   it('allows circling a free triangle and refuses an already circled or non-existent one', () => {
-    const board = applyCircle(generateStartBoard(), 2);
+    const board = applyCircle(freshStartBoard(), 2);
     expect(isCirclePlacementAllowed(board, 1)).toBe(true);
     expect(isCirclePlacementAllowed(board, 2)).toBe(false);
     expect(isCirclePlacementAllowed(board, -1)).toBe(false);
@@ -126,7 +131,7 @@ describe('threat vocabulary', () => {
   });
 
   it('agrees with the free-edge and free-triangle listings', () => {
-    const board = applyCircle(applyShade(generateStartBoard(), 3), 2);
+    const board = applyCircle(applyShade(freshStartBoard(), 3), 2);
     expect(freeEdges(board).every(e => isShadeAllowed(board, e))).toBe(true);
     expect(freeTriangles(board).every(t => isCirclePlacementAllowed(board, t))).toBe(true);
   });
@@ -136,7 +141,7 @@ const meta = { ctx: makeCtx() };
 
 describe('moves.shadeEdge', () => {
   it('shades the edge and passes the turn', () => {
-    const outcome = moves.shadeEdge.apply(generateStartBoard(), meta, 0);
+    const outcome = moves.shadeEdge.apply(freshStartBoard(), meta, 0);
     expect(outcome.nextBoard.edges[0]).toBe(true);
     expect(outcome.isTurnEnd).toBe(true);
     expect(outcome.gameEnd).toBeUndefined();
@@ -144,7 +149,7 @@ describe('moves.shadeEdge', () => {
 
   it('ends the game for the line player when it completes an un-circled triangle', () => {
     const [e0, e1, e2] = TRIANGLES[0].edgeIds;
-    const board = applyShade(applyShade(generateStartBoard(), e0), e1);
+    const board = applyShade(applyShade(freshStartBoard(), e0), e1);
     const outcome = moves.shadeEdge.apply(board, meta, e2);
     expect(outcome.gameEnd).toEqual({ winnerIndex: LINE });
     expect(outcome.isTurnEnd).toBeUndefined();
@@ -152,7 +157,7 @@ describe('moves.shadeEdge', () => {
 
   it('only passes the turn when the completed triangle is circled', () => {
     const [e0, e1, e2] = TRIANGLES[0].edgeIds;
-    const board = applyCircle(applyShade(applyShade(generateStartBoard(), e0), e1), 0);
+    const board = applyCircle(applyShade(applyShade(freshStartBoard(), e0), e1), 0);
     const outcome = moves.shadeEdge.apply(board, meta, e2);
     expect(outcome.isTurnEnd).toBe(true);
     expect(outcome.gameEnd).toBeUndefined();
@@ -161,7 +166,7 @@ describe('moves.shadeEdge', () => {
 
 describe('moves.placeCircle', () => {
   it('places the circle and passes the turn', () => {
-    const outcome = moves.placeCircle.apply(generateStartBoard(), meta, 7);
+    const outcome = moves.placeCircle.apply(freshStartBoard(), meta, 7);
     expect(outcome.nextBoard.circles[7]).toBe(true);
     expect(outcome.isTurnEnd).toBe(true);
     expect(outcome.gameEnd).toBeUndefined();
@@ -170,7 +175,7 @@ describe('moves.placeCircle', () => {
   it('ends the game for the circle player when the last triangle gets circled', () => {
     const circles = new Array(TRIANGLE_COUNT).fill(true);
     circles[12] = false;
-    const board = { edges: generateStartBoard().edges, circles };
+    const board = { edges: freshStartBoard().edges, circles };
     const outcome = moves.placeCircle.apply(board, meta, 12);
     expect(outcome.gameEnd).toEqual({ winnerIndex: CIRCLE });
     expect(outcome.isTurnEnd).toBeUndefined();

--- a/src/components/games/triangle-circle-game/gameplay.spec.ts
+++ b/src/components/games/triangle-circle-game/gameplay.spec.ts
@@ -1,4 +1,3 @@
-import { cloneDeep } from 'lodash';
 import { EDGES, TRIANGLES, TRIANGLE_COUNT } from './geometry';
 import {
   CIRCLE,
@@ -19,16 +18,12 @@ import {
 } from './gameplay';
 import { makeCtx, moveValidator } from 'test-utils';
 
-// `startBoard` is shared module data; a spec that steps a board forward needs
-// its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoard);
-
 const isShadeAllowed = moveValidator(moves.shadeEdge, makeCtx({ currentPlayer: LINE }));
 const isCirclePlacementAllowed = moveValidator(moves.placeCircle, makeCtx({ currentPlayer: CIRCLE }));
 
 // Shade the three edges of a triangle on a fresh board.
 const boardWithFullTriangle = (t: number): Board => {
-  let board = freshStartBoard();
+  let board = startBoard;
   for (const e of TRIANGLES[t].edgeIds) board = applyShade(board, e);
   return board;
 };
@@ -39,7 +34,7 @@ const preThreatSetup = () => {
   const edge = EDGES.find(e => e.triangleIds.length === 2)!;
   const [t1, t2] = edge.triangleIds;
   const otherEdge = (t: number) => TRIANGLES[t].edgeIds.find(e => e !== edge.id)!;
-  let board = freshStartBoard();
+  let board = startBoard;
   board = applyShade(board, otherEdge(t1));
   board = applyShade(board, otherEdge(t2));
   return { board, edge: edge.id, t1, t2 };
@@ -47,7 +42,7 @@ const preThreatSetup = () => {
 
 describe('start board', () => {
   it('has no shaded edges and no circles', () => {
-    const board = freshStartBoard();
+    const board = startBoard;
     expect(board.edges).toHaveLength(63);
     expect(board.circles).toHaveLength(36);
     expect(board.edges.some(Boolean)).toBe(false);
@@ -70,7 +65,7 @@ describe('win detection', () => {
   });
 
   it('circle wins only once every triangle is circled', () => {
-    let board = freshStartBoard();
+    let board = startBoard;
     expect(isCircleWin(board)).toBe(false);
     board = { edges: board.edges, circles: new Array(36).fill(true) };
     expect(isCircleWin(board)).toBe(true);
@@ -79,7 +74,7 @@ describe('win detection', () => {
   it('a nearly-complete circle board is not yet a win', () => {
     const circles = new Array(36).fill(true);
     circles[17] = false;
-    expect(isCircleWin({ edges: freshStartBoard().edges, circles })).toBe(false);
+    expect(isCircleWin({ edges: startBoard.edges, circles })).toBe(false);
   });
 });
 
@@ -87,7 +82,7 @@ describe('threat vocabulary', () => {
   it('isWinningShade is true exactly for the third edge of an un-circled 2-edge triangle', () => {
     const t = 5;
     const [e0, e1, e2] = TRIANGLES[t].edgeIds;
-    let board = freshStartBoard();
+    let board = startBoard;
     board = applyShade(board, e0);
     board = applyShade(board, e1);
     expect(isWinningShade(board, e2)).toBe(true);
@@ -98,7 +93,7 @@ describe('threat vocabulary', () => {
   it('a 2-edge un-circled triangle is a live threat; circling it clears the threat', () => {
     const t = 5;
     const [e0, e1] = TRIANGLES[t].edgeIds;
-    let board = applyShade(applyShade(freshStartBoard(), e0), e1);
+    let board = applyShade(applyShade(startBoard, e0), e1);
     expect(liveThreats(board)).toContain(t);
     board = applyCircle(board, t);
     expect(liveThreats(board)).not.toContain(t);
@@ -115,7 +110,7 @@ describe('threat vocabulary', () => {
   });
 
   it('allows shading a free edge and refuses an already shaded or non-existent one', () => {
-    const board = applyShade(freshStartBoard(), 3);
+    const board = applyShade(startBoard, 3);
     expect(isShadeAllowed(board, 4)).toBe(true);
     expect(isShadeAllowed(board, 3)).toBe(false);
     expect(isShadeAllowed(board, -1)).toBe(false);
@@ -123,7 +118,7 @@ describe('threat vocabulary', () => {
   });
 
   it('allows circling a free triangle and refuses an already circled or non-existent one', () => {
-    const board = applyCircle(freshStartBoard(), 2);
+    const board = applyCircle(startBoard, 2);
     expect(isCirclePlacementAllowed(board, 1)).toBe(true);
     expect(isCirclePlacementAllowed(board, 2)).toBe(false);
     expect(isCirclePlacementAllowed(board, -1)).toBe(false);
@@ -131,7 +126,7 @@ describe('threat vocabulary', () => {
   });
 
   it('agrees with the free-edge and free-triangle listings', () => {
-    const board = applyCircle(applyShade(freshStartBoard(), 3), 2);
+    const board = applyCircle(applyShade(startBoard, 3), 2);
     expect(freeEdges(board).every(e => isShadeAllowed(board, e))).toBe(true);
     expect(freeTriangles(board).every(t => isCirclePlacementAllowed(board, t))).toBe(true);
   });
@@ -141,7 +136,7 @@ const meta = { ctx: makeCtx() };
 
 describe('moves.shadeEdge', () => {
   it('shades the edge and passes the turn', () => {
-    const outcome = moves.shadeEdge.apply(freshStartBoard(), meta, 0);
+    const outcome = moves.shadeEdge.apply(startBoard, meta, 0);
     expect(outcome.nextBoard.edges[0]).toBe(true);
     expect(outcome.isTurnEnd).toBe(true);
     expect(outcome.gameEnd).toBeUndefined();
@@ -149,7 +144,7 @@ describe('moves.shadeEdge', () => {
 
   it('ends the game for the line player when it completes an un-circled triangle', () => {
     const [e0, e1, e2] = TRIANGLES[0].edgeIds;
-    const board = applyShade(applyShade(freshStartBoard(), e0), e1);
+    const board = applyShade(applyShade(startBoard, e0), e1);
     const outcome = moves.shadeEdge.apply(board, meta, e2);
     expect(outcome.gameEnd).toEqual({ winnerIndex: LINE });
     expect(outcome.isTurnEnd).toBeUndefined();
@@ -157,7 +152,7 @@ describe('moves.shadeEdge', () => {
 
   it('only passes the turn when the completed triangle is circled', () => {
     const [e0, e1, e2] = TRIANGLES[0].edgeIds;
-    const board = applyCircle(applyShade(applyShade(freshStartBoard(), e0), e1), 0);
+    const board = applyCircle(applyShade(applyShade(startBoard, e0), e1), 0);
     const outcome = moves.shadeEdge.apply(board, meta, e2);
     expect(outcome.isTurnEnd).toBe(true);
     expect(outcome.gameEnd).toBeUndefined();
@@ -166,7 +161,7 @@ describe('moves.shadeEdge', () => {
 
 describe('moves.placeCircle', () => {
   it('places the circle and passes the turn', () => {
-    const outcome = moves.placeCircle.apply(freshStartBoard(), meta, 7);
+    const outcome = moves.placeCircle.apply(startBoard, meta, 7);
     expect(outcome.nextBoard.circles[7]).toBe(true);
     expect(outcome.isTurnEnd).toBe(true);
     expect(outcome.gameEnd).toBeUndefined();
@@ -175,7 +170,7 @@ describe('moves.placeCircle', () => {
   it('ends the game for the circle player when the last triangle gets circled', () => {
     const circles = new Array(TRIANGLE_COUNT).fill(true);
     circles[12] = false;
-    const board = { edges: freshStartBoard().edges, circles };
+    const board = { edges: startBoard.edges, circles };
     const outcome = moves.placeCircle.apply(board, meta, 12);
     expect(outcome.gameEnd).toEqual({ winnerIndex: CIRCLE });
     expect(outcome.isTurnEnd).toBeUndefined();

--- a/src/components/games/triangle-circle-game/gameplay.ts
+++ b/src/components/games/triangle-circle-game/gameplay.ts
@@ -12,10 +12,10 @@ export interface Board {
 export const LINE = 0;
 export const CIRCLE = 1;
 
-export const startBoards: Board[] = [{
-  edges: new Array(EDGE_COUNT).fill(false),
-  circles: new Array(TRIANGLE_COUNT).fill(false)
-}];
+export const startBoard: Board = {
+edges: new Array(EDGE_COUNT).fill(false),
+circles: new Array(TRIANGLE_COUNT).fill(false)
+};
 
 // How many of a triangle's three edges are shaded.
 export const shadedCount = (board: Board, triangleId: number): number =>

--- a/src/components/games/triangle-circle-game/gameplay.ts
+++ b/src/components/games/triangle-circle-game/gameplay.ts
@@ -12,10 +12,10 @@ export interface Board {
 export const LINE = 0;
 export const CIRCLE = 1;
 
-export const generateStartBoard = (): Board => ({
+export const startBoards: Board[] = [{
   edges: new Array(EDGE_COUNT).fill(false),
   circles: new Array(TRIANGLE_COUNT).fill(false)
-});
+}];
 
 // How many of a triangle's three edges are shaded.
 export const shadedCount = (board: Board, triangleId: number): number =>

--- a/src/components/games/triangle-circle-game/strategy/bot-strategy.spec.ts
+++ b/src/components/games/triangle-circle-game/strategy/bot-strategy.spec.ts
@@ -2,15 +2,15 @@ import { cloneDeep } from 'lodash';
 import { EDGES, TRIANGLES } from '../geometry';
 import {
   LINE, CIRCLE,
-  startBoards, applyShade, applyCircle,
+  startBoard, applyShade, applyCircle,
   isLineWin, isCircleWin, isWinningShade, liveThreats, preThreatEdges
 } from '../gameplay';
 import { smartBotStrategy, randomBotStrategy, makeSmartBotStrategy } from './bot-strategy';
 import { playBotTurn } from './spec-helpers';
 
-// `startBoards` is shared module data; a spec that steps a board forward
-// needs its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoards[0]);
+// `startBoard` is shared module data; a spec that steps a board forward needs
+// its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoard);
 
 // Cheap search budget so full-game simulations stay fast in CI.
 const fastBot = makeSmartBotStrategy({ depth: 6, budget: 2000 });

--- a/src/components/games/triangle-circle-game/strategy/bot-strategy.spec.ts
+++ b/src/components/games/triangle-circle-game/strategy/bot-strategy.spec.ts
@@ -1,11 +1,16 @@
+import { cloneDeep } from 'lodash';
 import { EDGES, TRIANGLES } from '../geometry';
 import {
   LINE, CIRCLE,
-  generateStartBoard, applyShade, applyCircle,
+  startBoards, applyShade, applyCircle,
   isLineWin, isCircleWin, isWinningShade, liveThreats, preThreatEdges
 } from '../gameplay';
 import { smartBotStrategy, randomBotStrategy, makeSmartBotStrategy } from './bot-strategy';
 import { playBotTurn } from './spec-helpers';
+
+// `startBoards` is shared module data; a spec that steps a board forward
+// needs its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoards[0]);
 
 // Cheap search budget so full-game simulations stay fast in CI.
 const fastBot = makeSmartBotStrategy({ depth: 6, budget: 2000 });
@@ -16,7 +21,7 @@ describe('line-player bot', () => {
   it('takes an immediate win when a triangle has two shaded edges and no circle', () => {
     const t = 5;
     const [e0, e1, e2] = TRIANGLES[t].edgeIds;
-    const board = applyShade(applyShade(generateStartBoard(), e0), e1);
+    const board = applyShade(applyShade(freshStartBoard(), e0), e1);
     const played = playBotTurn(board, LINE, smartBotStrategy);
     expect(played.move).toBe('shadeEdge');
     expect(played.arg).toBe(e2);
@@ -26,7 +31,7 @@ describe('line-player bot', () => {
   it('creates a double threat when it can (plays a pre-threat edge)', () => {
     const edge = EDGES.find(e => e.triangleIds.length === 2)!;
     const [t1, t2] = edge.triangleIds;
-    let board = generateStartBoard();
+    let board = freshStartBoard();
     board = applyShade(board, otherEdge(t1, edge.id));
     board = applyShade(board, otherEdge(t2, edge.id));
     // No immediate win available, but shading `edge` makes two live threats.
@@ -37,7 +42,7 @@ describe('line-player bot', () => {
   });
 
   it('always plays a legal (still-free) edge', () => {
-    const board = applyShade(generateStartBoard(), 0);
+    const board = applyShade(freshStartBoard(), 0);
     const played = playBotTurn(board, LINE, smartBotStrategy);
     expect(board.edges[played.arg]).toBe(false);
   });
@@ -47,7 +52,7 @@ describe('circle-player bot', () => {
   it('covers the sole live threat', () => {
     const t = 8;
     const [e0, e1] = TRIANGLES[t].edgeIds;
-    const board = applyShade(applyShade(generateStartBoard(), e0), e1);
+    const board = applyShade(applyShade(freshStartBoard(), e0), e1);
     const played = playBotTurn(board, CIRCLE, smartBotStrategy);
     expect(played.move).toBe('placeCircle');
     expect(played.arg).toBe(t);
@@ -57,7 +62,7 @@ describe('circle-player bot', () => {
   it('defuses a pre-threat edge by circling one of its triangles', () => {
     const edge = EDGES.find(e => e.triangleIds.length === 2)!;
     const [t1, t2] = edge.triangleIds;
-    let board = generateStartBoard();
+    let board = freshStartBoard();
     board = applyShade(board, otherEdge(t1, edge.id));
     board = applyShade(board, otherEdge(t2, edge.id));
     expect(liveThreats(board)).toHaveLength(0);
@@ -68,7 +73,7 @@ describe('circle-player bot', () => {
   });
 
   it('always circles a still-empty triangle', () => {
-    const board = applyCircle(generateStartBoard(), 0);
+    const board = applyCircle(freshStartBoard(), 0);
     const played = playBotTurn(board, CIRCLE, smartBotStrategy);
     expect(board.circles[played.arg]).toBe(false);
   });
@@ -77,7 +82,7 @@ describe('circle-player bot', () => {
 describe('test bot', () => {
   it('takes an immediate win as the line player even though it otherwise plays randomly', () => {
     const [e0, e1, e2] = TRIANGLES[5].edgeIds;
-    const board = applyShade(applyShade(generateStartBoard(), e0), e1);
+    const board = applyShade(applyShade(freshStartBoard(), e0), e1);
     const played = playBotTurn(board, LINE, randomBotStrategy);
     expect(played.arg).toBe(e2);
     expect(isLineWin(played.nextBoard)).toBe(true);
@@ -86,7 +91,7 @@ describe('test bot', () => {
 
 describe('full playthroughs terminate with a valid winner', () => {
   const simulate = (lineStrategy: typeof smartBotStrategy, circleStrategy: typeof smartBotStrategy) => {
-    let board = generateStartBoard();
+    let board = freshStartBoard();
     let player = LINE;
     for (let turn = 0; turn < 200; turn++) {
       const played = playBotTurn(board, player, player === LINE ? lineStrategy : circleStrategy);

--- a/src/components/games/triangle-circle-game/strategy/bot-strategy.spec.ts
+++ b/src/components/games/triangle-circle-game/strategy/bot-strategy.spec.ts
@@ -1,4 +1,3 @@
-import { cloneDeep } from 'lodash';
 import { EDGES, TRIANGLES } from '../geometry';
 import {
   LINE, CIRCLE,
@@ -7,10 +6,6 @@ import {
 } from '../gameplay';
 import { smartBotStrategy, randomBotStrategy, makeSmartBotStrategy } from './bot-strategy';
 import { playBotTurn } from './spec-helpers';
-
-// `startBoard` is shared module data; a spec that steps a board forward needs
-// its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoard);
 
 // Cheap search budget so full-game simulations stay fast in CI.
 const fastBot = makeSmartBotStrategy({ depth: 6, budget: 2000 });
@@ -21,7 +16,7 @@ describe('line-player bot', () => {
   it('takes an immediate win when a triangle has two shaded edges and no circle', () => {
     const t = 5;
     const [e0, e1, e2] = TRIANGLES[t].edgeIds;
-    const board = applyShade(applyShade(freshStartBoard(), e0), e1);
+    const board = applyShade(applyShade(startBoard, e0), e1);
     const played = playBotTurn(board, LINE, smartBotStrategy);
     expect(played.move).toBe('shadeEdge');
     expect(played.arg).toBe(e2);
@@ -31,7 +26,7 @@ describe('line-player bot', () => {
   it('creates a double threat when it can (plays a pre-threat edge)', () => {
     const edge = EDGES.find(e => e.triangleIds.length === 2)!;
     const [t1, t2] = edge.triangleIds;
-    let board = freshStartBoard();
+    let board = startBoard;
     board = applyShade(board, otherEdge(t1, edge.id));
     board = applyShade(board, otherEdge(t2, edge.id));
     // No immediate win available, but shading `edge` makes two live threats.
@@ -42,7 +37,7 @@ describe('line-player bot', () => {
   });
 
   it('always plays a legal (still-free) edge', () => {
-    const board = applyShade(freshStartBoard(), 0);
+    const board = applyShade(startBoard, 0);
     const played = playBotTurn(board, LINE, smartBotStrategy);
     expect(board.edges[played.arg]).toBe(false);
   });
@@ -52,7 +47,7 @@ describe('circle-player bot', () => {
   it('covers the sole live threat', () => {
     const t = 8;
     const [e0, e1] = TRIANGLES[t].edgeIds;
-    const board = applyShade(applyShade(freshStartBoard(), e0), e1);
+    const board = applyShade(applyShade(startBoard, e0), e1);
     const played = playBotTurn(board, CIRCLE, smartBotStrategy);
     expect(played.move).toBe('placeCircle');
     expect(played.arg).toBe(t);
@@ -62,7 +57,7 @@ describe('circle-player bot', () => {
   it('defuses a pre-threat edge by circling one of its triangles', () => {
     const edge = EDGES.find(e => e.triangleIds.length === 2)!;
     const [t1, t2] = edge.triangleIds;
-    let board = freshStartBoard();
+    let board = startBoard;
     board = applyShade(board, otherEdge(t1, edge.id));
     board = applyShade(board, otherEdge(t2, edge.id));
     expect(liveThreats(board)).toHaveLength(0);
@@ -73,7 +68,7 @@ describe('circle-player bot', () => {
   });
 
   it('always circles a still-empty triangle', () => {
-    const board = applyCircle(freshStartBoard(), 0);
+    const board = applyCircle(startBoard, 0);
     const played = playBotTurn(board, CIRCLE, smartBotStrategy);
     expect(board.circles[played.arg]).toBe(false);
   });
@@ -82,7 +77,7 @@ describe('circle-player bot', () => {
 describe('test bot', () => {
   it('takes an immediate win as the line player even though it otherwise plays randomly', () => {
     const [e0, e1, e2] = TRIANGLES[5].edgeIds;
-    const board = applyShade(applyShade(freshStartBoard(), e0), e1);
+    const board = applyShade(applyShade(startBoard, e0), e1);
     const played = playBotTurn(board, LINE, randomBotStrategy);
     expect(played.arg).toBe(e2);
     expect(isLineWin(played.nextBoard)).toBe(true);
@@ -91,7 +86,7 @@ describe('test bot', () => {
 
 describe('full playthroughs terminate with a valid winner', () => {
   const simulate = (lineStrategy: typeof smartBotStrategy, circleStrategy: typeof smartBotStrategy) => {
-    let board = freshStartBoard();
+    let board = startBoard;
     let player = LINE;
     for (let turn = 0; turn < 200; turn++) {
       const played = playBotTurn(board, player, player === LINE ? lineStrategy : circleStrategy);

--- a/src/components/games/triangle-circle-game/strategy/forced-win.spec.ts
+++ b/src/components/games/triangle-circle-game/strategy/forced-win.spec.ts
@@ -1,4 +1,3 @@
-import { cloneDeep } from 'lodash';
 import { EDGES, TRIANGLES, TRIANGLE_COUNT } from '../geometry';
 import {
   type Board, LINE,
@@ -8,10 +7,6 @@ import {
 import { OPENING_EDGE, OPENING_EDGES, isLineTurnWon, marchEdges, winningPairHeatEdges } from './forced-win';
 import { makeSmartBotStrategy } from './bot-strategy';
 import { playBotTurn } from './spec-helpers';
-
-// `startBoard` is shared module data; a spec that steps a board forward needs
-// its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoard);
 
 // The centrepiece: a complete-branching certificate that the LINE player wins
 // the side-6 board. Soundness rests on the March Lemma (see forced-win.ts);
@@ -26,7 +21,7 @@ describe('forced-win certificate (line player wins the side-6 board)', () => {
 
   it('after any symmetric opening, every circle reply is answered: two-hot already, ' +
      'or a second pair-heat exists after which ALL circle replies leave two-hot', () => {
-    const empty = freshStartBoard();
+    const empty = startBoard;
     expect(isLineTurnWon(empty)).toBe(false);
 
     for (const opening of OPENING_EDGES) {
@@ -43,7 +38,7 @@ describe('forced-win certificate (line player wins the side-6 board)', () => {
 
 describe('isLineTurnWon (two-hot criterion)', () => {
   it('is false on the empty board and after a boundary shade (one hot only)', () => {
-    const empty = freshStartBoard();
+    const empty = startBoard;
     expect(isLineTurnWon(empty)).toBe(false);
     const boundary = EDGES.find(e => e.triangleIds.length === 1)!;
     expect(isLineTurnWon(applyShade(empty, boundary.id))).toBe(false);
@@ -52,12 +47,12 @@ describe('isLineTurnWon (two-hot criterion)', () => {
   it('is true after one interior shade: both heated triangles stay connected ' +
      'around the removed edge', () => {
     const interior = EDGES[OPENING_EDGE];
-    expect(isLineTurnWon(applyShade(freshStartBoard(), interior.id))).toBe(true);
+    expect(isLineTurnWon(applyShade(startBoard, interior.id))).toBe(true);
   });
 
   it('is true for an uncircled triangle with two shaded sides', () => {
     const [e0, e1] = TRIANGLES[5].edgeIds;
-    expect(isLineTurnWon(applyShade(applyShade(freshStartBoard(), e0), e1))).toBe(true);
+    expect(isLineTurnWon(applyShade(applyShade(startBoard, e0), e1))).toBe(true);
   });
 });
 
@@ -66,7 +61,7 @@ describe('marchEdges', () => {
     const edge = EDGES.find(e => e.triangleIds.length === 2)!;
     const [t1, t2] = edge.triangleIds;
     const other = (t: number) => TRIANGLES[t].edgeIds.find(e => e !== edge.id)!;
-    let board = freshStartBoard();
+    let board = startBoard;
     board = applyShade(board, other(t1));
     board = applyShade(board, other(t2));
     expect(marchEdges(board)).toEqual([edge.id]);
@@ -90,7 +85,7 @@ describe('marchEdges', () => {
     const [A, C] = flank;
     const boundaryEdge = (t: number) => TRIANGLES[t].edgeIds.find(x => EDGES[x].triangleIds.length === 1)!;
 
-    let board = freshStartBoard();
+    let board = startBoard;
     board = applyShade(board, boundaryEdge(A));
     board = applyShade(board, boundaryEdge(C));
 
@@ -121,7 +116,7 @@ describe('bot line player wins against adversarial circle defence', () => {
 
   it('wins for every one of the 36 first circle replies', () => {
     for (let reply = 0; reply < TRIANGLE_COUNT; reply++) {
-      let board = applyCircle(applyShade(freshStartBoard(), OPENING_EDGE), reply);
+      let board = applyCircle(applyShade(startBoard, OPENING_EDGE), reply);
       let won = false;
       for (let round = 0; round < 40; round++) {
         board = playBotTurn(board, LINE, bot).nextBoard;

--- a/src/components/games/triangle-circle-game/strategy/forced-win.spec.ts
+++ b/src/components/games/triangle-circle-game/strategy/forced-win.spec.ts
@@ -2,16 +2,16 @@ import { cloneDeep } from 'lodash';
 import { EDGES, TRIANGLES, TRIANGLE_COUNT } from '../geometry';
 import {
   type Board, LINE,
-  startBoards, applyShade, applyCircle,
+  startBoard, applyShade, applyCircle,
   isLineWin, isCircleWin, liveThreats, freeTriangles
 } from '../gameplay';
 import { OPENING_EDGE, OPENING_EDGES, isLineTurnWon, marchEdges, winningPairHeatEdges } from './forced-win';
 import { makeSmartBotStrategy } from './bot-strategy';
 import { playBotTurn } from './spec-helpers';
 
-// `startBoards` is shared module data; a spec that steps a board forward
-// needs its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoards[0]);
+// `startBoard` is shared module data; a spec that steps a board forward needs
+// its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoard);
 
 // The centrepiece: a complete-branching certificate that the LINE player wins
 // the side-6 board. Soundness rests on the March Lemma (see forced-win.ts);

--- a/src/components/games/triangle-circle-game/strategy/forced-win.spec.ts
+++ b/src/components/games/triangle-circle-game/strategy/forced-win.spec.ts
@@ -1,12 +1,17 @@
+import { cloneDeep } from 'lodash';
 import { EDGES, TRIANGLES, TRIANGLE_COUNT } from '../geometry';
 import {
   type Board, LINE,
-  generateStartBoard, applyShade, applyCircle,
+  startBoards, applyShade, applyCircle,
   isLineWin, isCircleWin, liveThreats, freeTriangles
 } from '../gameplay';
 import { OPENING_EDGE, OPENING_EDGES, isLineTurnWon, marchEdges, winningPairHeatEdges } from './forced-win';
 import { makeSmartBotStrategy } from './bot-strategy';
 import { playBotTurn } from './spec-helpers';
+
+// `startBoards` is shared module data; a spec that steps a board forward
+// needs its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoards[0]);
 
 // The centrepiece: a complete-branching certificate that the LINE player wins
 // the side-6 board. Soundness rests on the March Lemma (see forced-win.ts);
@@ -21,7 +26,7 @@ describe('forced-win certificate (line player wins the side-6 board)', () => {
 
   it('after any symmetric opening, every circle reply is answered: two-hot already, ' +
      'or a second pair-heat exists after which ALL circle replies leave two-hot', () => {
-    const empty = generateStartBoard();
+    const empty = freshStartBoard();
     expect(isLineTurnWon(empty)).toBe(false);
 
     for (const opening of OPENING_EDGES) {
@@ -38,7 +43,7 @@ describe('forced-win certificate (line player wins the side-6 board)', () => {
 
 describe('isLineTurnWon (two-hot criterion)', () => {
   it('is false on the empty board and after a boundary shade (one hot only)', () => {
-    const empty = generateStartBoard();
+    const empty = freshStartBoard();
     expect(isLineTurnWon(empty)).toBe(false);
     const boundary = EDGES.find(e => e.triangleIds.length === 1)!;
     expect(isLineTurnWon(applyShade(empty, boundary.id))).toBe(false);
@@ -47,12 +52,12 @@ describe('isLineTurnWon (two-hot criterion)', () => {
   it('is true after one interior shade: both heated triangles stay connected ' +
      'around the removed edge', () => {
     const interior = EDGES[OPENING_EDGE];
-    expect(isLineTurnWon(applyShade(generateStartBoard(), interior.id))).toBe(true);
+    expect(isLineTurnWon(applyShade(freshStartBoard(), interior.id))).toBe(true);
   });
 
   it('is true for an uncircled triangle with two shaded sides', () => {
     const [e0, e1] = TRIANGLES[5].edgeIds;
-    expect(isLineTurnWon(applyShade(applyShade(generateStartBoard(), e0), e1))).toBe(true);
+    expect(isLineTurnWon(applyShade(applyShade(freshStartBoard(), e0), e1))).toBe(true);
   });
 });
 
@@ -61,7 +66,7 @@ describe('marchEdges', () => {
     const edge = EDGES.find(e => e.triangleIds.length === 2)!;
     const [t1, t2] = edge.triangleIds;
     const other = (t: number) => TRIANGLES[t].edgeIds.find(e => e !== edge.id)!;
-    let board = generateStartBoard();
+    let board = freshStartBoard();
     board = applyShade(board, other(t1));
     board = applyShade(board, other(t2));
     expect(marchEdges(board)).toEqual([edge.id]);
@@ -85,7 +90,7 @@ describe('marchEdges', () => {
     const [A, C] = flank;
     const boundaryEdge = (t: number) => TRIANGLES[t].edgeIds.find(x => EDGES[x].triangleIds.length === 1)!;
 
-    let board = generateStartBoard();
+    let board = freshStartBoard();
     board = applyShade(board, boundaryEdge(A));
     board = applyShade(board, boundaryEdge(C));
 
@@ -116,7 +121,7 @@ describe('bot line player wins against adversarial circle defence', () => {
 
   it('wins for every one of the 36 first circle replies', () => {
     for (let reply = 0; reply < TRIANGLE_COUNT; reply++) {
-      let board = applyCircle(applyShade(generateStartBoard(), OPENING_EDGE), reply);
+      let board = applyCircle(applyShade(freshStartBoard(), OPENING_EDGE), reply);
       let won = false;
       for (let round = 0; round < 40; round++) {
         board = playBotTurn(board, LINE, bot).nextBoard;

--- a/src/components/games/triangle-circle-game/strategy/search.spec.ts
+++ b/src/components/games/triangle-circle-game/strategy/search.spec.ts
@@ -1,4 +1,3 @@
-import { cloneDeep } from 'lodash';
 import { EDGES, TRIANGLES, TRIANGLE_COUNT } from '../geometry';
 import {
   type Board, LINE, CIRCLE,
@@ -6,15 +5,11 @@ import {
 } from '../gameplay';
 import { evaluatePosition } from './search';
 
-// `startBoard` is shared module data; a spec that steps a board forward needs
-// its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoard);
-
 const otherEdge = (t: number, notEdge: number) => TRIANGLES[t].edgeIds.find(e => e !== notEdge)!;
 
 describe('bounded minimax search', () => {
   it('reports lineLoses once every triangle is circled', () => {
-    const board: Board = { edges: freshStartBoard().edges, circles: new Array(TRIANGLE_COUNT).fill(true) };
+    const board: Board = { edges: startBoard.edges, circles: new Array(TRIANGLE_COUNT).fill(true) };
     expect(evaluatePosition(board, LINE)).toBe('lineLoses');
     expect(evaluatePosition(board, CIRCLE)).toBe('lineLoses');
   });
@@ -22,14 +17,14 @@ describe('bounded minimax search', () => {
   it('sees an immediate line win (line to move, a triangle at two shaded edges)', () => {
     const t = 5;
     const [e0, e1] = TRIANGLES[t].edgeIds;
-    const board = applyShade(applyShade(freshStartBoard(), e0), e1);
+    const board = applyShade(applyShade(startBoard, e0), e1);
     expect(evaluatePosition(board, LINE)).toBe('lineWins');
   });
 
   it('sees a forced line win via a double threat (line to move on a pre-threat edge)', () => {
     const edge = EDGES.find(e => e.triangleIds.length === 2)!;
     const [t1, t2] = edge.triangleIds;
-    let board = freshStartBoard();
+    let board = startBoard;
     board = applyShade(board, otherEdge(t1, edge.id));
     board = applyShade(board, otherEdge(t2, edge.id));
     // Line has no immediate win, but shading `edge` makes two live threats.
@@ -42,14 +37,14 @@ describe('bounded minimax search', () => {
     const upTris = TRIANGLES.filter(t => t.dir === 'up');
     const a = upTris[0].id;
     const b = upTris[upTris.length - 1].id;
-    let board = freshStartBoard();
+    let board = startBoard;
     for (const e of TRIANGLES[a].edgeIds.slice(0, 2)) board = applyShade(board, e);
     for (const e of TRIANGLES[b].edgeIds.slice(0, 2)) board = applyShade(board, e);
     expect(evaluatePosition(board, CIRCLE)).toBe('lineWins');
   });
 
   it('degrades to unknown on the wide-open board within a small budget', () => {
-    const board = freshStartBoard();
+    const board = startBoard;
     expect(evaluatePosition(board, LINE, { depth: 6, budget: 1500 })).toBe('unknown');
   });
 });

--- a/src/components/games/triangle-circle-game/strategy/search.spec.ts
+++ b/src/components/games/triangle-circle-game/strategy/search.spec.ts
@@ -1,15 +1,20 @@
+import { cloneDeep } from 'lodash';
 import { EDGES, TRIANGLES, TRIANGLE_COUNT } from '../geometry';
 import {
   type Board, LINE, CIRCLE,
-  generateStartBoard, applyShade
+  startBoards, applyShade
 } from '../gameplay';
 import { evaluatePosition } from './search';
+
+// `startBoards` is shared module data; a spec that steps a board forward
+// needs its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoards[0]);
 
 const otherEdge = (t: number, notEdge: number) => TRIANGLES[t].edgeIds.find(e => e !== notEdge)!;
 
 describe('bounded minimax search', () => {
   it('reports lineLoses once every triangle is circled', () => {
-    const board: Board = { edges: generateStartBoard().edges, circles: new Array(TRIANGLE_COUNT).fill(true) };
+    const board: Board = { edges: freshStartBoard().edges, circles: new Array(TRIANGLE_COUNT).fill(true) };
     expect(evaluatePosition(board, LINE)).toBe('lineLoses');
     expect(evaluatePosition(board, CIRCLE)).toBe('lineLoses');
   });
@@ -17,14 +22,14 @@ describe('bounded minimax search', () => {
   it('sees an immediate line win (line to move, a triangle at two shaded edges)', () => {
     const t = 5;
     const [e0, e1] = TRIANGLES[t].edgeIds;
-    const board = applyShade(applyShade(generateStartBoard(), e0), e1);
+    const board = applyShade(applyShade(freshStartBoard(), e0), e1);
     expect(evaluatePosition(board, LINE)).toBe('lineWins');
   });
 
   it('sees a forced line win via a double threat (line to move on a pre-threat edge)', () => {
     const edge = EDGES.find(e => e.triangleIds.length === 2)!;
     const [t1, t2] = edge.triangleIds;
-    let board = generateStartBoard();
+    let board = freshStartBoard();
     board = applyShade(board, otherEdge(t1, edge.id));
     board = applyShade(board, otherEdge(t2, edge.id));
     // Line has no immediate win, but shading `edge` makes two live threats.
@@ -37,14 +42,14 @@ describe('bounded minimax search', () => {
     const upTris = TRIANGLES.filter(t => t.dir === 'up');
     const a = upTris[0].id;
     const b = upTris[upTris.length - 1].id;
-    let board = generateStartBoard();
+    let board = freshStartBoard();
     for (const e of TRIANGLES[a].edgeIds.slice(0, 2)) board = applyShade(board, e);
     for (const e of TRIANGLES[b].edgeIds.slice(0, 2)) board = applyShade(board, e);
     expect(evaluatePosition(board, CIRCLE)).toBe('lineWins');
   });
 
   it('degrades to unknown on the wide-open board within a small budget', () => {
-    const board = generateStartBoard();
+    const board = freshStartBoard();
     expect(evaluatePosition(board, LINE, { depth: 6, budget: 1500 })).toBe('unknown');
   });
 });

--- a/src/components/games/triangle-circle-game/strategy/search.spec.ts
+++ b/src/components/games/triangle-circle-game/strategy/search.spec.ts
@@ -2,13 +2,13 @@ import { cloneDeep } from 'lodash';
 import { EDGES, TRIANGLES, TRIANGLE_COUNT } from '../geometry';
 import {
   type Board, LINE, CIRCLE,
-  startBoards, applyShade
+  startBoard, applyShade
 } from '../gameplay';
 import { evaluatePosition } from './search';
 
-// `startBoards` is shared module data; a spec that steps a board forward
-// needs its own copy, the way the engine takes one per match.
-const freshStartBoard = () => cloneDeep(startBoards[0]);
+// `startBoard` is shared module data; a spec that steps a board forward needs
+// its own copy, the way the engine takes one per match.
+const freshStartBoard = () => cloneDeep(startBoard);
 
 const otherEdge = (t: number, notEdge: number) => TRIANGLES[t].edgeIds.find(e => e !== notEdge)!;
 

--- a/src/components/games/triangle-circle-game/triangle-circle-game.tsx
+++ b/src/components/games/triangle-circle-game/triangle-circle-game.tsx
@@ -1,6 +1,6 @@
 import { strategyGameFactory } from 'strategy-game-factory';
 import { BoardClient } from './board-client';
-import { LINE, generateStartBoard, moves } from './gameplay';
+import { LINE, startBoards, moves } from './gameplay';
 import { smartBotStrategy, randomBotStrategy } from './strategy/bot-strategy';
 
 const rule = {
@@ -46,7 +46,7 @@ export const TriangleCircleGame = strategyGameFactory({
   variants: [
     {
       botStrategy: randomBotStrategy,
-      generateStartBoard,
+      startBoards,
       label: { hu: 'Teszt', en: 'Test' }
     },
     // Smart bot. As the line player it executes a proven forced win (see
@@ -56,7 +56,7 @@ export const TriangleCircleGame = strategyGameFactory({
     // filter + bounded search), hence the notAlwaysOptimal marker.
     {
       botStrategy: smartBotStrategy,
-      generateStartBoard,
+      startBoards,
       label: { hu: 'Teljes', en: 'Full' },
       notAlwaysOptimal: true,
       isDefault: true

--- a/src/components/games/triangle-circle-game/triangle-circle-game.tsx
+++ b/src/components/games/triangle-circle-game/triangle-circle-game.tsx
@@ -1,6 +1,6 @@
 import { strategyGameFactory } from 'strategy-game-factory';
 import { BoardClient } from './board-client';
-import { LINE, startBoards, moves } from './gameplay';
+import { LINE, startBoard, moves } from './gameplay';
 import { smartBotStrategy, randomBotStrategy } from './strategy/bot-strategy';
 
 const rule = {
@@ -46,7 +46,7 @@ export const TriangleCircleGame = strategyGameFactory({
   variants: [
     {
       botStrategy: randomBotStrategy,
-      startBoards,
+      startBoards: [startBoard],
       label: { hu: 'Teszt', en: 'Test' }
     },
     // Smart bot. As the line player it executes a proven forced win (see
@@ -56,7 +56,7 @@ export const TriangleCircleGame = strategyGameFactory({
     // filter + bounded search), hence the notAlwaysOptimal marker.
     {
       botStrategy: smartBotStrategy,
-      startBoards,
+      startBoards: [startBoard],
       label: { hu: 'Teljes', en: 'Full' },
       notAlwaysOptimal: true,
       isDefault: true

--- a/src/components/games/triangle-coloring/triangle-coloring.tsx
+++ b/src/components/games/triangle-coloring/triangle-coloring.tsx
@@ -113,7 +113,7 @@ export const TriangleColoring = strategyGameFactory({
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
     {
       botStrategy: smartBotStrategy,
-      generateStartBoard: () => Array(16).fill(ALLOWED),
+      startBoards: [Array(16).fill(ALLOWED)],
       label: { hu: 'Teljes', en: 'Full' },
       isDefault: true
     }

--- a/src/components/games/twelve-squares/gameplay.ts
+++ b/src/components/games/twelve-squares/gameplay.ts
@@ -2,7 +2,7 @@ import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
 export type Board = { left: number, right: number }
 
-export const generateStartBoard = (): Board => ({ left: 1, right: 12 });
+export const startBoards: Board[] = [{ left: 1, right: 12 }];
 
 export const moves = {
   step: {

--- a/src/components/games/twelve-squares/gameplay.ts
+++ b/src/components/games/twelve-squares/gameplay.ts
@@ -2,7 +2,7 @@ import type { Ctx, MoveOutcome } from 'strategy-game-factory';
 
 export type Board = { left: number, right: number }
 
-export const startBoards: Board[] = [{ left: 1, right: 12 }];
+export const startBoard: Board = { left: 1, right: 12 };
 
 export const moves = {
   step: {

--- a/src/components/games/twelve-squares/twelve-squares.tsx
+++ b/src/components/games/twelve-squares/twelve-squares.tsx
@@ -1,7 +1,7 @@
 import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { range } from 'lodash';
 import { ChessBishopSvg } from '../chess-bishops/chess-bishop-svg';
-import { startBoards, moves, type Board } from './gameplay';
+import { startBoard, moves, type Board } from './gameplay';
 import { optimalBotStrategy, randomBotStrategy } from './bot-strategy';
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
@@ -78,7 +78,7 @@ export const TwelveSquares = strategyGameFactory({
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
     {
       botStrategy: optimalBotStrategy,
-      startBoards,
+      startBoards: [startBoard],
       label: { hu: 'Teljes', en: 'Full' },
       isDefault: true
     }

--- a/src/components/games/twelve-squares/twelve-squares.tsx
+++ b/src/components/games/twelve-squares/twelve-squares.tsx
@@ -1,7 +1,7 @@
 import { strategyGameFactory, type BoardClientProps, GameBoard } from 'strategy-game-factory';
 import { range } from 'lodash';
 import { ChessBishopSvg } from '../chess-bishops/chess-bishop-svg';
-import { generateStartBoard, moves, type Board } from './gameplay';
+import { startBoards, moves, type Board } from './gameplay';
 import { optimalBotStrategy, randomBotStrategy } from './bot-strategy';
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
@@ -78,7 +78,7 @@ export const TwelveSquares = strategyGameFactory({
     { botStrategy: randomBotStrategy, label: { hu: 'Teszt', en: 'Test' } },
     {
       botStrategy: optimalBotStrategy,
-      generateStartBoard,
+      startBoards,
       label: { hu: 'Teljes', en: 'Full' },
       isDefault: true
     }


### PR DESCRIPTION
**Stacked on #467** — base is that branch, so this diff shows only the sweep. Merge #467 first and this retargets to `main` cleanly.

The mechanical follow-up to #467's design: 40 variants across 36 games always start from the same position — an empty chessboard, a full deck, a rook in the corner — and said so by wrapping that constant in a function nobody varies. They now declare the position as data, following #467's "name the boards, not the list" rule:

```diff
-export const generateStartBoard = (): Board => Array(8).fill('');
+export const startBoard: Board = Array(8).fill('');

-      generateStartBoard,
+      startBoards: [startBoard],
```

That leaves `generateStartBoard` meaning what it says: positions that are actually *generated*, by sampling or rejection. A reader no longer has to read a generator's body to learn whether a game has one start position or a thousand, and the games whose position a competition would hand out verbatim now expose it as the value it is, in the React-free module a server reads.

## Which variants qualify was measured, not grepped

Grepping for `sample`/`random` would have missed a generator that computes its variation some other way, and mis-flagged one that imports lodash for something else. Instead a throwaway probe called every variant's generator 200 times and compared the results: 41 fixed, 72 varying.

The same probe re-run after the migration reports the **identical 41-variant set** (the 40 here plus `coins-in-3-piles`'s 3-5-7, already converted in #467). That's the evidence no game's start position changed.

## Three things the sweep turned up

- **Which specs actually need a clone was also measured.** Reading a shared board where the old code called a generator broke five spec files. Rather than guess, pointing all 22 board-reading specs at the shared board directly showed exactly which mutate: **5 do, 17 don't**. The five keep a one-line `freshStartBoard()`; the seventeen use `startBoard` and dropped four lines and a lodash import each (net −156/+69). Where the clone now appears it means something — this spec steps the board — instead of being uniform ceremony.
- **`Array(n).fill(x)` puts one reference in every slot**, which `cloneDeep` would split into n distinct objects — a behaviour change if anything compared by identity. Checked every fill in a converted board: all primitives, so nothing depended on the sharing.
- **`chess-ducks`' `generateStartBoard(rows, cols)` returned a generator**, not a board. It's now `startBoard(rows, cols)` returning the board, which also flattens its Test variant from `sample([gen4x6, gen4x7])()` to a two-entry `startBoards` list — the curated-list shape doing what the sampling wrapper did by hand.

## Considered and not done

A shared `test-utils` helper for the clone: at five call sites it would be an alias for `cloneDeep`, and `test-utils` is for helpers carrying repo-specific knowledge (`makeCtx`, `playBotMove`, `forcedWinnerIndex`). Deep-freezing the exported boards so a mutating spec fails at the mutation: it works, but it changes production code to protect specs, and the failure is already loud and local.

## Verification

`npm run test` (1914 tests), lint and typecheck green; `coverage:patch` above the 85% bar.

The catalog sweeps carry most of the weight here: `plays-to-an-end.spec.ts` plays every registered variant through the real moves and reducer, and `renders.spec.tsx` renders every board — so a variant left pointing at nothing, or at the wrong shape, fails loudly.