### PR TITLE
Say each rule once: dedupe the docs and the comments that restate them

### DIFF
--- a/.claude/commands/new-game.md
+++ b/.claude/commands/new-game.md
@@ -15,9 +15,10 @@ If the game rules weren't provided in $ARGUMENTS, ask for them before proceeding
 
 Past Dürer competition problem sets (including written solutions) are archived at https://durerinfo.hu/archivum/feladatsorok/. If the user provides a reference to a specific PDF (year, round, problem number), fetch it and read the problem statement and solution. If they paste the solution text directly, use that. Either way, use the written solution to inform both the board design and the AI strategy — it often contains the key invariant or characterisation that makes the optimal strategy straightforward to implement.
 
+> **Reminder:** Once the game is identified, ask the user to mark it as **in progress** in the [game tracking spreadsheet](https://docs.google.com/spreadsheets/d/1-6u9PCtvf_gDHrs65x36pmDzFt4nZZx_IUuXrgS2aZk/edit?gid=0#gid=0) before implementation starts, to avoid duplicate work by other developers.
+
 Before proceeding further, also collect the following metadata if not already provided in $ARGUMENTS — they are quick to answer and needed throughout implementation:
 
-> **Reminder:** Once the game is identified, ask the user to mark it as **in progress** in the [game tracking spreadsheet](https://docs.google.com/spreadsheets/d/1-6u9PCtvf_gDHrs65x36pmDzFt4nZZx_IUuXrgS2aZk/edit?gid=0#gid=0) before implementation starts, to avoid duplicate work by other developers.
 - **year**: display string (e.g. `"XVI. (22/23)"`) and sort string (e.g. `"22/23"`)
 - **category**: one or more of A, B, C, D, E, E+
 - **round**: `online` or `döntő`
@@ -31,7 +32,7 @@ A game is useful even without an optimal AI: human vs human mode lets real playe
 - **If now:** spend up to ~3 minutes reasoning through the winning strategy. If you arrive at a clear characterisation, explain it to the user before writing code. If after ~3 minutes you haven't found a clean solution, say so explicitly — don't keep the user waiting longer — and ask if they have any hints (e.g. from the official solution, a known invariant, or their own intuition). If hints resolve it, proceed; otherwise fall back to "later" and leave a placeholder.
 - **If later:** implement a simple or random bot strategy as a placeholder and note clearly in a code comment that it is not optimal yet.
 
-If the strategy needs a **precomputed table** (a JSON file of optimal moves, because searching at play time is too slow), commit the script that produces it to `scripts/pre-generate-ai-moves/` in the same PR — never the table alone. A table without a generator cannot be audited or rebuilt when the board changes. Write the script so that re-running it reproduces the committed JSON byte for byte, and so that it verifies the table (e.g. replaying it against every opponent reply) and fails rather than writing one it cannot prove correct. `modified-mill-strategy.cjs` is the worked example.
+If the strategy needs a **precomputed table** (a JSON file of optimal moves, because searching at play time is too slow), commit its generator in the same PR — never the table alone. What the script has to guarantee is in [AGENTS.md § Architecture](../../AGENTS.md#architecture); `modified-mill-strategy.cjs` is the worked example, and it should also verify the table (e.g. replaying it against every opponent reply) rather than write one it cannot prove correct.
 
 Note: written solutions typically only describe what to do from a winning position. The AI also needs a strategy for losing positions — i.e. when the opponent holds the winning advantage but hasn't played optimally. In that case the bot should still play as well as possible: making moves that are hardest to respond to correctly, maximising the chance the human makes a mistake. Ask the user how they want this handled if it isn't obvious from the solution.
 
@@ -44,7 +45,7 @@ Choose the simplest existing game that resembles the new one structurally:
 Read the chosen reference file in full before writing anything.
 
 ### 4. Create the game files
-Create `src/components/games/<game-name>/gameplay.ts` (board type, start boards, moves) and `<game-name>.tsx` (rule text, step description, variants, factory call). Which file holds what — and why `gameplay.ts` must stay React-free — is in [AGENTS.md § Files in a game folder](../../AGENTS.md#architecture); the contract you are implementing — `moves`/`apply`/`validate`, `isAllowed`, the bot contract, `ctx`, `setTurnState`, `useDeferredMove` — is in [src/components/CLAUDE.md § strategyGameFactory API](../../src/components/CLAUDE.md#strategygamefactory-api). Read both rather than guessing from the reference game alone. Authoring decisions on top of them:
+Create `src/components/games/<game-name>/gameplay.ts` (board type, start boards, moves) and `<game-name>.tsx` (rule text, step description, variants, factory call). Which file holds what — and why `gameplay.ts` must stay React-free — is in [AGENTS.md § Files in a game folder](../../AGENTS.md#files-in-a-game-folder); the contract you are implementing — `moves`/`apply`/`validate`, `isAllowed`, the bot contract, `ctx`, `setTurnState`, `useDeferredMove` — is in [src/components/CLAUDE.md § strategyGameFactory API](../../src/components/CLAUDE.md#strategygamefactory-api). Read both rather than guessing from the reference game alone. Authoring decisions on top of them:
 - If the user supplied the rule text, use it verbatim in `rule.hu` by default. Don't silently rephrase, correct, or abbreviate it. **Exception:** when the original wording doesn't fit the online implementation — e.g. it refers to the competition organizers/judges instead of the opponent/computer, or to physical artifacts (paper, pencil, cards on a table) that don't exist in the browser version — it's fine to reword it slightly to fit. In that case, explicitly highlight every change you made to the user (e.g. show before/after) so they can review it. For any other wording change, propose it and wait for approval before applying.
 - For user-facing text referring to the other participant, prefer "other player" / "másik játékos" over "opponent" / "ellenfél" — the latter reads as too harsh, especially in Hungarian
 - `getPlayerStepDescription` should make it obvious what the current player should do — it is the game's instruction line, not a status label
@@ -74,15 +75,10 @@ const { winnerIndex } = runMatch({
 ```
 
 Assert what the checklist asks for: the smart bot wins as the mover from a
-board the mover can win, and as the replier from one it cannot (every move
-loses there, so any opponent must lose). A spec for a single decision needs no
-mock either — read it with `botNextMoveArgs` from `test-utils`.
-
-**How many boards to sweep depends on what the strategy costs** — exhaustive
-where it is cheap, a few representative boards where it searches, with the
-exhaustive argument moved into unit tests of the characterisation itself. See
-[AGENTS.md § Testing](../../AGENTS.md#testing) for the reasoning and the
-measured numbers.
+board the mover can win, and as the replier from one it cannot. [AGENTS.md §
+Testing](../../AGENTS.md#testing) covers the rest — reading a single decision
+with `botNextMoveArgs`, and how many boards to sweep given what the strategy
+costs.
 
 ```bash
 npm run test

--- a/.claude/skills/play-game-in-browser/SKILL.md
+++ b/.claude/skills/play-game-in-browser/SKILL.md
@@ -12,13 +12,11 @@ a match completes and names a winner, `renders.spec.tsx` that a board renders at
 all — both drive the *engine*, not the UI. So every claim about what a player
 sees mid-turn is unverified until someone plays the game.
 
-That gap has already cost a bug. PR #461 claimed to have fixed `pile-splitter`
-showing a bare `0` for a pile it had just emptied, where the three- and
-four-pile boards show 🗑️. Only the bot's half of it was actually fixed:
-`removePile` does not end the turn, so on the mover's own `useDeferredMove` beat
-the label took a different branch and still rendered `0`. Lint, typecheck and
-1890 tests were green the whole time. A single playthrough would have caught it,
-and eventually a user did.
+That gap has already cost a bug: a fix for `pile-splitter` showing a bare `0`
+for a pile it had just emptied landed for the bot's half only, because on the
+mover's own `useDeferredMove` beat the label took a different branch. Lint,
+typecheck and the whole suite were green throughout; a single playthrough would
+have caught it, and eventually a user did.
 
 ## Start the dev server
 

--- a/.github/workflows/dependency_report.yml
+++ b/.github/workflows/dependency_report.yml
@@ -1,9 +1,8 @@
 name: dependency-report
 on:
   schedule:
-    # 06:00 UTC on the 1st of the month. GitHub disables a scheduled workflow after 60 days
-    # without repository activity, which at this repo's cadence should never come up — but it
-    # is the explanation for a month that passes silently.
+    # 06:00 UTC on the 1st. GitHub disables a scheduled workflow after 60 days without
+    # repository activity — the explanation for a month that passes silently.
     - cron: '0 6 1 * *'
   workflow_dispatch:
 
@@ -14,17 +13,15 @@ permissions:
 jobs:
   report:
     runs-on: ubuntu-24.04
-    # No `container: node:24.11.1` and no setup-node, unlike the other two workflows. This job only
-    # reads version strings and fetches URLs, so the pinned toolchain buys it nothing — and pinning
-    # Node here would add a sixth place that scripts/check-versions.mjs does not know to look at.
+    # No pinned container, unlike the other two workflows: this job only reads version strings and
+    # fetches URLs, and pinning Node here would add a place check-versions.mjs does not look at.
     steps:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Collect outdated versions
         id: report
-        # stdout goes to the run summary, so every run is readable in the Actions tab whatever
-        # happens to the issue below. The script never exits non-zero: an unreachable registry is
-        # reported as a row, not as a failed build.
+        # stdout goes to the run summary, so a run stays readable whatever happens to the issue
+        # below. The script never exits non-zero: an unreachable registry is a row, not a failure.
         run: node scripts/dependency-report.mjs --out dependency-report.md >> "$GITHUB_STEP_SUMMARY"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -34,15 +31,14 @@ jobs:
           BEHIND: ${{ steps.report.outputs.behind }}
           TITLE: Dependency update report
         run: |
-          # Matched on the title rather than the OPS label, so a label edited off by hand cannot
-          # cause a duplicate issue. --limit outruns gh's default page of 30.
+          # Matched on the title, not the OPS label, so a hand-edited label cannot cause a
+          # duplicate issue. --limit outruns gh's default page of 30.
           number=$(gh issue list --state open --limit 100 --json number,title \
             --jq "map(select(.title == \"$TITLE\")) | first | .number // empty")
 
           if [ "$BEHIND" = 'true' ] && [ -n "$number" ]; then
-            # Edit rather than comment. Editing a body sends no notification, so a month where
-            # something is still behind stays silent — the one notification worth having is the
-            # issue appearing in the first place.
+            # Edit rather than comment: editing a body sends no notification, so the only one
+            # worth having is the issue appearing in the first place.
             gh issue edit "$number" --body-file dependency-report.md
           elif [ "$BEHIND" = 'true' ]; then
             gh issue create --title "$TITLE" --label OPS --body-file dependency-report.md

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -25,9 +25,8 @@ jobs:
       - name: Install dependencies
         id: install
         run: npm ci
-      # Each check runs even after an earlier one failed, so a red build names every
-      # problem at once: a contributor whose only mistake is formatting can see that
-      # the game logic itself passed, without reading the logs.
+      # Each check runs even after an earlier one failed, so a red build names every problem
+      # at once rather than only the first.
       - name: Check tool versions
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: npm run check:versions
@@ -44,14 +43,10 @@ jobs:
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: npm run build
 
-  # A separate job rather than another step of `test`, so the coverage run — the suite again, and
-  # instrumented, so a couple of minutes — happens alongside the checks a contributor is actually
-  # waiting on rather than after them, and so a PR failing this one can still be read as passing
-  # everything else at a glance.
-  #
-  # Skipped, not failed, when the PR carries the `skip coverage` label: a diff with nothing worth
-  # asserting — a generated table, a renamed symbol, a batch of copy edits — should not need a green
-  # check invented for it.
+  # A separate job rather than a step of `test`: the coverage run is the suite again and
+  # instrumented, so it belongs alongside the checks a contributor is waiting on rather than after
+  # them, and a PR failing it still reads as passing everything else at a glance. The
+  # `skip coverage` label skips rather than fails it (AGENTS.md § Coverage).
   patch-coverage:
     if: >-
       github.event.pull_request.draft == false &&
@@ -80,9 +75,7 @@ jobs:
           restore-keys: npm-
       - name: Install dependencies
         run: npm ci
-      # Deliberately not `npm run coverage`: the plays-to-an-end and renders sweeps execute nearly
-      # every line under games/ while asserting almost nothing, so measured against them a new game
-      # with no spec at all reads as fully covered. See the comment atop scripts/patch-coverage.mjs.
+      # Deliberately not `npm run coverage` — see the comment atop scripts/patch-coverage.mjs.
       - name: Measure coverage without the sweeps
         run: npm run coverage:unswept -- --coverage.reporter=lcovonly
       # base.sha is the base branch as of the last sync, which is exactly the merge base the diff

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -28,9 +28,8 @@ jobs:
       - name: Install dependencies
         id: install
         run: npm ci
-      # Split as in pr_test.yml, and for the same reason: every check runs even after
-      # an earlier one failed, so a red main names every problem at once. Upload keeps
-      # the default success() guard, so a main that fails any check is never deployed.
+      # Split as in pr_test.yml, for the same reason. Upload keeps the default success() guard,
+      # so a main that fails any check is never deployed.
       - name: Check tool versions
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: npm run check:versions
@@ -65,7 +64,6 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v5
         with:
-          # A healthy deployment here reports success in well under a minute (28s for
-          # the last good one). The action's 10 minute default only ever delays the
-          # report when Pages' own queue is stalled, so fail fast instead.
+          # A healthy deployment reports success in well under a minute, so the action's 10
+          # minute default only ever delays the report when Pages' queue is stalled.
           timeout: 180000

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@ playing optimally.
 
 The goal is to include all past Dürer competition games. Most are implemented
 (see `gameList.ts`); what remains is a tail of stragglers plus each new
-competition's games as they are held.
+competition's games as they are held. Traffic is expected to remain low — no
+scalability concerns.
 
 ## Tech stack
 
@@ -24,32 +25,28 @@ readability.
 
 ## Architecture
 
-Games live under `src/components/games/`, one folder per game. The game list is
-registered in `gameList.ts`.
+Games live under `src/components/games/`, one folder per game, registered in
+`gameList.ts`. Shared infrastructure lives in
+`src/components/strategy-game-factory/`, a sibling of `games/`:
 
-**Shared infrastructure** (in `src/components/strategy-game-factory/`, a
-sibling of `games/`):
 - `game-parts/` — common UI elements (rules section, role chooser, restart
   button, etc.)
-- `strategy-game-factory.tsx` — game flow engine via `strategyGameFactory`: handles
-  turn-taking, end-of-game detection, restart/clean state. Defines a
-  well-specified API that every game must implement. Games import everything
-  through the `strategy-game-factory` barrel (`index.ts`) — no deep imports.
-  `strategy-game-factory` is a path alias, so no `../../` either; it is anchored
-  to the barrel, which is what makes the no-deep-imports rule self-enforcing.
+- `strategy-game-factory.tsx` — the game flow engine: turn-taking, end-of-game
+  detection, restart/clean state, and the API every game implements. Games
+  import through the barrel (`index.ts`) — no deep imports. The barrel is a
+  path alias, so no `../../` either, which is what makes the rule
+  self-enforcing.
 
-**Per-game responsibility:**
-Each game folder implements the optimal strategy (computer AI) and game-specific
-UI independently, conforming to the `strategyGameFactory` API (role labels,
-rules, permissible moves, initial state, etc.). Strategy is implemented however
-is simplest: on-the-fly calculation/logic when feasible, or precomputed optimal
-moves stored in a JSON file when performance requires it. **A committed table
-needs its generator committed too**, in `scripts/pre-generate-ai-moves/` — a
-table nobody can rebuild is one nobody can audit or fix when the game changes.
-Write it so re-running it reproduces the committed file byte for byte, and so it
-verifies the table before writing (see `modified-mill-strategy.cjs`).
+Each game folder implements the optimal strategy (computer AI) and its own UI
+against that API. Strategy is implemented however is simplest: calculated on the
+fly where feasible, or precomputed optimal moves in a JSON file where
+performance requires it. **A committed table needs its generator committed
+too**, in `scripts/pre-generate-ai-moves/` — a table nobody can rebuild is one
+nobody can audit or fix when the game changes. Write it so re-running reproduces
+the committed file byte for byte, and so it verifies the table before writing
+(see `modified-mill-strategy.cjs`).
 
-**Files in a game folder:**
+### Files in a game folder
 
 | File | Holds | React? |
 |---|---|---|
@@ -59,25 +56,14 @@ verifies the table before writing (see `modified-mill-strategy.cjs`).
 | `board-client.tsx` | `BoardClient` (split out once the JSX outgrows the game file) | yes |
 | `<game>.tsx` | `rule`, `getPlayerStepDescription`, `variants`, the `strategyGameFactory` call | yes |
 
-**The spec layout mirrors the file layout**: a spec is named after the module
-whose behaviour it asserts — `gameplay.spec.ts` for the rules,
-`bot-strategy.spec.ts` for the strategy, `<game>.spec.ts` for what the game file
-itself holds, plus a topical name (`solver.spec.ts`, `geometry.spec.ts`) where
-one part of the strategy is worth testing on its own. What the module *is*
-decides, not what the test reads along the way: "the bot only ever produces
-legal moves" belongs with the bot even though it checks a rule, and a start
-board asserted to be winnable belongs with the rules even though the Grundy
-value proving it comes from the bot. What must not happen is moves being tested
-from anywhere but `gameplay.spec.ts`.
-
 `gameplay.ts` is the **framework-free half of a game**: the same module a
 server-authoritative competition mode would validate moves with, so it has to
-run in plain Node (see issue #313). ESLint
-enforces that — a `react` import, or a value import from the
-`strategy-game-factory` barrel, is an error there; types from the barrel are
-fine, since `import type` is erased. A game whose gameplay is a handful of lines
-still gets the file: uniform layout is what makes the catalog skimmable, and it
-is what a spec and the bot's move pinning import without dragging in JSX.
+run in plain Node (issue #313). ESLint enforces that — a `react` import, or a
+value import from the `strategy-game-factory` barrel, is an error there; types
+from the barrel are fine, since `import type` is erased. A game whose gameplay
+is a handful of lines still gets the file: uniform layout is what makes the
+catalog skimmable, and it is what a spec and the bot's move pinning import
+without dragging in JSX.
 
 Two rules keep the boundary meaningful rather than nominal:
 
@@ -91,34 +77,32 @@ Two rules keep the boundary meaningful rather than nominal:
   is accepted for practice games, where the strategy is readable anyway. A
   **competition** game must not do it — curate its start boards instead.
 
-**Curated start boards.** A variant states its start position either as
-`generateStartBoard` or as `startBoards`, a list the engine picks from at
-random (a clone per pick, so a start board stays owned by the match it starts).
-Prefer the list whenever the positions are enumerable: it is what a competition
-hands out one entry of per attempt (#314), so its **order is part of the
-contract** — append, never reorder — and, unlike a generator, a spec can judge
-every board in it instead of sampling until they have all come up.
+A variant states its start position either as `generateStartBoard` or as
+`startBoards`, a curated list. Prefer the list whenever the positions are
+enumerable, and verify each entry with `forcedWinnerIndex` — the contract and
+the reasoning are in [src/components/CLAUDE.md § Curated start
+boards](src/components/CLAUDE.md#curated-start-boards).
 
-Curating is only half of it; a competition board has to be **verified**, since
-the team picks a role and must be able to force the win. `forcedWinnerIndex`
-(`test-utils`) plays the game's own optimal bot against itself and names the
-role that wins, throwing when the playouts disagree — which is either a board
-that is not decisive or a bot that is not optimal. Assert the winning role, not
-merely that the game ends: `coins-in-3-piles` pins 3-5-7 as a replier win, and
-`stones-remove-one-not-twice-from-left` plays every curated board out to
-cross-check the predicate its balance test relies on.
+### Where a spec lives
 
-Traffic is expected to remain low — no scalability concerns.
+A spec is named after the module whose behaviour it asserts —
+`gameplay.spec.ts` for the rules, `bot-strategy.spec.ts` for the strategy,
+`<game>.spec.ts` for what the game file itself holds — plus a topical name
+(`solver.spec.ts`, `geometry.spec.ts`) where one part of the strategy is worth
+testing on its own. What the module *is* decides, not what the test reads along
+the way: "the bot only ever produces legal moves" belongs with the bot even
+though it checks a rule. What must not happen is moves being tested from
+anywhere but `gameplay.spec.ts`.
 
 ## Testing
 
-Any logic change (not just styling) to `strategy-game-factory.tsx` or the overview page
-must be covered by new unit tests. Prefer adding tests before or alongside the
-change, not as an afterthought.
+Any logic change (not just styling) to `strategy-game-factory.tsx` or the
+overview page must be covered by new unit tests, added before or alongside the
+change rather than as an afterthought.
 
 Game-specific logic is also worth testing when the winning strategy is
 non-trivial. Because bots name their moves, a spec can read a decision straight
-off the return value (`botNextMoveArgs` in `test-utils`, imported by specs as
+off the return value (`botNextMoveArgs` in `test-utils`, imported as
 `from 'test-utils'` — an alias, so no `../../../`), and `runMatch`
 (`strategy-game-factory/engine/run-match.ts`) plays two strategies against each
 other through the real moves and the real reducer — no fake `moves` object, no
@@ -126,77 +110,80 @@ hand-rolled game loop. That is what turns "the AI is truly optimal" into a test:
 the smart bot must win as the mover from a winning start board, and as the
 replier from a losing one (see `coins-in-3-piles`, `remove-row-or-column`).
 
-Every registered game is already swept once by
-`games/plays-to-an-end.spec.ts`, which plays each variant headlessly and asserts
-only that a match completes and names a winner — `runMatch` throws on an unknown
-move, a move the game's own `validate` rejects, a move named after the turn
-ended, and a game that never ends, so a new game gets that much conformance for
-free. It is a test of the *game*, not of the bot's judgement, and it is kept
-cheap on purpose: variants whose bot searches are listed out of it by name
-(their own bot spec covers them), and the rest play as many random start boards
-as a small per-variant time budget allows.
+Every registered game is already swept once by `games/plays-to-an-end.spec.ts`,
+which plays each variant headlessly and asserts only that a match completes and
+names a winner. `runMatch` throws on an unknown move, a move the game's own
+`validate` rejects, a move named after the turn ended, and a game that never
+ends, so a new game gets that much conformance for free. It tests the *game*,
+not the bot's judgement, and is kept cheap on purpose: variants whose bot
+searches are listed out of it by name (their own bot spec covers them), and the
+rest play as many random start boards as a small per-variant time budget allows.
 
-Size the sweep to what the strategy costs. Sweeping every start board is right
-for a cheap strategy over a small state space (`coins-in-3-piles`: 124 boards,
-~50 ms) and wrong for one that searches (`totem-poles`: ~3 s for a handful of
-playouts). For those, play a few representative boards and leave the exhaustive
-argument to cheap unit tests of the characterisation itself — the Grundy value,
-the parity invariant, the win/loss predicate.
+Size the sweep to what the strategy costs: every start board for a cheap
+strategy over a small state space (`coins-in-3-piles`: 124 boards, ~50 ms), a
+few representative ones for a strategy that searches (`totem-poles`: ~3 s for a
+handful of playouts), leaving the exhaustive argument to cheap unit tests of the
+characterisation itself — the Grundy value, the parity invariant, the win/loss
+predicate.
 
-**Coverage is on demand and has no threshold** (`npm run coverage`), and should
-stay that way. Those two sweeps execute ~94% of the source — that is how much of
-this repo is `games/` — while asserting only that a match ends and a board
-renders, so the global percentage reads high whatever the tests are worth, and a
-CI gate on it would be satisfied by registering another game. What the report is
-good for is the question grep cannot answer: which modules **no spec loads at
-all**. That is why `coverage.include` in `vite.config.js` names every file under
-`src/` rather than letting Vitest report only what a test imported. Run
-`npm run coverage:unswept` for the other half — with the sweeps excluded, what
-drops to near zero is the game logic nothing but a sweep touches. Neither one is
-a measure of whether the bots are right; that is what a bot's own spec is for.
+### Coverage
 
-The one coverage number CI does gate on is a different question again:
-`npm run coverage:patch` (`scripts/patch-coverage.mjs`, run by the
-`patch-coverage` job on every PR) measures the lines a branch **adds** to
-non-JSX files under `src/`, against `coverage:unswept`. Added lines cannot be
-diluted by the rest of the repo, so unlike a global percentage the number means
-the same thing in every PR; and measuring without the sweeps is what stops
-`gameList.ts` registration from reading as coverage. Under 85% fails, diffs
-under twenty measured lines never do, and the `skip coverage` label skips the
-job. The bar is a floor under existing habit, not a stretch above it: measured
-over any range of recent history wide enough to mean anything, this repo already
-sits at 87–96%.
-A gate on either of the other two reports would still be wrong for the reasons
-above — don't add one.
+```bash
+npm run coverage         # line coverage, on demand
+npm run coverage:unswept # the same, without the two all-games sweeps
+npm run coverage:patch   # how much of what a branch adds a spec reaches
+```
+
+The first two are **on demand and have no threshold**, and should stay that way.
+The two sweeps execute ~94% of the source — that is how much of this repo is
+`games/` — while asserting only that a match ends and a board renders, so the
+global percentage reads high whatever the tests are worth, and a CI gate on it
+would be satisfied by registering another game. What the report is good for is
+the question grep cannot answer: which modules **no spec loads at all**, which
+is why `coverage.include` in `vite.config.js` names every file under `src/`
+rather than only what a test imported. `coverage:unswept` is the other half:
+what drops to near zero there is the game logic nothing but a sweep touches.
+
+`coverage:patch` (`scripts/patch-coverage.mjs`, run by the `patch-coverage` job
+on every PR) is the one number CI gates on: the lines a branch **adds** to
+non-JSX files under `src/`, measured against `coverage:unswept`. Added lines
+cannot be diluted by the rest of the repo, so the number means the same thing in
+every PR, and excluding the sweeps is what stops `gameList.ts` registration from
+reading as coverage. Under 85% fails, diffs under twenty measured lines never
+do, and the `skip coverage` label skips the job. Failing means the added logic
+is not *unit-tested*, not that it is untested. The bar is a floor under existing
+habit, not a stretch above it — recent history sits at 87–96%. A gate on either
+of the other two reports would still be wrong for the reasons above; don't add
+one.
 
 ## Planned future directions
 
-### Primary (ongoing)
 - **Replace `boardgame.io` in `durer-aion` with this engine** — the current main
   effort. `a-gondolkodas-orome/durer-aion` already runs real competitions
   (server-authoritative match state, team identity, timers, results); the plan
   is for `strategyGameFactory` to take over its game-engine slot rather than
-  build a competition backend here (see issue #313). What this repo owes that
-  effort is the engine work they share: a game's rules and its bot
-  each importable with no React, which is why `gameplay.ts` and
-  `bot-strategy.ts` are separate files.
+  build a competition backend here (issue #313). What this repo owes that effort
+  is the engine work they share: a game's rules and its bot each importable with
+  no React, which is why `gameplay.ts` and `bot-strategy.ts` are separate files.
 - **Add Dürer competition games** — the games of each new competition, plus the
   tail of older ones still missing
 - **Refactoring and style improvements** — keep the codebase clean, consistent,
   and easy to maintain
-
-## Adding a new game
-
-See `src/components/CLAUDE.md` for the `strategyGameFactory` API, the move and
-bot contracts, the store architecture, and the new-game checklist. It loads
-automatically when working under `src/components/`; read it directly when
-discussing that design without opening a file there.
 
 **Do not propose adopting boardgame.io.** The engine deliberately borrows its
 ideas — the long-form move shape and the external store already do — but the
 library itself is effectively unmaintained (no meaningful releases for years,
 and its React client pins React versions well behind the one used here). Build
 the rest in-repo.
+
+## Adding a new game
+
+The steps are in [README.md § Adding a new
+game](README.md#adding-a-new-game). The `strategyGameFactory` API, the move and
+bot contracts, the store architecture and the new-game checklist are in
+`src/components/CLAUDE.md`, which loads automatically when working under
+`src/components/`; read it directly when discussing that design without opening
+a file there.
 
 ## Dark mode
 
@@ -212,9 +199,7 @@ for its own sake.
 
 ## Internationalisation (i18n)
 
-See [README.md § Internationalisation
-(i18n)](README.md#internationalisation-i18n). Use the `t()` helper from
-`translate.ts`.
+See [README.md § Internationalisation (i18n)](README.md#internationalisation-i18n).
 
 ## Comments
 
@@ -235,9 +220,9 @@ if (nextBoard.length === 0) {
 return { nextBoard, isTurnEnd: true };
 ```
 
-This applies with particular force to moves on the outcome-returning `apply`
-contract: `gameEnd: { winnerIndex }` already names the winner, so prose
-narrating who won earns nothing.
+Say a thing once. Rationale that belongs to a rule of the repo lives in the doc
+that owns the rule, and the comment points at it (`see AGENTS.md § Testing`)
+rather than restating it — otherwise one decision goes stale in a dozen places.
 
 ## Unused parameters
 
@@ -245,11 +230,8 @@ A parameter that has to be written but is never read starts with `_`: the `meta`
 slot of a move whose `validate` only asks about the board, the value slot of an
 `(_, i) => …` callback. A bare `_` is fine when it is the only unused parameter
 in the signature; give it a name (`_board`, `_meta`) when a second one would
-collide with it, or when the name is worth reading.
-
-ESLint enforces this (`no-unused-vars` with `args: 'all'`), so an unused
-parameter left under its real name is an error rather than a silent
-inconsistency.
+collide with it, or when the name is worth reading. ESLint enforces this
+(`no-unused-vars` with `args: 'all'`).
 
 The rule is about parameters you are *forced* to write. One that is merely
 unwanted should be dropped instead — trailing parameters can simply be left off
@@ -268,9 +250,8 @@ starting, not after the diff has grown. Two rules cover most cases:
   design first with 2–3 games converted, the bulk conversion after.
 - **Migrate a contract with a legacy path, not in one commit.** The engine can
   accept the old and new shape at once, which turns "every game must change
-  together" into themed batches. This is how the move contract went: #361 added
-  the outcome-returning `apply` alongside the old one, ~10 batches migrated the
-  games by family, #385 dropped the legacy path. Follow that shape.
+  together" into themed batches — as the move contract went: add the new shape
+  alongside the old, migrate the games by family, then drop the legacy path.
 
 A mechanical sweep that follows a merged design PR is fine at any size — it is
 skimmable precisely because the pattern was already reviewed.

--- a/README.md
+++ b/README.md
@@ -3,20 +3,86 @@
 Code for the online, client-side versions of past strategy games at the Dürer
 Math Competition.
 
-The deployed version is here:
-https://jatek.durerinfo.hu/ .
-
-# Development
+The deployed version is here: https://jatek.durerinfo.hu/ .
 
 When you push to the default (main) branch, the tests are run, and if they are
 successful, the project is deployed to the live website within a few minutes.
+
+## Project setup
+
+Two ways to get started:
+
+- **Locally**: install the Node.js version in `.nvmrc` globally (or run `nvm use`
+  in the project directory), then run `npm ci`.
+- **Devcontainer**: a fairly minimal setup, written for local Docker. It pins
+  Node and bakes Playwright's Chromium into the image, so container creation
+  only has to run `npm ci`; it also ships the GitHub CLI and keeps `gh` and
+  Claude Code logins in named volumes across rebuilds. Details below.
+
+Claude Code on the web is neither: its container ships its own Node and starts
+without `node_modules`, so `.claude/hooks/session-start.sh` installs the pinned
+Node through nvm and puts it on `PATH` ahead of the image's own, then runs
+`npm ci` unless the installed tree is already sound. It reads the version from
+`.nvmrc` rather than restating it, so it is not another place to keep in sync.
+
+<details>
+<summary>Devcontainer details</summary>
+
+- **Codespaces** supports only a restricted set of devcontainer properties and
+  may ignore the `mounts` block, in which case none of the persistence below
+  happens.
+- **Playwright**: bumping `playwright` in `package.json` means bumping
+  `PLAYWRIGHT_VERSION` in `.devcontainer/Dockerfile` and rebuilding, or
+  Playwright looks for a browser revision that is not in the image.
+- **Node** is pinned in four other places besides the devcontainer feature in
+  `.devcontainer/devcontainer.json` (the image tag only fixes the major):
+  `.nvmrc`, `engines.node`, and the container image in both
+  `.github/workflows/*.yml`. Bump them together, or the container quietly runs
+  a different Node than CI. `npm run test` fails on either mismatch, so you
+  will not find out the hard way.
+- **npm's update notifier is off** (`NPM_CONFIG_UPDATE_NOTIFIER`): the npm that
+  matters is the one bundled with the pinned Node.
+- **`gh`** does not pick up your SSH key or VS Code's credential helper, so run
+  `gh auth login` once inside the container. A fine-grained token limited to
+  this repository is enough.
+- **Named volumes** keep the `gh` and Claude Code logins across rebuilds
+  (`CLAUDE_CONFIG_DIR` points at the default path only so `~/.claude.json` lands
+  inside the volume too). They take their `node` ownership from the image the
+  first time Docker creates them, so a volume from an older version of this
+  setup stays root-owned and **rebuilding does not repair it** — `gh auth login`
+  keeps failing. Remove them and rebuild:
+  `docker volume rm durer-gh-config durer-claude-home`. Volume names are per
+  Docker host, so every clone and worktree on one machine shares the login.
+
+</details>
+
+## Useful npm commands
+
+```bash
+npm run dev              # compiles and hot-reloads for development
+npm run test             # lint, typecheck and unit tests, as GitHub Actions runs them
+npm run lint:fix         # auto-fix simple formatting errors such as trailing spaces
+npm run build            # prod build — some problems only appear here
+
+npm run coverage         # line coverage, on demand
+npm run coverage:unswept # the same, without the two all-games sweeps
+npm run coverage:patch   # how much of what your branch adds a spec reaches
+```
+
+The three coverage commands, and which of them CI gates on, are explained in
+[AGENTS.md § Coverage](AGENTS.md#coverage).
+
+## IDE setup
+
+Recommended VS Code extensions:
+
+- [Eslint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
+- [Tailwind Css](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss)
 
 ## Adding a new game
 
 To keep track of who works on which game, use [this
 table](https://docs.google.com/spreadsheets/d/1-6u9PCtvf_gDHrs65x36pmDzFt4nZZx_IUuXrgS2aZk/edit#gid=0).
-
-TL;DR;
 
 1. Add the game metadata to `src/components/games/gameList.ts`.
 2. Create a folder for the game under `src/components/games` with the standard
@@ -28,157 +94,21 @@ TL;DR;
    `src/components/games/index.ts`, keyed by the game's `gameList` key. The router
    in `src/components/app/app.tsx` picks it up automatically — no edit needed there.
 
-*For more information, see Section [How to Develop](#how-to-develop)*
+Every field, edge case and enforcement rule of the engine API lives in
+[src/components/CLAUDE.md](src/components/CLAUDE.md). *It is recommended to copy
+and modify an existing, similar game.*
 
-## Project setup
+## Anatomy of a game
 
-Two ways to get started:
-
-- **Locally**: install the Node.js version in `.nvmrc` globally (or run `nvm use`
-  in the project directory), then run `npm ci`.
-- **Devcontainer**: there is a (fairly minimal) setup, written for local Docker.
-  It bakes Playwright's Chromium into the image and pins Node, so container
-  creation only has to run `npm ci`. It also ships the GitHub CLI and keeps `gh`
-  and Claude Code logins in named volumes across rebuilds.
-
-Claude Code on the web is neither: its container ships its own Node and starts
-without `node_modules`, so `.claude/hooks/session-start.sh` installs the pinned
-Node through nvm and puts it on `PATH` ahead of the image's own, then runs
-`npm ci` unless the installed tree is already sound. It reads the version from
-`.nvmrc` rather than restating it, so it is not another place to keep in sync.
-
-<details>
-<summary>Devcontainer details</summary>
-
-It is written for local Docker — GitHub Codespaces supports only a restricted
-set of devcontainer properties and may ignore the `mounts` block, in which case
-none of the persistence described below happens.
-
-It bakes a Chromium build for Playwright into the image at build time, so
-container creation only has to run `npm ci`. If you bump `playwright` in
-`package.json`, also bump `PLAYWRIGHT_VERSION` in `.devcontainer/Dockerfile` and
-rebuild the container — otherwise Playwright will look for a browser revision
-that is not in the image.
-
-Node is pinned the same way. The image tag only fixes the major version, so the
-exact one comes from the node devcontainer feature in `.devcontainer/devcontainer.json`
-and must match the three other places it is written down: `.nvmrc`, `engines.node`
-in `package.json`, and the container image in both `.github/workflows/*.yml`. Bump
-them together and rebuild, or the container quietly runs a different Node than CI does.
-
-`npm run test` fails on either mismatch, so you will not find out the hard way.
-
-The container also has npm's update notifier switched off
-(`NPM_CONFIG_UPDATE_NOTIFIER`). The npm that matters here is the one bundled with
-the pinned Node; upgrading it separately would only diverge from CI.
-
-The GitHub CLI (`gh`) is included too. It does not pick up your SSH key or VS Code's
-git credential helper, so run `gh auth login` once inside the container; the login is
-kept in a named Docker volume and survives rebuilds. A fine-grained token limited to
-this repository is enough for the usual PR and CI commands.
-
-Claude Code's config directory (`~/.claude`) is a named volume as well, so its login and
-settings — default permission mode, theme, notifications — survive rebuilds. `CLAUDE_CONFIG_DIR`
-is set to that same default path only so that `~/.claude.json`, which normally sits next to the
-directory, is stored inside the volume too.
-
-Both volumes get their `node` ownership from the image the first time Docker creates them.
-That means a volume created under an older version of this setup stays root-owned, and
-**rebuilding does not repair it** — `gh auth login` keeps failing. If you hit that, remove the
-volumes and rebuild:
-
-```bash
-docker volume rm durer-gh-config durer-claude-home
-```
-
-Volume names are per Docker host, so every clone, worktree and branch checkout on one
-machine shares the same login state.
-
-</details>
-
-## Useful npm commands
-<details>
-<summary>The commands</summary>
-
-### Compiles and hot-reloads for development
-
-```bash
-npm run dev
-```
-
-### Run tests
-
-```bash
-npm run test # lint and tests (as Github Actions)
-```
-
-Simple formatting errors such as trailing spaces can be automatically fixed with
-```bash
-npm run lint:fix
-```
-
-```bash
-npm run coverage         # line coverage, on demand
-npm run coverage:unswept # the same, without the two all-games sweeps
-npm run coverage:patch   # how much of what your branch adds a spec reaches
-```
-
-The first two are on demand, never part of `npm run test`, and with no threshold
-to pass.
-The plain report is for finding code **no spec loads at all** — it
-lists every file under `src/`, not only the ones a test imported. The global
-percentage is not a target: `plays-to-an-end.spec.ts` and `renders.spec.tsx`
-execute nearly every line under `games/` while asserting almost nothing, so it
-reads high whatever the state of the tests. `coverage:unswept` drops those two,
-and what falls to near zero there is the game logic those sweeps are the only
-thing touching.
-
-`coverage:patch` is the one that runs on every PR. It measures only the lines
-your branch **adds** to non-JSX files under `src/`, and only against
-`coverage:unswept` — so registering a game in `gameList.ts` does not count as
-covering it. Under 85% fails the build, and diffs under twenty measured lines
-never do — below that the percentage is arithmetic rather than a judgement.
-Failing means the added logic is not *unit-tested*, not that it is untested:
-a registered game is still played by `plays-to-an-end.spec.ts`, which catches an
-illegal move or a game that never ends, but nothing there asserts the strategy
-is right. Label the PR `skip coverage` to skip the job when a diff genuinely has
-nothing worth asserting.
-
-### Build for prod
-
-(some problems only appear in prod build, not while testing, for example using a
-variable without declaring it)
-
-```bash
-npm run build
-```
-
-</details>
-
-
-## IDE setup
-
-Recommended VS Code extensions:
-
-- [Eslint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
-- [Tailwind Css](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss)
-
-# How to develop
-
-This project uses the React frontend "framework", the [official
-tutorial](https://react.dev/learn) is a good starting point.
-
-The common parts of all games (showing rules, alternating turns, buttons for
-choosing a role, restart game) are extracted to a `strategyGameFactory`.
-
-
-*It is recommended to copy and modify an existing, similar game.*
-
-## Minimal demonstrative example
+This project uses the React frontend "framework"; the [official
+tutorial](https://react.dev/learn) is a good starting point. The common parts of
+all games (showing rules, alternating turns, buttons for choosing a role,
+restart game) are extracted to a `strategyGameFactory`, which a game hands four
+things.
 
 <details>
 
-<summary>The code</summary>
+<summary>A minimal demonstrative example</summary>
 
 ```tsx
 // gameplay.ts — the React-free rules half of the game
@@ -228,30 +158,12 @@ export const PlusOneTwo = strategyGameFactory({
 ```
 </details>
 
-## Anatomy of a game
-
-A game hands `strategyGameFactory` four things. What follows is the shape of
-each; every field, edge case and enforcement rule lives in
-[src/components/CLAUDE.md § strategyGameFactory
-API](src/components/CLAUDE.md#strategygamefactory-api).
-
 **`gameplay.moves`** — a move is one player-initiated change to the board, and
-the unit that keeps the game played by its rules. Each is `{ apply, validate? }`:
-
-```ts
-moves: {
-  removeCoin: {
-    validate: (board, { ctx }, value) => board[value - 1] > 0,
-    apply: (board, { ctx }, value) => ({ nextBoard, isTurnEnd: true })
-  }
-}
-```
-
+the unit that keeps the game played by its rules. Each is `{ apply, validate? }`.
 `apply` is a pure reducer that *returns* everything it causes — the next board,
-and whether the turn passed (`isTurnEnd`), the game ended
-(`gameEnd: { winnerIndex }`) or the mid-turn state changed (`nextTurnState`) —
-rather than causing it. It applies its arguments blindly; legality lives in the
-optional `validate` next to it, which is the single source of truth: the engine
+and whether the turn passed, the game ended or the mid-turn state changed —
+rather than causing it, and it applies its arguments blindly. Legality lives in
+the optional `validate` next to it, the single source of truth: the engine
 enforces it, and the `BoardClient` reads it back as
 `moves.<name>.isAllowed(board, ...args)` to drive `disabled`.
 
@@ -260,18 +172,14 @@ moves, given `board`, `ctx`, `moves` and `setTurnState`. State that only matters
 within a turn (a hover, a pending selection) belongs in the component, not in
 `board`.
 
-**`variants[].botStrategy`** — a pure function of the position that *names* the
-move it wants, `({ board, ctx }) => ({ move, args })`, or an array of those when
-a turn is one decision made of several moves. The engine plays them out and
-paces them, so a bot never calls a move, never threads a board and never uses
-`setTimeout`. Being a pure function, its decision can be read straight off the
-return value in a spec, and `runMatch` can play two strategies against each
-other through the real engine — see [AGENTS.md § Testing](AGENTS.md#testing).
+**`variants[]`** — each supplies `generateStartBoard()` or `startBoards`, and a
+`botStrategy`: a pure function of the position that *names* the move it wants,
+`({ board, ctx }) => ({ move, args })`. See [src/components/CLAUDE.md § Bot
+contract](src/components/CLAUDE.md#bot-contract), and [AGENTS.md §
+Testing](AGENTS.md#testing) for what being a pure function buys a spec.
 
 **`presentation`** — the rule text and `getPlayerStepDescription`, both i18n
 values.
-
-Each variant also supplies `generateStartBoard()`.
 
 ### Where it lives
 
@@ -279,11 +187,8 @@ A game folder splits along one line: `gameplay.ts` holds the `Board` type, the
 start boards, the `moves` and the legality and win-detection helpers they use,
 and never imports React — ESLint enforces that. The rest (`bot-strategy.ts`,
 `board-client.tsx`, `<game>.tsx` with the rule text and the factory call) sits
-on the React side. The split exists because a future server-authoritative
-competition mode has to validate moves in plain Node with the very same module
-(a future server-authoritative competition mode, see issue #313); it also
-lets specs and the bot's move pinning import the rules without dragging in JSX.
-Details in [AGENTS.md § Files in a game folder](AGENTS.md#architecture).
+on the React side. Which file holds what, and why the split exists, is in
+[AGENTS.md § Files in a game folder](AGENTS.md#files-in-a-game-folder).
 
 ### board and ctx
 
@@ -292,21 +197,12 @@ by the framework in `ctx`: `currentPlayer`, `isClientMoveAllowed` (guard every
 player interaction with it), `isHumanVsHumanGame`, `chosenRoleIndex`, and
 `turnState` for multi-stage turns. Never modify either in place.
 
-A multi-stage game pins what its `turnState` holds — `export type TurnState` in
-`gameplay.ts`, `BoardClientProps<Board, TurnState>` on the component — and the
-factory infers the rest of the config from there, so nothing has to cast it
-back. See [src/components/CLAUDE.md § Pinning the turn
-state](src/components/CLAUDE.md#strategygamefactory-api).
-
-Always pass the current `board` as a move's first argument, including to
-subsequent moves within the same turn. The framework's own state is
-authoritative — it lives in a synchronous store outside React — so the argument
-is not what makes the engine correct. It stays because a move is then a pure
-function of its inputs, callable on hypothetical boards by bot look-ahead and
-by specs, and because the explicit threading lets the engine catch chaining
-bugs: a stale board throws in development instead of corrupting the game. See
-[src/components/CLAUDE.md § Game state
-architecture](src/components/CLAUDE.md#game-state-architecture-synchronous-store-outside-react).
+A multi-stage game pins what its `turnState` holds ([§ Pinning the turn
+state](src/components/CLAUDE.md#pinning-the-turn-state)), and every move takes
+the current `board` as its first argument, including subsequent moves within one
+turn ([§ Game state
+architecture](src/components/CLAUDE.md#game-state-architecture-synchronous-store-outside-react)
+for why, given that the store is authoritative either way).
 
 ## Before opening a PR
 
@@ -357,9 +253,9 @@ same table on demand. It opens no pull requests — upgrading stays deliberate,
 majors one at a time as in
 [#168](https://github.com/a-gondolkodas-orome/durer-jatekok/issues/168). Why a
 report rather than dependabot or renovate: the header comment of
-`scripts/dependency-report.mjs`, and `docs/project-review-2026-08.md` §7.
+`scripts/dependency-report.mjs`.
 
-# License
+## License
 
 Copyright (c) 2020-present [A Gondolkodás Öröme
 Alapítvány](https://agondolkodasorome.hu/).

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -59,13 +59,10 @@ export default [
     }
   },
   {
-    // A game's gameplay.ts is its framework-free half — the module a future
-    // server-authoritative competition mode validates moves with, so it has to
-    // run in plain Node. See issue #313. A start-boards.ts is the same half:
-    // it is the curated data that competition mode hands out, so a server has
-    // to be able to read it without pulling in React. The .ts half of
-    // games/shared/ is engine-shaped for the same reason; its *-svg.tsx
-    // siblings are not matched.
+    // The React-free half of the repo, which has to run in plain Node
+    // (AGENTS.md § Files in a game folder). Beyond each game's gameplay.ts that
+    // is start-boards.ts, the curated data a competition hands out, and the .ts
+    // half of games/shared/ — its *-svg.tsx siblings are deliberately unmatched.
     files: [
       'src/components/games/**/gameplay.ts',
       'src/components/games/**/start-boards.ts',

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react-router": "8.3.0"
   },
   "//": [
-    "playwright is imported by no code here, so this is the only place to say why it is a dependency at all: the devcontainer bakes its Chromium into the image at build time, which means the version has to be written down somewhere the Dockerfile can be checked against — see ARG PLAYWRIGHT_VERSION there, which `npm run check:versions` compares this entry to."
+    "playwright is imported by no code here. It is a dependency so that its version is written down where the devcontainer's ARG PLAYWRIGHT_VERSION can be checked against it, which `npm run check:versions` does."
   ],
   "devDependencies": {
     "@eslint-react/eslint-plugin": "5.18.3",

--- a/scripts/check-versions.mjs
+++ b/scripts/check-versions.mjs
@@ -1,11 +1,6 @@
-// Two toolchain versions are written down in more than one place, and both mismatches stay
-// invisible until something fails far from the cause. Fail the test run instead.
-//
-// - playwright: the devcontainer image bakes a Chromium build in at build time, so the version
-//   lives both as a devDependency and as ARG PLAYWRIGHT_VERSION in the Dockerfile. On a mismatch
-//   Playwright looks for a browser revision that is not in the image.
-// - node: pinned in .nvmrc, package.json engines, both GitHub workflows and the node devcontainer
-//   feature. On a mismatch the container quietly runs a different Node than CI does.
+// Playwright and Node are each written down in several places (README § Project setup lists them),
+// and a mismatch stays invisible until something fails far from the cause. Fail the test run
+// instead.
 //
 // Files are compared against each other only — never against the running process.version, so a
 // contributor on a slightly different local patch is not blocked.

--- a/scripts/dependency-report.mjs
+++ b/scripts/dependency-report.mjs
@@ -1,11 +1,10 @@
-// Every version this project depends on is pinned exactly (`save-exact=true`, plus the lockfile),
-// so nothing ever drifts on its own and nothing ever goes stale loudly either — a dependency four
-// minors behind looks exactly like one released yesterday. This reports what is behind.
+// Under `save-exact=true` a dependency four minors behind looks exactly like one released
+// yesterday, so nothing goes stale loudly. This reports what is behind (README § Dependency
+// updates).
 //
 // It is the outward-facing half of scripts/check-versions.mjs: that one compares the versions
 // written down in this repo against *each other* and fails a build on a mismatch; this one compares
-// them against *upstream* and never fails anything. Deciding to upgrade stays a human act — see the
-// "Dependency updates" section of README.md.
+// them against *upstream* and never fails anything.
 //
 // Three sources, each read-only over the network:
 //   - npm packages: dependencies + devDependencies, against the registry's `latest` dist-tag.

--- a/scripts/patch-coverage.mjs
+++ b/scripts/patch-coverage.mjs
@@ -1,25 +1,12 @@
 // Reports how much of the *logic* a pull request adds is reached by a spec, and fails the build
-// when too little of it is. Not a coverage threshold: the global percentage is not a measure of
-// anything here (see AGENTS.md § Testing), and a gate on it would be satisfied by registering
-// another game. Only the lines this PR adds are measured, so the number cannot be diluted by the
-// rest of the repo and cannot drift as the repo grows.
+// when too little of it is. What it measures and why, including the 85% floor and the twenty-line
+// exemption, is in AGENTS.md § Coverage. Two implementation choices worth knowing here:
 //
-// Two decisions make it mean what it says:
-//
-//   - It reads the coverage of `npm run coverage:unswept`, not `npm run coverage`. The two sweeps
-//     (plays-to-an-end, renders) execute nearly every line under games/ while asserting almost
-//     nothing, so a new game registered in gameList.ts is *executed* the moment it exists. Measured
-//     against the full run, a game with no spec at all reads as fully covered — precisely the PR
-//     this is here to catch. With the sweeps excluded, what is left is coverage a real spec caused.
-//
+//   - It reads `npm run coverage:unswept`, so what is left is coverage a real spec caused.
 //   - It measures added *lines*, not files. Every non-spec .ts file in src/ is already at non-zero
 //     coverage, because the overview specs import gameList, which transitively loads every game;
 //     the floor is ~10% of top-level import and const lines, not 0%. So "this file is uncovered"
 //     never fires, while "these added lines never ran" does.
-//
-// Failing here means the added logic is not *unit-tested*. It does not mean it is untested: a
-// registered game still gets real conformance checking from the plays-to-an-end sweep, which throws
-// on an illegal move, a move named after the turn ended, and a game that never ends.
 import { appendFileSync, existsSync, readFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';

--- a/scripts/pre-generate-ai-moves/chess-bishops-optimal-3rd-moves.cjs
+++ b/scripts/pre-generate-ai-moves/chess-bishops-optimal-3rd-moves.cjs
@@ -11,7 +11,6 @@
 */
 
 const { flatMap, range, sample, cloneDeep, shuffle, isEqual } = require('lodash');
-const fs = require('fs');
 
 const boardSize = 8;
 
@@ -193,10 +192,6 @@ uniqueBishopPairs.map(([r1, c1, r2, c2]) => {
   const initialMessage = `Initial steps: ${JSON.stringify({ r1, c1, r2, c2 })}`;
   
   console.log(initialMessage);
-  // fs.appendFileSync(
-  //   './scripts/pre-generate-ai-moves/chess-bishops-third-steps.txt',
-  //   initialMessage + '\n'
-  // );
   
   const startDate = new Date();
   
@@ -211,10 +206,6 @@ uniqueBishopPairs.map(([r1, c1, r2, c2]) => {
   `.replace(/\s+/g, ' ');
   
   console.log(aiMoveMessage);
-  // fs.appendFileSync(
-  //   './scripts/pre-generate-ai-moves/chess-bishops-third-steps.txt',
-  //   aiMoveMessage + '\n'
-  // )
 
   optimalMoves[`${r1};${c1} - ${r2};${c2}`] = optimalMove['move'];
 })

--- a/scripts/pre-generate-ai-moves/chess-ducks/chess-ducks-optimal-2nd-moves.cjs
+++ b/scripts/pre-generate-ai-moves/chess-ducks/chess-ducks-optimal-2nd-moves.cjs
@@ -7,7 +7,6 @@
 */
 
 const { flatMap, range, sample, cloneDeep, shuffle } = require('lodash');
-const fs = require('fs');
 
 const [ROWS, COLS] = [4, 7];
 const [DUCK, FORBIDDEN] = [1, 2]
@@ -84,10 +83,6 @@ uniqueDuckPositions.map(([r1, c1]) => {
   const initialMessage = `Initial steps: ${JSON.stringify({ r1, c1 })}`;
   
   console.log(initialMessage);
-  // fs.appendFileSync(
-  //   './scripts/pre-generate-ai-moves/chess-ducks-2nd-steps.txt',
-  //   initialMessage + '\n'
-  // );
   
   const startDate = new Date();
   
@@ -102,10 +97,6 @@ uniqueDuckPositions.map(([r1, c1]) => {
   `.replace(/\s+/g, ' ');
   
   console.log(aiMoveMessage);
-  // fs.appendFileSync(
-  //   './scripts/pre-generate-ai-moves/chess-ducks-2nd-steps.txt',
-  //   aiMoveMessage + '\n'
-  // )
 
   if (optimalMove.optimal) {
     optimalMoves[`${r1};${c1}`] = optimalMove['move'];

--- a/scripts/pre-generate-ai-moves/chess-ducks/chess-ducks-optimal-3rd-moves.cjs
+++ b/scripts/pre-generate-ai-moves/chess-ducks/chess-ducks-optimal-3rd-moves.cjs
@@ -7,7 +7,6 @@
 */
 
 const { flatMap, range, sample, cloneDeep, shuffle, isEqual } = require('lodash');
-const fs = require('fs');
 
 const [ROWS, COLS] = [4, 7];
 const [DUCK, FORBIDDEN] = [1, 2];
@@ -155,10 +154,6 @@ uniqueDuckPairs.map(([r1, c1, r2, c2]) => {
   const initialMessage = `Initial steps: ${JSON.stringify({ r1, c1, r2, c2 })}`;
   
   console.log(initialMessage);
-  // fs.appendFileSync(
-  //   './scripts/pre-generate-ai-moves/chess-ducks-3rd-steps.txt',
-  //   initialMessage + '\n'
-  // );
   
   const startDate = new Date();
   
@@ -173,10 +168,6 @@ uniqueDuckPairs.map(([r1, c1, r2, c2]) => {
   `.replace(/\s+/g, ' ');
   
   console.log(aiMoveMessage);
-  // fs.appendFileSync(
-  //   './scripts/pre-generate-ai-moves/chess-ducks-3rd-steps.txt',
-  //   aiMoveMessage + '\n'
-  // )
 
   if (optimalMove.optimal) {
     optimalMoves[`${r1};${c1} - ${r2};${c2}`] = optimalMove['move'];

--- a/src/components/CLAUDE.md
+++ b/src/components/CLAUDE.md
@@ -262,40 +262,19 @@ state without going through a move, deliberately: a selection is not a move, so
 it must not bump `moveCount` or take an undo snapshot. Moves never get it; they
 return `nextTurnState` instead.
 
-**`useMoveScopedState(ctx.moveCount, initial)`** — for a `BoardClient`'s own
-mid-turn UI state: a half-made selection, a pending set of removals. The value
-is stamped with the `moveCount` at which it was set and exposed only while that
-stamp holds, so any move discards it during the next render.
+Three hooks in `strategy-game-factory/hooks/` cover the rest; each carries its
+own usage notes and footguns in its JSDoc, so reach for them rather than
+re-deriving the pattern:
 
-Do not clear such state with `useEffect(() => setX(initial), [ctx.moveCount])`.
-That repairs it one render too late — the browser paints a frame with the old
-selection over the advanced board — and it is a reset every component has to
-remember rather than a property of the state itself.
-
-```tsx
-const [selectedCell, setSelectedCell] = useMoveScopedState<number | null>(ctx.moveCount, null);
-```
-
-Two things to get right: `initial` is handed back on every stale render, so a
-non-primitive must be one stable reference (hoist it to module scope, never
-`[]` inline); and mid-turn state the *engine* has to see — anything
-`getPlayerStepDescription` reads — belongs in `ctx.turnState` instead, since
-this hook is local to the component.
-
-`useHoverPreview(ctx.moveCount)` is this hook plus pointer/focus plumbing, so
-board previews get the same invalidation for free.
-
-**`useDeferredMove(ctx.moveCount)`** — for a `BoardClient` whose single click
-submits a whole turn made of two moves (`pile-splitter`, `three-piles-rebuild`).
-Dispatch the first move, then hand the second to the returned function: it plays
-a `STEP_DELAY` later, so the board reads as two actions rather than one jump —
-the same beat the engine gives a bot's multi-move turn.
-
-Do not schedule that beat with a bare `setTimeout`. The callback closes over the
-board the first move produced, so a restart, a variant switch or an undo inside
-the window fires the move at a position that is gone — in dev that throws
-"stale board passed to move". The hook cancels on all of those (they rewind
-`moveCount`) and on unmount.
+- **`useMoveScopedState(ctx.moveCount, initial)`** — the `BoardClient`'s own
+  mid-turn UI state (a half-made selection, a pending set of removals),
+  discarded by the next move without a `useEffect` reset.
+- **`useHoverPreview(ctx.moveCount)`** — that hook plus pointer/focus plumbing,
+  so board previews get the same invalidation for free.
+- **`useDeferredMove(ctx.moveCount)`** — for a single click that submits a
+  two-move turn (`pile-splitter`, `three-piles-rebuild`): it plays the second
+  move a beat later, cancelling if a restart, variant switch or undo takes the
+  position away. Never schedule that beat with a bare `setTimeout`.
 
 ```tsx
 const deferMove = useDeferredMove(ctx.moveCount);

--- a/src/components/CLAUDE.md
+++ b/src/components/CLAUDE.md
@@ -11,7 +11,7 @@ Follow the steps in [README.md § Adding a new
 game](../../README.md#adding-a-new-game). Use `strategyGameFactory` (see
 `strategy-game-factory.tsx`) — copy a similar existing game as a starting point.
 
-### strategyGameFactory API
+## strategyGameFactory API
 
 Required params: `presentation`, `BoardClient`, `gameplay`, `variants`.
 
@@ -31,57 +31,75 @@ strategyGameFactory({
 })
 ```
 
-**`variants`** — array of `{ id?, botStrategy?, generateStartBoard?,
-startBoards?, label?, isDefault? }`. The default variant (marked
-`isDefault: true`, or the
-only entry if there is just one) must state its start position. If
-`botStrategy` is omitted on a variant, the default variant's `botStrategy` is
-used as fallback. If multiple variants are provided, exactly one must be
-`isDefault: true`. A single-entry array needs no `isDefault` flag.
+### Variants
 
-A variant states that start position **either** as `generateStartBoard`
+An array of `{ id?, botStrategy?, generateStartBoard?, startBoards?, label?,
+isDefault? }`. The default variant (marked `isDefault: true`, or the only entry
+if there is just one) must state its start position. If `botStrategy` is omitted
+on a variant, the default variant's `botStrategy` is used as fallback. If
+multiple variants are provided, exactly one must be `isDefault: true`. A
+single-entry array needs no `isDefault` flag.
+
+**Variants are addressable in the URL** as `?variant=`, alongside `?lang=` —
+`#/game/CoinsIn3Piles?variant=3-5-7`. The param and the selection are kept in
+step both ways; the default variant is the param's *absence* (as `hu` is for
+`?lang=`), and a param naming no variant of that game is ignored rather than
+obeyed. A param that changes without a remount is followed, because the app is
+hash-routed: a `?variant=` link to the game **already open** remounts nothing,
+so reading it once on mount would change the URL and leave the board untouched —
+which is exactly the link people share. Following it restarts the game, as
+choosing a variant does everywhere else in the UI.
+
+`id` is what the param names. It is optional — a variant without one is
+addressed by its index — and worth declaring where variants are really separate
+games and a link should survive them being reordered (`coins-in-3-piles`,
+`chess-ducks`, `ten-coins`); adding ids everywhere is not a goal. Ids must be
+unique and must not read as another variant's index; both throw.
+
+That key also names the variant in the `game-finished` analytics event
+(`variant: '3-5-7'` rather than `variant: 2`) and in the per-visitor win/loss
+counts in `localStorage` (`stats_<gameId>_<variantKey>`). Where no id is
+declared the key is the index, so reordering hands a variant the tally of
+whichever one used to sit at its position.
+
+### Curated start boards
+
+A variant states its start position **either** as `generateStartBoard`
 (`() => Board`) **or** as `startBoards` (`Board[]`, a curated list the engine
 picks from at random) — declaring both throws, as does an empty list.
-`startBoards` is the declarative form: the engine derives the generator from
-it, so nothing downstream distinguishes the two. Reach for it whenever the
-positions are enumerable rather than sampled — a competition hands out one
-entry per attempt (#314), so the list order is part of the contract (append,
-never reorder), and a spec can judge every entry instead of calling the
-generator a few hundred times until they have all come up. Each pick is cloned,
-so a curated board is as freshly owned by its match as a generated one.
+`startBoards` is the declarative form: the engine derives the generator from it,
+so nothing downstream distinguishes the two. Each pick is cloned, so a curated
+board is as freshly owned by its match as a generated one.
 
-The commonest case is a list of one: a game that always starts from the same
-position — an empty board, a full deck, a rook in the corner — writes
-`startBoards: [startBoard]` rather than wrapping that constant in a function
-nobody varies. `generateStartBoard` is then what it says: for positions that are
+Reach for the list whenever the positions are enumerable rather than sampled: a
+competition hands out one entry per attempt (#314), so the list order is part of
+the contract — **append, never reorder** — and a spec can judge every entry
+instead of calling the generator until they have all come up. The commonest case
+is a list of one, for a game that always starts from the same position:
+`startBoards: [startBoard]`, rather than wrapping that constant in a function
+nobody varies. `generateStartBoard` is then what it says — positions that are
 actually *generated*, by sampling or rejection.
 
 **Name the boards, not the list.** A module exports the positions themselves —
 `startBoard`, `startBoardOfCategoryA`, `adjacentStartBoards` — and the variant
 assembles the list where it is used: `startBoards: [startBoardOfCategoryA]`. A
-single position stays singular rather than being pluralised into a one-entry
-export, and the name says which position it is instead of restating the field
-it feeds.
+single position stays singular, and the name says which position it is instead
+of restating the field it feeds.
 
 **A spec never edits an exported board — it works on `cloneDeep(startBoard)`.**
-An exported board is module-scope data, and `isolate: false`
-(vite.config.js) shares one module registry across every spec file in a worker,
-so `const board = startBoard` followed by an in-place edit corrupts that board
-for every later file. It surfaces as a failure in an unrelated game, in some
-file orderings only — which is how it reached a deploy once.
-
-Reading one is fine; only an edit needs the copy. You do not have to work out
-which is which, and you should not try: `test-setup.ts` deep-freezes every
-exported start board, so an edit throws where it happens rather than surfacing
-somewhere else later. Judging it by eye is what failed before — the spec that
-broke the deploy asserted against the board it had just mutated, so it went
-green while breaking its neighbour. The freeze needs no per-game upkeep either:
-a board added tomorrow is covered without opting in.
+`isolate: false` (vite.config.js) shares one module registry across every spec
+file in a worker, so an in-place edit of module-scope data corrupts that board
+for every later file, surfacing as a failure in an unrelated game and in some
+file orderings only — which is how it reached a deploy once. Reading is fine;
+only an edit needs the copy, and you need not work out which is which:
+`test-setup.ts` deep-freezes every exported start board, with no per-game
+upkeep, so an edit throws where it happens.
 
 Curated boards want `forcedWinnerIndex` (`test-utils`) in their spec: it plays
 the game's own optimal bot against itself and returns the role that forces the
-win, throwing when playouts disagree. Assert the *role*, not just that the game
-ends — that is the property a competition depends on, since the team's role
+win, throwing when playouts disagree — which means either a board that is not
+decisive or a bot that is not optimal. Assert the *role*, not just that the game
+ends; that is the property a competition depends on, since the team's role
 choice is part of its strategy. See `coins-in-3-piles`, and
 `stones-remove-one-not-twice-from-left`, which uses it to cross-check the win
 predicate its own balance test relies on. A game whose bot searches too deeply
@@ -89,41 +107,12 @@ to play out repeatedly verifies its list against a characterisation instead —
 `bacteria` judges every curated board with `deficiency` and an independent
 brute-force solver.
 
-**Variants are addressable in the URL** as `?variant=`, alongside `?lang=` —
-`#/game/CoinsIn3Piles?variant=3-5-7`. The param and the selected variant are
-kept in step both ways: choosing a variant rewrites the param, and a param that
-changes without a remount is followed. The default variant is the param's
-*absence* (as `hu` is for `?lang=`), so dropping it selects the default; a param
-naming no variant of that game is ignored rather than obeyed.
+### moves
 
-Following the param matters because of the one case that is easy to miss: the
-app is hash-routed, so navigating to a `?variant=` link for the game **already
-open** remounts nothing. Read once on mount, such a link would change the URL
-and leave the board untouched — which is exactly the link people share. The
-cost is that following it restarts the game, but that is what choosing a variant
-means everywhere else in the UI, so the URL should not be the exception.
-
-`id` is what the param names. It is optional — a variant without one is
-addressed by its index, which is enough for most games — and is worth declaring
-where variants are really separate games and a link should survive them being
-reordered (`coins-in-3-piles`, `chess-ducks`, `ten-coins`). Ids must be unique,
-and must not read as another variant's index; both throw. Adding ids everywhere
-is not a goal: do it case by case, when a durable link is actually wanted.
-
-That key is what a variant is named by everywhere it is named at all: the URL,
-the `game-finished` analytics event (`variant: '3-5-7'` rather than
-`variant: 2`), and the per-visitor win/loss counts in `localStorage`
-(`stats_<gameId>_<variantKey>`). So declaring an id buys more than a durable
-link — it also keeps that game's tallies and its dashboard rows attached to the
-variant they belong to. Where no id is declared the key is the index, and all
-three only mean anything as long as that game's variant order holds; reordering
-hands a variant the tally of whichever one used to sit at its position.
-
-**`moves`** — every move is `{ apply, validate? }`: an optional legality
-predicate paired with an outcome-returning
-`(board, { ctx }, ...args) => MoveOutcome`. A move is handed nothing it could
-cause an effect through — everything it causes is data in the returned
-`MoveOutcome`:
+Every move is `{ apply, validate? }`: an optional legality predicate paired with
+an outcome-returning `(board, { ctx }, ...args) => MoveOutcome`. A move is
+handed nothing it could cause an effect through — everything it causes is data
+in the returned `MoveOutcome`:
 `{ nextBoard, isTurnEnd?, nextTurnState?, gameEnd?, autoEndOfTurn? }`.
 `isTurnEnd: true` passes the turn (omitted = further moves follow in the same
 turn); `gameEnd: { winnerIndex }` ends the game with an always-explicit winner
@@ -132,49 +121,50 @@ turn); `gameEnd: { winnerIndex }` ends the game with an always-explicit winner
 `nextTurnState` sets `ctx.turnState` (`null` clears, omitted keeps);
 `autoEndOfTurn: true` schedules `endOfTurnMove`. Causing nothing directly is
 what makes a move a pure reducer, and what lets the same function run in a
-future authoritative competition server (see issue #313).
+future authoritative competition server (issue #313).
 
 Always pass the current `board` as first arg when chaining moves within a turn.
 `apply` does not validate its arguments — it applies them blindly; legality is
-enforced by `validate` (below) and/or the `BoardClient`'s `disabled` gating.
+enforced by `validate` and/or the `BoardClient`'s `disabled` gating.
 
-**`validate`** (optional, per move) — a pure, side-effect-free legality predicate
-`(board, { ctx }, ...args) => boolean` sitting right next to its `apply`. When
-present, the engine rejects any dispatch whose args fail it (in dev it throws
-loudly to surface the bug; in prod it warns, fires an `illegal-move` analytics
-event, and no-ops so a stray call cannot corrupt the board). Omitting it means
-"always legal", so this is fully opt-in and moves whose legality is trivial
-simply leave it out. The validator is the **single source of truth** for
-legality: it drives the engine's enforcement, and — being React-free — a
-possible future server-side authoritative check can reuse the same predicate.
-Do **not** put the "whose turn is it" check (`ctx.isClientMoveAllowed`) inside
-`validate`; the engine folds that in for the client (below). The engine hands
-out two wrappings of the same moves: the `moves` object the `BoardClient`
-receives **silently ignores** any dispatch that fails `isAllowed` (so a stray
-click — even on a button a browser failed to disable — is a harmless no-op),
-while bot and auto `endOfTurnMove` dispatches are checked against `validate`
-alone and fail loudly (dev: throw; prod: warn + `illegal-move` analytics event
-+ no-op), since there an illegal move is a bug. See `coins-in-3-piles`
-(two-phase turn) and `cube-coloring` (reuses the existing `isAllowedStep`
-helper) for examples.
+#### validate
+
+Optional, per move: a pure, side-effect-free legality predicate
+`(board, { ctx }, ...args) => boolean` sitting right next to its `apply`.
+Omitting it means "always legal", so moves whose legality is trivial simply
+leave it out. It is the **single source of truth** for legality — it drives the
+engine's enforcement, and being React-free a future server-side authoritative
+check can reuse it. Do **not** put the "whose turn is it" check
+(`ctx.isClientMoveAllowed`) inside `validate`; the engine folds that in for the
+client.
+
+The engine hands out two wrappings of the same moves. The `moves` object the
+`BoardClient` receives **silently ignores** any dispatch that fails `isAllowed`,
+so a stray click — even on a button a browser failed to disable — is a harmless
+no-op. Bot and auto `endOfTurnMove` dispatches are checked against `validate`
+alone and fail loudly (dev: throw; prod: warn + `illegal-move` analytics event +
+no-op), since there an illegal move is a bug. See `coins-in-3-piles` (two-phase
+turn) and `cube-coloring` (reuses the existing `isAllowedStep` helper).
 
 Both halves take `(board, { ctx }, ...args)`, and the meta slot sits *before* the
-game-specific args, so it has to be written even when the move ignores it. Write
-it `_` then — `validate: (board: Board, _, cell: number) => …` — and `_board`
-when it is the board that goes unread instead. This is the repo-wide rule for
-unused parameters (AGENTS.md § Unused parameters); ESLint enforces it.
+game-specific args, so it has to be written even when the move ignores it — as
+`_`, or `_board` when it is the board that goes unread (AGENTS.md § Unused
+parameters).
 
-**`moves.<name>.isAllowed(board, ...args)`** — exposed on every move of the
-`BoardClient`'s wrapped `moves` object: `ctx.isClientMoveAllowed` (turn
-ownership) AND the move's `validate` (when defined), with `ctx` already bound.
-Drive button `disabled` state with it. Because the engine applies the same
-check to every client dispatch, click handlers need no `if (!allowed) return`
-guards — keep one only when the handler couples local UI state to a successful
-move (see `cube-coloring`'s colour-selection reset). Not for bots: a bot is
-handed no move wrappers at all (see the bot contract below), so it enumerates
-legal moves via the raw `validate`/helpers instead.
+#### `moves.<name>.isAllowed(board, ...args)`
 
-**Bot contract** — a `botStrategy` is a pure function of the position,
+Exposed on every move of the `BoardClient`'s wrapped `moves` object:
+`ctx.isClientMoveAllowed` (turn ownership) AND the move's `validate` (when
+defined), with `ctx` already bound. Drive button `disabled` state with it.
+Because the engine applies the same check to every client dispatch, click
+handlers need no `if (!allowed) return` guards — keep one only when the handler
+couples local UI state to a successful move (see `cube-coloring`'s
+colour-selection reset). Not for bots: a bot is handed no move wrappers at all,
+so it enumerates legal moves via the raw `validate`/helpers instead.
+
+### Bot contract
+
+A `botStrategy` is a pure function of the position,
 `({ board, ctx }) => BotMove | BotMove[]`, where a `BotMove` is
 `{ move: string, args?: unknown[] }`. It **names** the move it wants rather than
 playing it: no move wrappers, no board to thread, no `setTimeout`. Naming a
@@ -191,15 +181,13 @@ is fine (they are dropped).
 Two hosts play a named turn out: the browser shell in
 `strategy-game-factory.tsx` and the headless runner in `engine/run-match.ts`.
 They differ deliberately in pacing and in how loudly they complain — a bad
-strategy must not crash the site in production, while headless it should throw
-— but *which* moves land has to be identical.
-`engine/bot-turn-agreement.spec.tsx` plays the same turn through both and
-compares, so the two cannot drift apart on what counts as a bug.
+strategy must not crash the site in production, while headless it should throw —
+but *which* moves land has to be identical, which
+`engine/bot-turn-agreement.spec.tsx` pins by playing the same turn through both.
 
-Left unpinned, `BotMove` is `{ move: string, args?: unknown[] }`, so neither a
-mistyped name nor wrong arguments surface until the bot plays the move (dev:
-throw). A game pins both by exporting its moves as a type, next to the moves
-themselves:
+Left unpinned, neither a mistyped move name nor wrong arguments surface until
+the bot plays the move (dev: throw). A game pins both by exporting its moves as
+a type, next to the moves themselves:
 
 ```ts
 // gameplay.ts, under the moves object
@@ -224,7 +212,10 @@ parameter there types as `any` and silently checks nothing, so annotate them.
 `BotStrategy<Board>` (or a bare name union) still works and pins nothing beyond
 the name; a game that has not been converted yet keeps compiling.
 
-**`ctx`** fields available in moves and `BoardClient`:
+### ctx
+
+Available in moves and `BoardClient`:
+
 - `currentPlayer`: 0/1 — use this for game logic in both modes
 - `isClientMoveAllowed`: boolean — guard all player interactions with this
 - `isHumanVsHumanGame`: boolean — branch mode-specific rendering if needed
@@ -233,9 +224,10 @@ the name; a game that has not been converted yet keeps compiling.
   remembered during a turn if needed, i.e. to expose it from BoardClient to
   getPlayerStepDescription
 
-**Pinning the turn state.** Left unpinned, `ctx.turnState` is `unknown`, and
-every reader casts. A multi-stage game names the shape instead, next to the
-moves that produce it:
+#### Pinning the turn state
+
+Left unpinned, `ctx.turnState` is `unknown`, and every reader casts. A
+multi-stage game names the shape instead, next to the moves that produce it:
 
 ```ts
 // gameplay.ts — the payload only; the engine adds the `| null` every turn
@@ -261,6 +253,8 @@ Bots are deliberately left out: a bot is asked again with a fresh `ctx` for
 every move it still owes, so it plans a whole turn rather than reading its own
 half-made selection back. `BotStrategy` therefore stays
 `BotStrategy<Board, Moves>` and sees `turnState` as `unknown`.
+
+### BoardClient state
 
 **`setTurnState(stage)`** — a `BoardClient`-only prop, for components that keep
 mid-turn UI state in `ctx.turnState`. It is the one path that writes engine
@@ -312,20 +306,22 @@ const clickPiece = ({ pileId, pieceId }: Piece) => {
 };
 ```
 
-### Game state architecture: synchronous store outside React
+## Game state architecture: synchronous store outside React
 
 Authoritative game state (`board`, `phase`, `currentPlayer`, `turnState`,
 `moveCount`, …) lives in a small synchronous store outside React
 (`strategy-game-factory/engine/store.ts`); the factory component subscribes via
 `useSyncExternalStore` and renders snapshots of it. Every dispatch — from the
 `BoardClient`, a bot, or the auto `endOfTurnMove` — is validated and applied by
-a framework-free reducer (`engine/reducer.ts`)
-against `store.getState()`, so bots and chained `setTimeout` dispatches can
-never observe a stale render snapshot. Validators may depend on **any** `ctx`
-field (`turnState`, `moveCount`, …); `ctx` is always derived fresh from the
-store (`engine/build-ctx.ts`). This boardgame.io-style architecture replaced
-the earlier per-field workarounds (a render-synced `ctxRef` shadow) that made
-staleness a reviewable hazard.
+a framework-free reducer (`engine/reducer.ts`) against `store.getState()`, so
+bots and chained `setTimeout` dispatches can never observe a stale render
+snapshot. Validators may depend on **any** `ctx` field, which is always derived
+fresh from the store (`engine/build-ctx.ts`). This boardgame.io-style
+architecture replaced per-field workarounds (a render-synced `ctxRef` shadow)
+that made staleness a reviewable hazard; "boardgame.io-style" means the
+architecture only — see [AGENTS.md § Planned future
+directions](../../AGENTS.md#planned-future-directions) for why the library
+itself is not adopted.
 
 Two conventions to keep in mind:
 
@@ -337,20 +333,12 @@ Two conventions to keep in mind:
   because it keeps a move a pure function of its inputs, callable on
   hypothetical boards outside a live game — bot look-ahead and specs both do
   that.
-- The `engine/` modules are React-free by design — they are the seed of the
-  headless engine a future server-authoritative competition mode needs (see
-  issue #313). Don't import React (or
-  anything React-flavoured) there; ESLint enforces it, as it does for each
-  game's `gameplay.ts`.
+- The `engine/` modules are React-free by design, for the reason each game's
+  `gameplay.ts` is ([AGENTS.md § Files in a game
+  folder](../../AGENTS.md#files-in-a-game-folder)). Don't import React (or
+  anything React-flavoured) there; ESLint enforces it.
 
-Note "boardgame.io-style" means the architecture only. **Do not propose
-adopting boardgame.io itself**: it is a good library but effectively
-unmaintained (no meaningful releases for years, and its React client pins
-React versions well behind the one used here). Borrow its ideas — the
-long-form move shape and the external store already do — and build the rest
-in-repo.
-
-### New game checklist
+## New game checklist
 
 - Game works correctly in both `vsComputer` and `vsHuman` mode
 - Starting positions representative of the game's complexity; each player wins
@@ -373,7 +361,7 @@ in-repo.
 - The bot names its moves and schedules nothing: the engine paces multi-move
   turns so the AI appears to "think"
 
-### Bot / variant conventions
+## Bot / variant conventions
 
 These are deliberate design choices — treat them as expected, don't "fix" them:
 

--- a/src/components/games/architect-and-bandits/gameplay.ts
+++ b/src/components/games/architect-and-bandits/gameplay.ts
@@ -26,10 +26,8 @@ export const isArchitectStepAllowed = (board: Board, targetVertex: number, kmPer
 
 export const makeStartBoard = (vertexCount: number): Board => {
   const towers = Array(vertexCount).fill(false);
-  /*
-  Workaround to have a tower at the start of day 1, as startOfTurnMove or
-  similar is not supported by framework.
-  */
+  // Day 1 has to open with a tower already built, and the engine has no
+  // start-of-turn hook (only `endOfTurnMove`), so it goes into the start board.
   towers[0] = true;
   return {
     architectPosition: 0,

--- a/src/components/games/dominoes-4x4/bot-strategy.ts
+++ b/src/components/games/dominoes-4x4/bot-strategy.ts
@@ -23,9 +23,6 @@ const boardToMask = (board: Board): number => {
 
 type MaskMove = { domino: Domino; mask: number };
 
-// All legal placements for `player` given the occupied-cell `mask`.
-// player 0 places vertical dominoes (two cells in the same column),
-// player 1 places horizontal dominoes (two cells in the same row).
 const movesForPlayer = (mask: number, player: number): MaskMove[] => {
   const result: MaskMove[] = [];
   for (let row = 0; row < BOARDSIZE; row++) {

--- a/src/components/games/gameplay-react-free.spec.ts
+++ b/src/components/games/gameplay-react-free.spec.ts
@@ -1,9 +1,8 @@
-// Every game's gameplay.ts has to run in plain Node: it is the module a
-// server-authoritative competition mode would validate moves with (see
-// issue #313). ESLint bans `react` and the factory barrel by
-// specifier, but it cannot tell that a specifier like './pebble-pile' resolves
-// to a .tsx — that is what this walk is for, and it follows the .ts files it
-// finds so an indirect pull is caught too.
+// Every game's gameplay.ts has to run in plain Node (AGENTS.md § Files in a
+// game folder). ESLint bans `react` and the factory barrel by specifier, but it
+// cannot tell that a specifier like './pebble-pile' resolves to a .tsx — that is
+// what this walk is for, and it follows the .ts files it finds so an indirect
+// pull is caught too.
 const sources = import.meta.glob('./**/*.{ts,tsx}', { query: '?raw', import: 'default', eager: true }) as
   Record<string, string>;
 

--- a/src/components/games/hunyadi-and-the-janissaries/gameplay.ts
+++ b/src/components/games/hunyadi-and-the-janissaries/gameplay.ts
@@ -5,9 +5,9 @@ export type Board = SoldierColor[][];
 export type Soldier = { rowIndex: number; pieceIndex: number; group: SoldierColor };
 
 export const generateStartBoard = (): Board => {
-  // this code is not 50% Hunyadi - 50% Szultan winnin position generator,
-  // but relatively balanced and biased toward situations with more soldiers
-  // and not single-step game
+  // Not an exact 50/50 generator between the two roles, only a roughly balanced
+  // one, biased towards boards with more soldiers so the game lasts more than a
+  // single step.
   const rowCount = 5;
   let board: SoldierColor[][] = [];
   // Complexity score: a soldier counts for more the closer to the castle it

--- a/src/components/games/magic-box/magic-box-b/magic-box-b.tsx
+++ b/src/components/games/magic-box/magic-box-b/magic-box-b.tsx
@@ -26,11 +26,9 @@ const rule = {
 export const MagicBoxB = strategyGameFactory({
   presentation: {
     rule,
-    /*
-    Only the first player can move first in the framework implementation, but
-    the rule says the second player moves first, meaning they make a line
-    designation move, and then the first player will make a stone placement move
-    */
+    // The engine always seats player 0 first, but here it is the *second*
+    // player who opens (with a line designation), so the roles are labelled the
+    // other way round rather than the seating being changed.
     roleLabels: [
       { hu: 'Másodszor rakok', en: "I'll place second" },
       { hu: 'Először rakok', en: "I'll place first" }

--- a/src/components/games/pile-splitting-games/pile-splitter-3/bot-strategy.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter-3/bot-strategy.ts
@@ -49,9 +49,10 @@ export const getSmartBotStep = (board: Board): BotStep => {
       pieceCount: getOptimalDivision(board[start])
     };
   } else {
-    // this is the case where all piles have even number of pieces
-    // should not occur in an optimal game with 37 pieces
-    // with this the enemy also has a strategy when the game starts with 36 pieces
+    // Every pile even and not all 2: halving is the same position one scale
+    // down, so the odd-pile strategy above applies to it. The 37-piece start is
+    // odd, so an optimal line never reaches here — it is the branch that keeps
+    // the bot playing well after the opponent has left one.
     const botStep = getSmartBotStep(board.map((x) => x / 2));
     return { ...botStep, pieceCount: botStep.pieceCount * 2 };
   }

--- a/src/components/games/policeman-thief/policeman-thief-c/bot-strategy.ts
+++ b/src/components/games/policeman-thief/policeman-thief-c/bot-strategy.ts
@@ -4,12 +4,11 @@ import type { BotMove, BotStrategy } from 'strategy-game-factory';
 
 type Bot = BotStrategy<Board, Moves>
 
-// ---------------------------------------------------------------------------
-// Minimax core (exhaustive; the graph and rules are fixed so the memo below is
-// valid for the whole session). A "round" is: all policemen move, then the
-// thief moves. The thief wins by completing 3 moves without ever sharing a
-// vertex with a policeman.
-// ---------------------------------------------------------------------------
+// --- Minimax core -----------------------------------------------------------
+// Exhaustive; the graph and rules are fixed so the memo below is valid for the
+// whole session. A "round" is: all policemen move, then the thief moves. The
+// thief wins by completing 3 moves without ever sharing a vertex with a
+// policeman.
 
 const sortedKey = (cops: number[]) => [...cops].sort((a, b) => a - b).join(',');
 
@@ -106,9 +105,7 @@ const argExtreme = <T,>(arr: T[], keyFn: (x: T) => number, wantMax: boolean): T[
 
 const totalCentrality = (v: number) => range(VERTEX_COUNT).reduce((s, u) => s + dist[v][u], 0);
 
-// ---------------------------------------------------------------------------
-// Smart (optimal) bot
-// ---------------------------------------------------------------------------
+// --- Smart (optimal) bot ----------------------------------------------------
 
 const chooseCopPlacement = (copCount: number): number[] => {
   const winning = winningPlacements(copCount);
@@ -168,11 +165,10 @@ export const smartBotStrategy: Bot = ({ board, ctx }) => {
   return board.phase === 'placingThief' ? placeThiefOptimally(board) : moveThiefOptimally(board);
 };
 
-// ---------------------------------------------------------------------------
-// Random test bot: plays random legal moves, but always grabs an immediate
-// catch (police) or a safe step (thief) when one is available. This lets a
-// human thief realistically win, unlike the optimal bot.
-// ---------------------------------------------------------------------------
+// --- Random test bot --------------------------------------------------------
+// Plays random legal moves, but always grabs an immediate catch (police) or a
+// safe step (thief) when one is available, so a human thief can realistically
+// win, unlike against the optimal bot.
 
 const placeCopsRandom = (board: Board): BotMove<Moves>[] =>
   asCopMoves('placeCop', range(board.copCount).map(() => random(0, VERTEX_COUNT - 1)));

--- a/src/components/games/recolouring-discs/gameplay.ts
+++ b/src/components/games/recolouring-discs/gameplay.ts
@@ -1,17 +1,4 @@
 import type { Ctx, MoveOutcome } from 'strategy-game-factory';
-// Recolouring discs — core game logic.
-//
-// A row of `n` fields. Field 0 starts with a red disc, field n-1 with a blue
-// disc. Player 0 (red) moves first, player 1 (blue) second. On a turn a player
-// either moves one own disc 1–2 fields into an empty cell (may jump over a
-// disc), places a new own disc on an empty cell adjacent to one of their own
-// discs, or passes. Whenever a disc *enters* an empty cell, every
-// opposite-coloured disc in an adjacent cell flips to the mover's colour.
-//
-// Red wins the instant red has strictly more than n/2 discs; blue wins the
-// instant blue has at least n/2 discs; if neither happens within 200 plies,
-// blue wins.
-
 import { range, sample } from 'lodash';
 
 export type Cell = 'red' | 'blue' | null;

--- a/src/components/games/remove-row-or-column/gameplay.ts
+++ b/src/components/games/remove-row-or-column/gameplay.ts
@@ -52,7 +52,6 @@ export const getRectangles = (grid: Grid): Rect[] => {
   return rects;
 };
 
-// Remove every disc in the chosen row / column of the rectangle containing (r, c).
 export const applyMove = (grid: Grid, { r, c, orientation }: Move): Grid => {
   const rect = getRectangleAt(grid, r, c)!;
   const next = grid.map(row => row.slice());

--- a/src/components/games/ten-coins/bot-strategy.ts
+++ b/src/components/games/ten-coins/bot-strategy.ts
@@ -22,6 +22,9 @@ const isWinningMove = (move: Move): boolean =>
   // leaves the opponent in a losing position.
   move.resultSet.length === 1 || !playerToMoveWins(move.resultSet);
 
+// The exhaustive answer, for reference: the sets losing for the player to move
+// are {1,2,3} over values 1..4, and {1,2,3}, {1,4,5}, {2,3,4,5}, {1,2,3,4,5}
+// over values 1..5. Every other set is a win, driven towards one of those.
 const winMemo: Record<string, boolean> = {};
 const playerToMoveWins = (set: number[]): boolean => {
   const key = set.join(',');

--- a/src/components/games/ten-coins/ten-coins.tsx
+++ b/src/components/games/ten-coins/ten-coins.tsx
@@ -9,15 +9,6 @@ import {
 } from './gameplay';
 import { distinctValues, randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
-// --- Exact solver over the non-empty subsets of the present values ------------
-// A move picks a present value K and turns *all* K-coins into some L < K, so the
-// set of distinct values goes from S to (S \ {K}) ∪ {L}. You win when only one
-// distinct value remains after your move.
-
-// Losing positions (second player to move wins): {1,2,3} for values 1..4; and
-// {1,2,3}, {1,4,5}, {2,3,4,5}, {1,2,3,4,5} for values 1..5. Everything else is a
-// first-player win, driven towards one of these (or merged to a single value).
-
 const BoardClient = ({ board, ctx, setTurnState, moves }: BoardClientProps<Board, TurnState>) => {
   const { t } = useTranslation();
   const selectedValue = ctx.turnState;

--- a/src/components/games/tictactoe-alikes/board-client.tsx
+++ b/src/components/games/tictactoe-alikes/board-client.tsx
@@ -11,10 +11,8 @@ import { type Board } from './gameplay';
 export const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
   const pieceColor = (id: number) => board[id] === 'red' ? 'bg-red-800' : 'bg-blue-800';
 
-  /*
-  Due to simulating borders with the background peeking through gaps, we need
-  to explicitly give surface background to children.
-  */
+  // The grid gap is the border: the container colour shows through it, so every
+  // cell needs its own background or the gaps disappear into it.
   return (
     <GameBoard>
       <div className="grid grid-cols-3 bg-slate-200 dark:bg-slate-600 gap-1 p-1">

--- a/src/components/games/tictactoe-alikes/tictactoe/tictactoe.tsx
+++ b/src/components/games/tictactoe-alikes/tictactoe/tictactoe.tsx
@@ -23,10 +23,8 @@ const BoardClient = ({ board, moves }: BoardClientProps<Board>) => {
     return 'bg-blue-800';
   };
 
-  /*
-  Due to simulating borders with the background peeking through gaps, we need
-  to explicitly give surface background to children.
-  */
+  // The grid gap is the border: the container colour shows through it, so every
+  // cell needs its own background or the gaps disappear into it.
   return (
   <GameBoard>
     <div className="grid grid-cols-3 bg-slate-200 dark:bg-slate-600 gap-1 p-1">

--- a/src/components/strategy-game-factory/engine/bot-turn.ts
+++ b/src/components/strategy-game-factory/engine/bot-turn.ts
@@ -1,15 +1,11 @@
 import type { BotMove } from '../types';
 import type { CoreState } from './store';
 
-// The bot contract: a strategy NAMES the moves it wants — one, or the whole
-// turn when the turn is one decision — and its caller plays them out: the React
-// shell with a pause between them so the bot appears to think, the headless
-// runner (run-match.ts) immediately.
-//
-// Pacing is therefore the caller's concern, never the strategy's: a bot that
-// scheduled its own follow-up move with setTimeout could not run outside a
-// browser, which is exactly what an authoritative server would have to do
-// (issue #313).
+// A strategy NAMES the moves it wants and its caller plays them out — the React
+// shell paced, the headless runner (run-match.ts) immediately. Pacing is
+// therefore the caller's concern, never the strategy's: a bot that scheduled its
+// own follow-up with setTimeout could not run outside a browser. See
+// src/components/CLAUDE.md § Bot contract.
 export const asBotMoves = (named: BotMove | BotMove[]): BotMove[] =>
   Array.isArray(named) ? named : [named];
 

--- a/src/components/strategy-game-factory/engine/build-ctx.ts
+++ b/src/components/strategy-game-factory/engine/build-ctx.ts
@@ -1,17 +1,15 @@
 import type { Ctx } from '../types';
 import type { CoreState } from './store';
 
-// Derives the ctx games see (moves, validators, BoardClient, bot) from the
-// authoritative CoreState. Called fresh at every use, so consumers always see
-// current values — there is no cached/stale ctx anywhere anymore.
+// Derives the ctx games see from the authoritative CoreState, fresh at every
+// use, so there is no cached ctx to go stale.
 //
 // The fields are listed out rather than spread from `state` on purpose: this is
 // the allow-list defining the public ctx surface. `{ ...state }` would also hand
 // games `board` (a second source of truth competing with the board threaded
-// through moves), the raw `mode` (ctx deliberately exposes only the derived
-// `isHumanVsHumanGame`), and `undoSnapshot`/`currentTurnHasMoves` — engine
-// bookkeeping that would silently become public API, and that an authoritative
-// server must never ship to a client.
+// through moves), the raw `mode` (only the derived `isHumanVsHumanGame` is
+// public), and `undoSnapshot`/`currentTurnHasMoves` — engine bookkeeping that
+// would silently become API.
 export const buildCtx = <TBoard, TTurnState>(
   state: CoreState<TBoard, TTurnState>, resolvedPlayerNames: [string, string]
 ): Ctx<TTurnState> => ({

--- a/src/components/strategy-game-factory/engine/run-match.ts
+++ b/src/components/strategy-game-factory/engine/run-match.ts
@@ -24,11 +24,8 @@ export type MatchResult<TBoard> = {
 const PLAYER_NAMES: [string, string] = ['0', '1'];
 
 // Plays a whole game outside React: two strategies, the real moves, the real
-// reducer. This is the browser-free half of the match loop an authoritative
-// competition server needs (issue #313) — issue a start
-// board, validate every move, drive the bot, detect the end — and, today, the
-// way a game's spec plays its bots against each other without faking `moves`
-// or re-implementing win detection.
+// reducer — so a game's spec plays its bots against each other without faking
+// `moves` or re-implementing win detection.
 //
 // Everything that goes wrong throws: unlike the shell, which must keep a live
 // game playable, a headless match only ever runs in tests and CI, where a

--- a/src/components/strategy-game-factory/engine/store.ts
+++ b/src/components/strategy-game-factory/engine/store.ts
@@ -4,9 +4,6 @@ import type { Mode, Phase } from '../types';
 // dispatches (setTimeout closures) read and write it synchronously through the
 // store, so they can never observe a stale snapshot — the root cause behind
 // the old board-threading convention and the ctxRef per-field shadow.
-// This module is framework-free (no React import): together with reducer.ts
-// and build-ctx.ts it is the seed of the headless engine a future
-// server-authoritative competition mode needs (issue #313).
 export type CoreState<TBoard, TTurnState = unknown> = {
   board: TBoard
   phase: Phase

--- a/src/components/strategy-game-factory/helpers/resolve-variants.ts
+++ b/src/components/strategy-game-factory/helpers/resolve-variants.ts
@@ -1,16 +1,14 @@
 import { cloneDeep, sample } from 'lodash';
 import type { VariantInput } from '../types';
 
-// A variant states its start position either as a generator or as a curated
-// list, and everything downstream only ever sees the generator — `startBoards`
-// is the declarative form of `generateStartBoard`, not a second channel.
+// Everything downstream only ever sees the generator, so `startBoards` is the
+// declarative form of `generateStartBoard`, not a second channel.
 //
-// The pick is cloned so that a generator built from a list keeps the guarantee
-// every game is already written against: a start board is freshly owned by the
-// match it starts. Nothing mutates one today, but the list is module-scope data
-// shared by every match, so without the clone one in-place write — which
-// nothing here can detect — would silently corrupt every later game started
-// from that entry, and hand one object to every team of a competition.
+// The pick is cloned to keep the guarantee every game is already written
+// against: a start board is freshly owned by the match it starts. The list is
+// module-scope data shared by every match, so without the clone one in-place
+// write — which nothing here can detect — would corrupt every later game
+// started from that entry, and hand one object to every team of a competition.
 const startBoardGenerator = <TBoard,>({ generateStartBoard, startBoards }: VariantInput<TBoard>) => {
   if (generateStartBoard) return generateStartBoard;
   if (!startBoards) return undefined;

--- a/src/components/strategy-game-factory/hooks/use-hover-preview.ts
+++ b/src/components/strategy-game-factory/hooks/use-hover-preview.ts
@@ -1,13 +1,10 @@
 import { useMoveScopedState } from './use-move-scoped-state';
 
 /**
- * Move-scoped hover state for board previews.
- *
- * The hover is `useMoveScopedState` (which owns the moveCount stamping) plus
- * the pointer/focus plumbing: any move invalidates the preview on the very
- * next render, which is what stops one from "sticking" after a move on touch
- * devices, where no `pointerleave` fires (the original reason the `moveCount`
- * guard was added).
+ * Move-scoped hover state for board previews: `useMoveScopedState` plus the
+ * pointer/focus plumbing, so any move invalidates the preview on the next
+ * render — which is what stops one from "sticking" after a move on touch
+ * devices, where no `pointerleave` fires.
  *
  * Pass `ctx.moveCount` from a BoardClient, or a `moveCount` prop when the hover
  * lives inside a repeated child component.
@@ -18,9 +15,8 @@ import { useMoveScopedState } from './use-move-scoped-state';
  * child's focus previews the container — matching pointer hover.
  *
  * `set`/`clear` are the imperative escape hatch for flows `hoverProps` can't
- * express — e.g. a touch two-tap flow where the first tap (onClick) sets the
- * preview, or handlers that filter by `pointerType`. Values set this way get
- * the same moveCount stamp, so they are invalidated by the next move too.
+ * express — a touch two-tap where the first tap sets the preview, or handlers
+ * filtering by `pointerType`. Values set that way carry the same stamp.
  */
 export function useHoverPreview<T>(moveCount: number) {
   const [value, setHovered, clear] = useMoveScopedState<T | null>(moveCount, null);

--- a/src/components/strategy-game-factory/hooks/use-move-scoped-state.ts
+++ b/src/components/strategy-game-factory/hooks/use-move-scoped-state.ts
@@ -1,28 +1,21 @@
 import { useState } from 'react';
 
 /**
- * State that lives for exactly one move.
+ * State that lives for exactly one move: the value is stamped with the
+ * `moveCount` at which it was set and exposed only while that stamp matches, so
+ * any move discards it on the very next render — no effect, no reset call, and
+ * no frame in which a stale selection is painted over an advanced board. That
+ * last part is why this exists rather than
+ * `useEffect(() => setX(initial), [ctx.moveCount])`.
  *
- * The value is stamped with the `moveCount` at which it was set, and is
- * exposed only while that stamp still matches. Any move bumps `moveCount`, so
- * a value set under the previous one is gone on the very next render — no
- * effect, no reset call, and no frame in which a stale selection is painted
- * over an advanced board.
+ * Pass `ctx.moveCount` from a BoardClient, or a `moveCount` prop when the state
+ * lives inside a repeated child component.
  *
- * This is the alternative to `useEffect(() => setX(initial), [ctx.moveCount])`,
- * which repairs the state one render too late and has to be remembered on
- * every component that keeps mid-turn UI state.
- *
- * Pass `ctx.moveCount` from a BoardClient, or a `moveCount` prop when the
- * state lives inside a repeated child component.
- *
- * `initial` is returned whenever the stamp is stale, so it must be a stable
- * reference — hoist a non-primitive to module scope rather than writing `[]`
- * or `{}` inline, which would hand out a fresh object on every such render.
- *
- * For mid-turn state the *engine* has to see — anything
- * `getPlayerStepDescription` reads — use `ctx.turnState` and `setTurnState`
- * instead. This hook is local to the component.
+ * Two things to get right:
+ * - `initial` is returned on every stale render, so a non-primitive must be one
+ *   stable reference — hoist it to module scope, never write `[]` inline.
+ * - mid-turn state the *engine* has to see (anything `getPlayerStepDescription`
+ *   reads) belongs in `ctx.turnState`; this hook is local to the component.
  */
 export function useMoveScopedState<T>(moveCount: number, initial: T) {
   const [stamped, setStamped] = useState<{ value: T; moveCount: number } | null>(null);

--- a/src/components/strategy-game-factory/strategy-game-factory.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.tsx
@@ -34,11 +34,9 @@ export type StrategyGameConfig<TBoard, TTurnState = unknown> = {
   variants: VariantInput<TBoard>[]
 }
 
-// The game component carries the headless half of its own configuration. It is
-// what `runMatch` needs to play the game with no browser, so the catalog-wide
-// conformance spec can reach every registered game without a second registry to
-// keep in step — and it is the shape a competition server would load a game by
-// (issue #313).
+// The game component carries the headless half of its own configuration — what
+// `runMatch` needs to play it with no browser, so the catalog-wide conformance
+// spec reaches every registered game without a second registry to keep in step.
 export type StrategyGame<TBoard, TTurnState = unknown> = React.FC & {
   gameplay: Gameplay<TBoard, TTurnState>
   variants: VariantInput<TBoard>[]
@@ -58,9 +56,8 @@ export const strategyGameFactory = <TBoard, TTurnState = unknown>({
   const Game = () => {
     const { t } = useTranslation();
     const [searchParams, setSearchParams] = useSearchParams();
-    // The variant the URL asks for, or the default — which the param's absence
-    // means, the way it means `hu` for `?lang=`. `-1` is a param naming no
-    // variant of this game, which is ignored rather than obeyed.
+    // The variant the URL asks for, or the default, which the param's absence
+    // means. `-1` is a param naming no variant of this game.
     const requestedVariantIndex = (params: URLSearchParams) => {
       const requested = params.get('variant');
       return requested === null ? defaultVariantIndex : variantKeys.indexOf(requested);
@@ -73,9 +70,8 @@ export const strategyGameFactory = <TBoard, TTurnState = unknown>({
     const defaultGenerateStartBoard = defaultVariant.generateStartBoard!;
     const activeGenerateStartBoard = activeVariant.generateStartBoard ?? defaultGenerateStartBoard;
 
-    // Authoritative game state lives in a synchronous store outside React (see
-    // engine/store.ts); React renders a snapshot of it. Bots and chained
-    // dispatches always read the store, so they can never see stale state.
+    // Authoritative game state lives in a synchronous store outside React
+    // (engine/store.ts); React renders a snapshot of it.
     const [store] = useState(
       () => createGameStore(createInitialCoreState<TBoard, TTurnState>(activeGenerateStartBoard()))
     );
@@ -121,10 +117,8 @@ export const strategyGameFactory = <TBoard, TTurnState = unknown>({
 
     let wrappedGameMoves: GameMoves<TBoard, TTurnState> = {} as GameMoves<TBoard, TTurnState>;
 
-    // An illegal move should never happen through the UI (buttons are disabled)
-    // or a correct bot, so reaching here means a bug or tampering. In dev we
-    // throw loudly to surface the bug; in prod we fail safe: warn, record it,
-    // and no-op so a stray call can't corrupt the board or white-screen a player.
+    // Reaching here means a bug or tampering, so dev throws. Prod fails safe
+    // instead: a stray call must not corrupt the board or white-screen a player.
     const reportIllegalMove = (name: string, moveBoard: TBoard, args: unknown[]) => {
       const message = `strategyGameFactory: illegal move ${name}(${JSON.stringify(args)}) `
         + `rejected on board ${JSON.stringify(moveBoard)}`;
@@ -147,8 +141,7 @@ export const strategyGameFactory = <TBoard, TTurnState = unknown>({
         game: gameId,
         mode: s.mode,
         // The same key the URL uses, so a variant reads the same in a dashboard
-        // as in a link. Games that declare no id still report their index, and
-        // for those the value only means anything as long as the order holds.
+        // as in a link.
         variant: variantKeys[selectedVariantIndex],
         ...(s.mode === 'vsHuman' ? {} : { result: resolvedWinner === s.chosenRoleIndex ? 'win' : 'loss' })
       });
@@ -157,10 +150,8 @@ export const strategyGameFactory = <TBoard, TTurnState = unknown>({
     const dispatchMove = (
       name: string, moveBoard: TBoard, args: unknown[]
     ): MoveOutcome<TBoard, TTurnState> => {
-      // The store board is authoritative; the board argument remains for API
-      // compatibility. A mismatch means a chaining bug — a bot or BoardClient
-      // passed a stale board to the second move of a turn — so fail loudly in
-      // dev; in prod the store board silently wins.
+      // A mismatch means a chaining bug — a stale board passed to the second
+      // move of a turn — so fail loudly in dev; in prod the store board wins.
       if (import.meta.env.DEV && !isEqual(moveBoard, store.getState().board)) {
         throw new Error(`strategyGameFactory: stale board passed to move ${name} — `
           + 'pass the latest nextBoard when chaining moves within a turn');
@@ -211,19 +202,15 @@ export const strategyGameFactory = <TBoard, TTurnState = unknown>({
       resetGameState({ newVariantIndex: index });
     };
 
-    // A shared `?variant=` link has to work even when it points at the game
-    // already open — a same-route hash navigation remounts nothing, so without
-    // this the URL would change and the board would not. Following it restarts
-    // the game, which is what choosing a variant means everywhere else.
+    // Follows a `?variant=` link to the game already open, which a same-route
+    // hash navigation would otherwise leave on the old board (see
+    // src/components/CLAUDE.md § Variants).
     //
-    // Guarded on the index rather than run unconditionally: `resetGameState`
-    // writes the param itself, so an unguarded effect would re-enter. An index
-    // of -1 — a param naming no variant of this game — is left alone.
-    //
-    // Deriving this during render is not an option: it has to *restart the
-    // game*, which is an event, not a projection of the URL. `searchParams`
-    // alone in the deps for the same reason the language provider does it —
-    // re-running when the selection changes would fight the write path.
+    // Guarded on the index because `resetGameState` writes the param itself, so
+    // an unguarded effect would re-enter. Not derivable during render either: it
+    // has to *restart the game*, which is an event, not a projection of the URL.
+    // `searchParams` alone in the deps for the same reason — re-running when the
+    // selection changes would fight the write path.
     /* eslint-disable react-hooks/exhaustive-deps */
     useEffect(() => {
       const index = requestedVariantIndex(searchParams);
@@ -285,14 +272,10 @@ export const strategyGameFactory = <TBoard, TTurnState = unknown>({
       return wrapped;
     });
 
-    // What the BoardClient receives: the same moves, but a dispatch is silently
-    // ignored unless `isAllowed` holds — turn ownership (ctx.isClientMoveAllowed)
-    // AND the move's validator, both judged against the current store state.
-    // This engine-side gate replaces per-handler `if (!allowed) return` guards,
-    // and also covers browsers that fire pointer events on disabled buttons.
-    // Bots and the auto `endOfTurnMove` dispatch use `wrappedGameMoves` instead:
-    // there an illegal move is a bug, and the validator fails loudly (see
-    // `reportIllegalMove`).
+    // What the BoardClient receives: the same moves, but a dispatch that fails
+    // `isAllowed` is silently ignored, judged against the current store state.
+    // Bots and the auto `endOfTurnMove` use `wrappedGameMoves` instead, where an
+    // illegal move fails loudly. See src/components/CLAUDE.md § validate.
     const clientGameMoves: ClientGameMoves<TBoard, TTurnState> = mapValues(moves, ({ validate }, name) => {
       const isAllowed = (moveBoard: TBoard, ...args: unknown[]) => {
         const liveCtx = buildCtx(store.getState(), resolvedPlayerNames);
@@ -327,9 +310,8 @@ export const strategyGameFactory = <TBoard, TTurnState = unknown>({
     };
 
     // Plays the bot's named moves one at a time. The pause before each is what
-    // makes the bot look like it is thinking; keeping it here rather than
-    // inside the strategy is what lets the same strategy run headless
-    // (engine/run-match.ts).
+    // makes the bot look like it is thinking; keeping it out of the strategy is
+    // what lets the same strategy run headless (engine/run-match.ts).
     const runBotTurn = (queue: BotMove[], delay: number, botStrategy: BotStrategy<TBoard>) => {
       botTimeoutRef.current = setTimeout(() => {
         botTimeoutRef.current = null;

--- a/src/components/strategy-game-factory/types.ts
+++ b/src/components/strategy-game-factory/types.ts
@@ -3,11 +3,9 @@ import type { I18nString, TranslatableNode } from 'language';
 export type Phase = 'roleSelection' | 'play' | 'gameEnd'
 export type Mode = 'vsComputer' | 'vsHuman'
 
-// TTurnState is the game's own mid-turn state — the half-made selection a
-// multi-stage turn carries between its moves. It names the payload only: the
-// engine adds the `| null` that every turn starts and ends in, so a game never
-// has to spell it out. Left unpinned it is `unknown`, and reading `turnState`
-// then needs a cast, exactly as it did before the parameter existed.
+// TTurnState names the mid-turn payload only — the engine adds the `| null`
+// every turn starts and ends in. See src/components/CLAUDE.md § Pinning the
+// turn state.
 export interface Ctx<TTurnState = unknown> {
   isHumanVsHumanGame: boolean
   resolvedPlayerNames: [string, string]
@@ -24,29 +22,27 @@ export interface Ctx<TTurnState = unknown> {
 // the move returns, so a move never reaches out and changes anything itself.
 export type MoveOutcome<TBoard, TTurnState = unknown> = {
   nextBoard: TBoard
-  // Turn passes to the other player. Omitted/false = turn continues (mid-turn
-  // move of a multi-phase turn). Ignored when `gameEnd` is present.
+  // Turn passes to the other player. Omitted = further moves follow in the same
+  // turn. Ignored when `gameEnd` is present.
   isTurnEnd?: boolean
   // undefined = turnState unchanged; null = cleared; anything else = new value.
   nextTurnState?: TTurnState | null
-  // Terminal: the game is over, naming the winner explicitly (use
-  // `ctx.currentPlayer!` when the mover wins).
+  // Terminal, naming the winner explicitly (`ctx.currentPlayer!` when the mover
+  // wins).
   gameEnd?: { winnerIndex: number }
   // Schedule gameplay.endOfTurnMove after a delay. Ignored when `gameEnd` is
   // present (contradiction; throws in dev).
   autoEndOfTurn?: boolean
 }
-// A move is a pure reducer: board in, outcome out. It is handed nothing it
-// could cause an effect through, so purity is enforced by the type system
-// rather than by convention — which is what lets the same function run in a
-// future authoritative server.
+// A move is a pure reducer: board in, outcome out, handed nothing it could
+// cause an effect through — see AGENTS.md § Files in a game folder for why that
+// matters beyond this repo.
 export type MoveFunction<TBoard, TTurnState = unknown> = (
   board: TBoard, meta: { ctx: Ctx<TTurnState> }, ...args: any[]
 ) => MoveOutcome<TBoard, TTurnState>
-// Pure, side-effect-free legality predicate for a single move, colocated with
-// its `apply`. Because it depends only on `board` + `ctx` (no React), the same
-// function drives the UI (button `disabled`), the engine (illegal-move
-// enforcement) and, in the future, an authoritative server-side check.
+// The single source of truth for a move's legality, colocated with its `apply`
+// and free of React so the UI, the engine and a future server can share it.
+// See src/components/CLAUDE.md § validate.
 type MoveValidator<TBoard, TTurnState = unknown> = (
   board: TBoard, meta: { ctx: Ctx<TTurnState> }, ...args: any[]
 ) => boolean
@@ -59,19 +55,15 @@ export interface Gameplay<TBoard, TTurnState = unknown> {
   // move name auto-executed (after a delay) following moves returning autoEndOfTurn: true
   endOfTurnMove?: string
 }
-// Engine-wrapped moves, callable to dispatch. This is the bot's view: a bot
-// enumerates legal moves through the raw `validate`/its own helpers, because
-// `isAllowed` would be false throughout its turn anyway (see below).
+// Engine-wrapped moves, callable to dispatch. This is the bot's view: no
+// `isAllowed`, which would be false throughout its turn anyway.
 export type GameMoves<TBoard, TTurnState = unknown> = Record<
   string,
   (board: TBoard, ...args: any[]) => MoveOutcome<TBoard, TTurnState>
 >
-// The BoardClient's view: the same dispatchers, plus `isAllowed(board, ...args)`
-// on every move — `ctx.isClientMoveAllowed` (turn ownership) AND the move's
-// `validate`, with `ctx` already bound. That is what a `disabled` state should
-// ask; the same check silently gates every client dispatch, so handlers need no
-// `if (!allowed) return` guards. Assignable to GameMoves, so helpers shared with
-// a bot keep taking the wider type.
+// The BoardClient's view: the same dispatchers plus `isAllowed(board, ...args)`,
+// which is what a `disabled` state should ask. Assignable to GameMoves, so
+// helpers shared with a bot keep taking the wider type.
 export type ClientGameMoves<TBoard, TTurnState = unknown> = Record<
   string,
   ((board: TBoard, ...args: any[]) => MoveOutcome<TBoard, TTurnState>)
@@ -81,47 +73,35 @@ export type StrategyArgs<TBoard, TTurnState = unknown> = {
   board: TBoard
   ctx: Ctx<TTurnState>
 }
-// A game's `moves` object seen as a type — what a game exports as `Moves` so
-// its bots can name moves out of it.
+// A game's `moves` object seen as a type — what a game exports as `Moves`.
 type AnyMoves = Record<string, MoveDefinition<any, any>>
 // What a move takes beyond the board and the meta object: exactly the tail a
 // bot has to supply as `args`.
 type MoveArgs<TApply> =
   TApply extends (board: any, meta: any, ...args: infer TArgs) => any ? TArgs : never
-// A move a bot wants played, named rather than dispatched. Parameterised by the
-// game's `Moves` it pins both halves: naming a move the game does not have, or
-// passing it the wrong arguments, is a typecheck error at the bot. Given only a
-// union of names (or nothing) it still pins the name, leaving `args` unchecked.
+// A move a bot wants played, named rather than dispatched. Given the game's
+// `Moves` it pins the name and the arguments; given only a union of names (or
+// nothing) it still pins the name, leaving `args` unchecked.
 export type BotMove<TMoves extends string | AnyMoves = string> =
   TMoves extends string ? { move: TMoves; args?: unknown[] }
   : TMoves extends AnyMoves
     ? { [K in keyof TMoves]: { move: K; args?: MoveArgs<TMoves[K]['apply']> } }[keyof TMoves]
     : never
-// A bot is a pure function of the position: it names the move it wants, or the
-// whole sequence when the turn is planned as one decision, and the engine plays
-// them out — paced in the browser so the bot appears to think, immediately in a
-// headless match (engine/run-match.ts). Naming moves rather than dispatching
-// them is what keeps a strategy free of timers, of the move wrappers and of any
-// board to thread, so the same function can run on an authoritative server.
-// If the turn is still the bot's once its moves are played, it is asked again
-// (see engine/bot-turn.ts), so naming one move at a time is equally fine.
-// Deliberately not parameterised over the turn state: a bot is asked again with
-// a fresh `ctx` for every move it owes, so it plans a whole turn rather than
-// reading its own half-made selection back — the one consumer `turnState` has
-// no client for. A bot that ever needs it reads `unknown` and casts.
+// A pure function of the position that names what it wants played; the engine
+// plays it out (see src/components/CLAUDE.md § Bot contract). Deliberately not
+// parameterised over the turn state: a bot is asked again with a fresh `ctx`
+// for every move it owes, so it plans a whole turn rather than reading its own
+// half-made selection back.
 export type BotStrategy<TBoard, TMoves extends string | AnyMoves = string> =
   (args: StrategyArgs<TBoard>) => BotMove<TMoves> | BotMove<TMoves>[]
-// A game pins TTurnState by annotating its BoardClient — `BoardClientProps<Board,
-// TurnState>` — and the factory infers the rest of the config from it, so
-// `ctx.turnState` and `setTurnState` are typed with no cast anywhere.
+// Annotating these props is what pins TTurnState for the whole game: the
+// factory infers the rest of the config from it.
 export type BoardClientProps<TBoard, TTurnState = unknown> =
   StrategyArgs<TBoard, TTurnState> & {
     moves: ClientGameMoves<TBoard, TTurnState>
-    // Writes the mid-turn UI state a BoardClient needs to remember (which pile is
-    // selected, which slot is being edited), read back as `ctx.turnState`. The one
-    // path that writes engine state without going through a move: a selection is
-    // not a move, so it must not bump `moveCount` or take an undo snapshot. Moves
-    // never get this — they return `nextTurnState` in their MoveOutcome instead.
+    // The one path that writes engine state without going through a move,
+    // deliberately: a selection is not a move, so it must not bump `moveCount`
+    // or take an undo snapshot. Moves return `nextTurnState` instead.
     setTurnState: (state: TTurnState | null) => void
   }
 
@@ -140,16 +120,15 @@ export interface Variant {
 
 export interface VariantInput<TBoard> {
   // Stable slug this variant is addressable by in the URL (`?variant=3-5-7`).
-  // Optional: a variant without one is addressed by its index, which is enough
-  // for a link that need not outlive a reordering. Declare it where a durable
-  // link matters — the variants that are really separate games.
+  // Optional — without one a variant is addressed by its index, which no
+  // reordering survives. See src/components/CLAUDE.md § Variants.
   id?: string
   label?: I18nString
   isDefault?: boolean
   generateStartBoard?: () => TBoard
   // A curated list of start boards, in place of generating one: the variant
-  // plays a random entry. Its order is part of the contract — a competition
-  // hands out `startBoards[attemptIndex]`, so append rather than reorder.
+  // plays a random entry. Its order is part of the contract — see
+  // src/components/CLAUDE.md § Curated start boards.
   startBoards?: TBoard[]
   botStrategy?: BotStrategy<TBoard>
   notAlwaysOptimal?: boolean

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -53,17 +53,15 @@ export const playBotMove = <TBoard, TTurnState = unknown>(
 };
 
 // Which role can force the win from `startBoard`, read off the game's own
-// optimal bot playing both sides. Every position of these games has such a
-// role: they are finite, deterministic, perfect-information and cannot end in
-// a draw (`gameEnd` always names a winner), so by Zermelo's theorem one side
-// can always force the win. What a curated board needs asserting is *which*
-// role that is — the team choosing it is the decision a competition is made of.
+// optimal bot playing both sides. One always exists: these games are finite,
+// deterministic, perfect-information and cannot end in a draw, so by Zermelo's
+// theorem one side can force the win.
 //
 // Bots shuffle among equally-optimal moves, so one playout samples one line.
-// Playouts that disagree therefore say nothing about the board: they mean the
-// bot is not optimal, having thrown the win away on some line. That is a bug in
-// the game rather than a fact about the position, so this throws instead of
-// returning a winner nobody can trust.
+// Playouts that disagree therefore say nothing about the board — they mean the
+// bot threw the win away on some line, a bug rather than a fact about the
+// position — so this throws instead of returning a winner nobody can trust.
+// See src/components/CLAUDE.md § Curated start boards.
 export const forcedWinnerIndex = <TBoard, TTurnState = unknown>({
   gameplay,
   botStrategy,

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,13 +1,9 @@
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-// import { visualizer } from 'rollup-plugin-visualizer';
 
 export default defineConfig(() => ({
-  plugins: [
-    react()
-    // visualizer({ open: true })
-  ],
+  plugins: [react()],
   resolve: {
     // Games and their specs sit two to four folders deep under src/, so without
     // these every one of them reaches a shared module through a wall of `../` —
@@ -73,12 +69,9 @@ export default defineConfig(() => ({
     // is still a `vitest run --isolate` away if a leak is ever suspected.
     isolate: false,
     setupFiles: ['./src/test-setup.ts'],
-    // On demand only (`npm run coverage`), never in `npm test` or CI, and with no
-    // thresholds, deliberately: the two sweeps (plays-to-an-end, renders) execute
-    // nearly every line under games/ while asserting almost nothing, so the global
-    // percentage is not a measure of anything. What the report is good for is the
-    // opposite question — code no spec loads at all — which is why `include` is
-    // spelled out below.
+    // On demand only, never in `npm test` or CI, and with no thresholds — see
+    // AGENTS.md § Coverage for why, and for what the report is actually good
+    // for, which is what `include` below is spelled out for.
     coverage: {
       provider: 'v8',
       // Without this, only files a test imported are reported, and a module no


### PR DESCRIPTION
Four topics were told two or three times across the six markdown files, so a reader had to check three of them to know whether they had the current rule — and the `gameplay.ts`/#313 paragraph was additionally written out **eight times** in code, meaning one change to that plan would go stale in eight places at once.

Four commits, reviewable in order and independently revertable.

## 1. Docs: one owner per topic

Twelve topics now have one owner and links from everywhere else:

| Topic | Owner |
|---|---|
| Coverage policy, the 85% gate, `skip coverage` | `AGENTS.md § Coverage` |
| Curated `startBoards`, `forcedWinnerIndex`, the #314 order contract | `src/components/CLAUDE.md` |
| The bot contract, `board` threading, turn-state pinning | `src/components/CLAUDE.md` |
| `gameplay.ts` being React-free, #313, table-ships-with-generator | `AGENTS.md` |
| The three-step "adding a new game" recipe | `README.md` |

That last one had **no** owner: `AGENTS.md` pointed at `src/components/CLAUDE.md`, which pointed at `README.md`, which pointed back — a three-way loop where no file carried the steps end to end.

Fixes four defects the duplication was hiding:

- a dead link to `docs/project-review-2026-08.md`, deleted in c6cde85;
- a sentence that repeated its own parenthetical clause (`README.md:282`);
- the devcontainer summary stated twice, fifteen lines apart;
- the dev/prod illegal-move behaviour stated twice in one section.

And four cross-references that **named a section they did not link to** — they pointed at bold pseudo-headings, which have no anchor. Those are real headings now. `README.md`'s four `<h1>`s become one with `##` under it.

## 2. Engine comments: point at the docs instead of restating them

`types.ts` was 75 comment lines in 161, mostly a paragraph-length retelling of a doc section next to a type that already said the shape. Each site now keeps only what is locally true — `gameplay-react-free.spec.ts` keeps why ESLint cannot do this job by itself, `build-ctx.ts` keeps why the `ctx` fields are an allow-list rather than a spread.

One split is **inverted** rather than deduped. The three `BoardClient` hooks' footguns — the stable `initial` reference, no `useEffect` reset, no bare `setTimeout` — now live only in the JSDoc, because that is what an editor shows at the call site where the mistake gets made; the doc lists the three hooks and says when to reach for each.

The diff for this commit contains no non-comment line.

## 3. Game comments: drop the ones that restate, fix the ones that misled

`recolouring-discs/gameplay.ts` opened with an English translation of the rule text the game already ships. `ten-coins.tsx` carried an "Exact solver" banner over a `BoardClient` — the solver moved to `bot-strategy.ts` and the banner didn't; the one thing under it worth keeping, the enumerated losing sets, went with the solver.

Two were **wrong**, not merely long:

- `pile-splitter-3`'s all-even branch was annotated *"should not occur"*, which reads as a bug guard. It is the branch that keeps the bot playing well once a human has left an even position, and it says so now.
- `magic-box-b` and `architect-and-bandits` both blamed "the framework" for a shape that is a deliberate choice — player 0 always being seated first, and there being no start-of-turn hook. Both now name the actual reason.

## 4. CI and config: delete the dead code, link the rest

Six commented-out `fs.appendFileSync` blocks in the move-table generators, left from a debugging session, plus the `require('fs')` each file kept only for them. The commented-out `rollup-plugin-visualizer` lines in `vite.config.js` could not have been uncommented at all — the package is not a dependency.

The workflow comments keep every trap they recorded — the shallow-fetch merge base, `safe.directory` under a container job, `base.sha` as the merge base, the 60-day schedule disable, edit-don't-comment on the OPS issue — in about half the lines.

## Considered and not done

- **The game code is not the problem.** Surveying all 508 multi-line comment blocks, nearly every long one under `games/` explains an invariant, a profiling result, or a bug actually hit — `dominoes-on-chessboard`'s Sprague–Grundy note, `triangle-circle-game`'s March Lemma, `distinct-squares`' NaN trap. `src/` comment lines went 3708 → 3638; cutting further there would have been a loss, not a saving.
- **Three flagged comments kept.** The `// Return +1 …` sign convention appears three times, but the signature says `number`, so it is not a restatement; the `add-reduce-double` spec's arithmetic derives its expected value rather than transcribing it.
- **`asSharkRoute` and a totem-poles helper are duplicated in code**, so their comments are too. Deduplicating means extracting generic functions across sibling games — a refactor, not a comment pass, and better as its own PR.

## Verification

`npm run test` — `check:versions`, lint, typecheck and 1914 tests — plus `npm run build`, all green. `dependency-report.mjs` still runs and exits 0, and all three workflow files still parse as YAML.

For commits 2–4 the diff was mechanically checked to contain no non-comment line, other than three now-unused `require('fs')`s, the dead visualizer plugin entry, and the reworded `package.json` `"//"` note.

For commit 1, a script extracts every relative markdown link and resolves both the file and the `#anchor` against the real headings: all resolve. The four labels that used to lie now match what they link to.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AyC5D7KbNCjabM4x8EbHim)_