### PR TITLE
Fix the four-pile bot giving up won positions, and say the strategy once per game

### DIFF
--- a/src/components/games/pile-splitting-games/bot-strategy.spec.ts
+++ b/src/components/games/pile-splitting-games/bot-strategy.spec.ts
@@ -1,6 +1,13 @@
-import { runMatch } from 'strategy-game-factory';
+import { range } from 'lodash';
+import {
+  runMatch, type BotStrategy, type MoveDefinition
+} from 'strategy-game-factory';
+import { makeCtx } from 'test-utils';
 import { randomBotStrategy } from './bot-strategy';
-import { moves, type Board } from './gameplay';
+import { isLosingForMover, moves, type Board } from './gameplay';
+import { smartBotStrategy as smartTwoPileBot } from './pile-splitter/bot-strategy';
+import { smartBotStrategy as smartThreePileBot } from './pile-splitter-3/bot-strategy';
+import { smartBotStrategy as smartFourPileBot } from './pile-splitter-4/bot-strategy';
 
 // The random bot reads the number of piles off the board, so one spec covers
 // all three sibling games. `runMatch` throws on a move the rules reject, which
@@ -22,5 +29,57 @@ describe('random pile-splitting bot', () => {
       });
       expect([0, 1]).toContain(winnerIndex);
     }
+  });
+});
+
+// Plays a whole named turn through the real moves, as the engine would. Each
+// sibling names its turn as both halves at once, so the reduction runs them in
+// the order the bot listed them.
+const playSmartTurn = (botStrategy: BotStrategy<Board>, board: Board): Board => {
+  const ctx = makeCtx({ currentPlayer: 0 });
+  const named = botStrategy({ board, ctx });
+  const turnMoves: Record<string, MoveDefinition<Board>> = moves;
+
+  return (Array.isArray(named) ? named : [named]).reduce(
+    (current, { move, args = [] }) => turnMoves[move]!.apply(current, { ctx }, ...args).nextBoard,
+    board
+  );
+};
+
+// Non-decreasing tuples: the value of a position depends on the pile sizes
+// alone, so one ordering of each stands for all of them.
+const boardsUpTo = (pileCount: number, maxPile: number): Board[] =>
+  pileCount === 0
+    ? [[]]
+    : boardsUpTo(pileCount - 1, maxPile).flatMap(rest =>
+      range(rest[rest.length - 1] ?? 1, maxPile + 1).map(size => [...rest, size]));
+
+// The property that makes a bot optimal, checked a turn at a time rather than
+// over a match: from a position the mover can win, the turn it names must hand
+// the opponent one they cannot. A match only says who won — against a bot that
+// plays at random a thrown-away win is usually not punished, which is how the
+// four-pile bot gave one up in roughly a quarter of its turns unnoticed.
+const smartBots = [
+  { pileCount: 2, maxPile: 12, botStrategy: smartTwoPileBot },
+  { pileCount: 3, maxPile: 9, botStrategy: smartThreePileBot },
+  { pileCount: 4, maxPile: 7, botStrategy: smartFourPileBot }
+];
+
+describe('smart pile-splitting bots', () => {
+  it.each(smartBots)('never gives up a won position, on $pileCount piles', (
+    { pileCount, maxPile, botStrategy }
+  ) => {
+    const wonBoards = boardsUpTo(pileCount, maxPile).filter(board => !isLosingForMover(board));
+    expect(wonBoards.length).toBeGreaterThan(20);
+
+    wonBoards.forEach(board => {
+      // Each bot shuffles among equally-optimal turns, so one board has to hold
+      // for every draw it can make.
+      range(ITERATIONS).forEach(() => {
+        const nextBoard = playSmartTurn(botStrategy, board);
+        const handedOver = nextBoard.every(size => size === 1) || isLosingForMover(nextBoard);
+        expect([board, handedOver]).toEqual([board, true]);
+      });
+    });
   });
 });

--- a/src/components/games/pile-splitting-games/bot-strategy.spec.ts
+++ b/src/components/games/pile-splitting-games/bot-strategy.spec.ts
@@ -1,10 +1,10 @@
-import { range } from 'lodash';
+import { random, range } from 'lodash';
 import {
   runMatch, type BotStrategy, type MoveDefinition
 } from 'strategy-game-factory';
 import { makeCtx } from 'test-utils';
 import { randomBotStrategy } from './bot-strategy';
-import { isLosingForMover, moves, type Board } from './gameplay';
+import { isLosingForMover, isRemovalAllowed, moves, type Board } from './gameplay';
 import { smartBotStrategy as smartTwoPileBot } from './pile-splitter/bot-strategy';
 import { smartBotStrategy as smartThreePileBot } from './pile-splitter-3/bot-strategy';
 import { smartBotStrategy as smartFourPileBot } from './pile-splitter-4/bot-strategy';
@@ -32,18 +32,21 @@ describe('random pile-splitting bot', () => {
   });
 });
 
-// Plays a whole named turn through the real moves, as the engine would. Each
-// sibling names its turn as both halves at once, so the reduction runs them in
-// the order the bot listed them.
+// Plays a whole named turn through the real moves, as the engine would — each
+// half checked against its own `validate` first, which is what the engine does
+// with a bot's move and what it throws on. Each sibling names its turn as both
+// halves at once, so the reduction runs them in the order the bot listed them.
 const playSmartTurn = (botStrategy: BotStrategy<Board>, board: Board): Board => {
   const ctx = makeCtx({ currentPlayer: 0 });
   const named = botStrategy({ board, ctx });
   const turnMoves: Record<string, MoveDefinition<Board>> = moves;
 
-  return (Array.isArray(named) ? named : [named]).reduce(
-    (current, { move, args = [] }) => turnMoves[move]!.apply(current, { ctx }, ...args).nextBoard,
-    board
-  );
+  return (Array.isArray(named) ? named : [named]).reduce((current, { move, args = [] }) => {
+    const definition = turnMoves[move]!;
+    expect([board, move, definition.validate!(current, { ctx }, ...args)])
+      .toEqual([board, move, true]);
+    return definition.apply(current, { ctx }, ...args).nextBoard;
+  }, board);
 };
 
 // Non-decreasing tuples: the value of a position depends on the pile sizes
@@ -80,6 +83,40 @@ describe('smart pile-splitting bots', () => {
         const handedOver = nextBoard.every(size => size === 1) || isLosingForMover(nextBoard);
         expect([board, handedOver]).toEqual([board, true]);
       });
+    });
+  });
+
+  // A lost position has no turn that saves it, so the bot is only held to
+  // playing a legal one — but it still has to, and the reductions are where that
+  // is easiest to get wrong: three or four 2s halve to a board nobody can move
+  // on, and [1, 2, 2, 2] tops up into one of them.
+  it.each(smartBots)('plays a legal turn from a lost position, on $pileCount piles', (
+    { pileCount, maxPile, botStrategy }
+  ) => {
+    const lostBoards = boardsUpTo(pileCount, maxPile).filter(board =>
+      isLosingForMover(board) && range(board.length).some(id => isRemovalAllowed(board, id)));
+    expect(lostBoards.length).toBeGreaterThan(5);
+
+    lostBoards.forEach(board => range(ITERATIONS).forEach(() => {
+      playSmartTurn(botStrategy, board);
+    }));
+  });
+
+  // Both reductions recurse, so the deep end of each game's real range is worth
+  // its own sweep: three piles start from 37 pieces, and four piles reach 24 in
+  // a pile once the generator doubles a board.
+  it.each(smartBots)('never gives up a won full-size position, on $pileCount piles', (
+    { pileCount, botStrategy }
+  ) => {
+    const boards = range(400)
+      .map(() => range(pileCount).map(() => random(1, 24)))
+      .filter(board => !isLosingForMover(board));
+    expect(boards.length).toBeGreaterThan(50);
+
+    boards.forEach(board => {
+      const nextBoard = playSmartTurn(botStrategy, board);
+      const handedOver = nextBoard.every(size => size === 1) || isLosingForMover(nextBoard);
+      expect([board, handedOver]).toEqual([board, true]);
     });
   });
 });

--- a/src/components/games/pile-splitting-games/bot-strategy.ts
+++ b/src/components/games/pile-splitting-games/bot-strategy.ts
@@ -8,7 +8,6 @@ export type BotStep = { removedPileId: number; pileId: number; pieceCount: numbe
 
 export type Bot = BotStrategy<Board, Moves>
 
-
 export const asTurn = ({ removedPileId, pileId, pieceCount }: BotStep): BotMove<Moves>[] => [
   { move: 'removePile', args: [removedPileId] },
   { move: 'splitPile', args: [{ pileId, pieceCount }] }

--- a/src/components/games/pile-splitting-games/gameplay.spec.ts
+++ b/src/components/games/pile-splitting-games/gameplay.spec.ts
@@ -1,4 +1,8 @@
-import { emptiedPileId, isRemovalAllowed, isSplitAllowed, moves, withPileRemoved } from './gameplay';
+import { range } from 'lodash';
+import {
+  emptiedPileId, isLosingForMover, isRemovalAllowed, isSplitAllowed, moves, withPileRemoved,
+  type Board
+} from './gameplay';
 import { makeCtx } from 'test-utils';
 
 describe('pile-splitting shared turn legality', () => {
@@ -129,4 +133,67 @@ describe('pile-splitting shared turn', () => {
       expect(outcome.isTurnEnd).toBeUndefined();
     }
   );
+});
+
+// `isLosingForMover` is a claim about the game, so it is checked against the
+// game rather than against the parity rule it is written from — restating that
+// rule would pass just as happily with the sign the wrong way round, which is
+// how the four-pile generator carried an inverted copy of it. Every line is
+// searched through the real moves and the real legality predicates, on boards
+// small enough to solve outright.
+const solved = new Map<string, boolean>();
+
+const canWinBySearch = (board: Board): boolean => {
+  // A turn discards a whole pile, so the total strictly shrinks and the search
+  // terminates; only the pile sizes matter, not which slot holds them.
+  const key = `${board.length}|${[...board].sort((a, b) => a - b).join(',')}`;
+  if (solved.has(key)) return solved.get(key)!;
+
+  const won = range(board.length).filter(id => isRemovalAllowed(board, id)).some(removedPileId => {
+    const afterRemoval = withPileRemoved(board, removedPileId);
+
+    return range(board.length).some(pileId => range(1, board[pileId]).some(pieceCount => {
+      if (!isSplitAllowed(afterRemoval, pileId, pieceCount)) return false;
+      const { nextBoard, gameEnd } = moves.splitPile.apply(
+        afterRemoval, asPlayer(0), { pileId, pieceCount }
+      );
+      return gameEnd !== undefined || !canWinBySearch(nextBoard);
+    }));
+  });
+
+  solved.set(key, won);
+  return won;
+};
+
+// Non-decreasing tuples: the value of a position depends on the pile sizes
+// alone, so one ordering of each stands for all of them.
+const boardsUpTo = (pileCount: number, maxPile: number): Board[] =>
+  pileCount === 0
+    ? [[]]
+    : boardsUpTo(pileCount - 1, maxPile).flatMap(rest =>
+      range(rest[rest.length - 1] ?? 1, maxPile + 1).map(size => [...rest, size]));
+
+describe('isLosingForMover', () => {
+  it.each([2, 3, 4])('agrees with a search of every line, on %i piles', pileCount => {
+    const boards = boardsUpTo(pileCount, 6);
+
+    expect(boards.length).toBeGreaterThan(20);
+    boards.forEach(board => {
+      expect([board, isLosingForMover(board)]).toEqual([board, !canWinBySearch(board)]);
+    });
+  });
+
+  it('reads a board with no even pile as lost, whatever the piles are', () => {
+    expect(isLosingForMover([1, 1])).toBe(true);
+    expect(isLosingForMover([3, 5, 7])).toBe(true);
+    expect(isLosingForMover([1, 1, 1, 1])).toBe(true);
+  });
+
+  // The two branches past a decided turn: every pile even halves, and four piles
+  // around a lone odd one top that pile up. Both were the four-pile game's own
+  // reduction, and are what the sibling games now share.
+  it('reduces a position no single turn decides', () => {
+    expect(isLosingForMover([2, 2, 2, 2])).toBe(isLosingForMover([1, 1, 1, 1]));
+    expect(isLosingForMover([1, 2, 2, 2])).toBe(isLosingForMover([2, 2, 2, 2]));
+  });
 });

--- a/src/components/games/pile-splitting-games/gameplay.ts
+++ b/src/components/games/pile-splitting-games/gameplay.ts
@@ -77,3 +77,28 @@ export const moves = {
 };
 
 export type Moves = typeof moves;
+
+// Which side can force the win, on 2, 3 and 4 piles alike. A turn leaves every
+// pile odd exactly when it splits an even pile into two odd halves and discards
+// the second even pile if there is one — so a mover facing no even pile has
+// already lost, and one facing a single even pile, or two, has won. Past two
+// the turn cannot decide it, and the position reduces instead: halving every
+// pile leaves the class untouched, as does topping the lone odd pile up to
+// even, and both shrink the board.
+//
+// This characterises the winning strategy, so it would belong with the bot were
+// it not what `pile-splitter-4` draws its start boards against — the exception
+// AGENTS.md § Files in a game folder makes for a practice game's generator.
+export const isLosingForMover = (board: Board): boolean => {
+  const evenPileCount = board.filter(size => size % 2 === 0).length;
+
+  if (evenPileCount === 0) return true;
+  if (evenPileCount <= 2) return false;
+  if (evenPileCount === board.length) return isLosingForMover(board.map(size => size / 2));
+
+  // Every pile but one even, which on this family's widest board means four
+  // piles around a single odd one. Five piles could reach here with two odd
+  // ones, which this does not answer.
+  const oddPileId = board.findIndex(size => size % 2 === 1);
+  return isLosingForMover(board.map((size, i) => i === oddPileId ? size + 1 : size));
+};

--- a/src/components/games/pile-splitting-games/pile-splitter-3/bot-strategy.spec.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter-3/bot-strategy.spec.ts
@@ -1,4 +1,6 @@
-import { getSmartBotStep } from './bot-strategy';
+import { runMatch } from 'strategy-game-factory';
+import { isLosingForMover, moves, type Board } from '../gameplay';
+import { getSmartBotStep, randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 // getSmartBotStep picks an internal random `start` in 0..2, so each assertion must
 // hold for every possible start: loop enough times to exercise all branches.
@@ -40,6 +42,35 @@ describe('getSmartBotStep', () => {
       expect(botStep.pieceCount).toEqual(2);
       // halved board [5,7,2] is odd,odd,even: split pile 2, remove an odd pile
       expect([0, 1]).toContainEqual(botStep.removedPileId);
+    }
+  });
+});
+
+// A full-strength optimality check, end to end: from a position the mover can
+// win the smart bot must win as the mover, and from one it cannot every turn
+// loses, so it must win as the replier whatever the random bot throws at it.
+// See AGENTS.md § Testing.
+describe('pile-splitter-3 smartBotStrategy', () => {
+  const startBoards: Board[] = [
+    [3, 5, 4], [2, 4, 6], [1, 1, 4], [6, 10, 21], [5, 16, 16],
+    [5, 15, 17], [9, 9, 9], [4, 4, 4], [11, 13, 13]
+  ];
+
+  const winnerAgainstRandom = (startBoard: Board, smartSeat: 0 | 1) => runMatch({
+    gameplay: { moves },
+    strategies: smartSeat === 0
+      ? [smartBotStrategy, randomBotStrategy]
+      : [randomBotStrategy, smartBotStrategy],
+    startBoard
+  }).winnerIndex;
+
+  it.each(startBoards)('wins from %j as the role that can force it', (...startBoard) => {
+    // Both bots shuffle among their choices, so the board has to hold for every
+    // line the pair of them can produce.
+    const smartSeat = isLosingForMover(startBoard) ? 1 : 0;
+
+    for (let i = 0; i < 10; i++) {
+      expect(winnerAgainstRandom(startBoard, smartSeat)).toEqual(smartSeat);
     }
   });
 });

--- a/src/components/games/pile-splitting-games/pile-splitter-3/bot-strategy.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter-3/bot-strategy.ts
@@ -1,4 +1,4 @@
-import { random } from 'lodash';
+import { random, range, sample } from 'lodash';
 import { asTurn, getOptimalDivision, type Bot, type BotStep } from '../bot-strategy';
 import type { Board } from './gameplay';
 
@@ -6,54 +6,48 @@ export { randomBotStrategy } from '../bot-strategy';
 
 export const smartBotStrategy: Bot = ({ board }) => asTurn(getSmartBotStep(board));
 
+// Leaving all three piles odd is what the opponent cannot answer, and a turn
+// reaches it whenever one or two piles are even: cut one of them into two odd
+// halves, and discard the second even pile if there is one. With every pile
+// even no turn reaches it and the position reduces instead — the same reduction
+// `isLosingForMover` reads it by.
 export const getSmartBotStep = (board: Board): BotStep => {
-  const start = random(0, 2);
-  let removedPileId: number, splitPileId: number;
+  const evenPileIds = range(3).filter(id => board[id] % 2 === 0);
 
-  if (board.some(size => size % 2 === 1)) {
-    if (board[start] % 2 === 0) {
-      if (board[(start + 1) % 3] % 2 === 0) {
-        removedPileId = (start + 1) % 3;
-        splitPileId = start;
-      } else {
-        removedPileId = (start + 2) % 3;
-        splitPileId = start;
-      }
-    } else if (board[(start + 1) % 3] % 2 === 0) {
-      removedPileId = (start + 2) % 3;
-      splitPileId = (start + 1) % 3;
-    } else if (board[(start + 2) % 3] % 2 === 0) {
-      removedPileId = (start + 1) % 3;
-      splitPileId = (start + 2) % 3;
-    } else {
-      if (board[start] !== 1) {
-        removedPileId = (start + 1) % 3;
-        splitPileId = start;
-      } else if (board[(start + 1) % 3] !== 1) {
-        removedPileId = (start + 2) % 3;
-        splitPileId = (start + 1) % 3;
-      } else {
-        removedPileId = start;
-        splitPileId = (start + 2) % 3;
-      }
-    }
-    return {
-      removedPileId,
-      pileId: splitPileId,
-      pieceCount: getOptimalDivision(board[splitPileId])
-    };
-  } else if (board.every(size => size === 2)) {
-    return {
-      removedPileId: (start + 1) % 3,
-      pileId: start,
-      pieceCount: getOptimalDivision(board[start])
-    };
-  } else {
-    // Every pile even and not all 2: halving is the same position one scale
-    // down, so the odd-pile strategy above applies to it. The 37-piece start is
-    // odd, so an optimal line never reaches here — it is the branch that keeps
-    // the bot playing well after the opponent has left one.
-    const botStep = getSmartBotStep(board.map((x) => x / 2));
-    return { ...botStep, pieceCount: botStep.pieceCount * 2 };
+  const cutInTwo = (splitPileId: number, removedPileId: number): BotStep => ({
+    removedPileId,
+    pileId: splitPileId,
+    pieceCount: getOptimalDivision(board[splitPileId])
+  });
+
+  // Every pile odd: the position is lost whatever follows, so the turn only has
+  // to be legal — split whatever still has two pieces to give.
+  if (evenPileIds.length === 0) {
+    const splitPileId = sample(range(3).filter(id => board[id] !== 1))!;
+    return cutInTwo(splitPileId, (splitPileId + 1) % 3);
   }
+
+  if (evenPileIds.length < 3) {
+    const splitPileId = sample(evenPileIds)!;
+    // Discard the second even pile where there is one: leaving it standing is
+    // what would keep a pile of the wrong parity on the board.
+    const secondEvenPileIds = evenPileIds.filter(id => id !== splitPileId);
+    const removable = secondEvenPileIds.length > 0
+      ? secondEvenPileIds
+      : range(3).filter(id => id !== splitPileId);
+    return cutInTwo(splitPileId, sample(removable)!);
+  }
+
+  // Every pile even, so halving is the same position one scale down — except
+  // for three 2s, which halves to a board nobody can move on and so is played
+  // out here instead. The 37-piece start is odd, so an optimal line never
+  // reaches this branch: it is what keeps the bot playing well after the
+  // opponent has left one.
+  if (board.every(size => size === 2)) {
+    const splitPileId = random(0, 2);
+    return cutInTwo(splitPileId, (splitPileId + 1) % 3);
+  }
+
+  const botStep = getSmartBotStep(board.map(size => size / 2));
+  return { ...botStep, pieceCount: botStep.pieceCount * 2 };
 };

--- a/src/components/games/pile-splitting-games/pile-splitter-3/gameplay.spec.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter-3/gameplay.spec.ts
@@ -1,0 +1,27 @@
+import { sum } from 'lodash';
+import { isLosingForMover } from '../gameplay';
+import { generateStartBoard } from './gameplay';
+
+const DRAWS = 200;
+
+describe('pile-splitter-3 start boards', () => {
+  it('always deals 37 pieces into three non-empty piles', () => {
+    Array.from({ length: DRAWS }, generateStartBoard).forEach(board => {
+      expect(board).toHaveLength(3);
+      expect(sum(board)).toEqual(37);
+      expect(Math.min(...board)).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // The rules fix the total at 37, an odd number, so the two piles the
+  // generator does not fix outright always share a parity: a board is either
+  // all odd, which the mover has already lost, or holds exactly two even piles,
+  // which the mover wins. Both have to come up, or one role would always win.
+  it('deals both roles a winnable board', () => {
+    const boards = Array.from({ length: DRAWS }, generateStartBoard);
+    const wonByMover = boards.filter(board => !isLosingForMover(board)).length;
+
+    expect(wonByMover).toBeGreaterThan(DRAWS / 4);
+    expect(wonByMover).toBeLessThan(3 * DRAWS / 4);
+  });
+});

--- a/src/components/games/pile-splitting-games/pile-splitter-4/bot-strategy.spec.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter-4/bot-strategy.spec.ts
@@ -1,4 +1,6 @@
-import { getSmartBotStep } from './bot-strategy';
+import { runMatch } from 'strategy-game-factory';
+import { isLosingForMover, moves, type Board } from '../gameplay';
+import { getSmartBotStep, randomBotStrategy, smartBotStrategy } from './bot-strategy';
 
 describe('getSmartBotStep', () => {
   it('odd, odd, odd, odd case: split a non-1 pile', () => {
@@ -40,7 +42,9 @@ describe('getSmartBotStep', () => {
     it('2, 2, 2, 3', () => {
       const botStep = getSmartBotStep([2, 2, 2, 3]);
       expect(botStep.pileId).toEqual(3);
-      expect(botStep.pieceCount).toEqual(1);
+      // 2 and 1; which of the two halves lands in the emptied slot is arbitrary,
+      // and either way the opponent is left with one pile of 1 and three of 2.
+      expect(botStep.pieceCount).toEqual(2);
     });
 
     it('4, 4, 4, 15', () => {
@@ -54,5 +58,36 @@ describe('getSmartBotStep', () => {
       expect(botStep.pileId).toEqual(1);
       expect([3, 4, 7, 8]).toContainEqual(botStep.pieceCount);
     });
+  });
+});
+
+// A full-strength optimality check, end to end: from a position the mover can
+// win the smart bot must win as the mover, and from one it cannot every turn
+// loses, so it must win as the replier whatever the random bot throws at it.
+// See AGENTS.md § Testing.
+describe('pile-splitter-4 smartBotStrategy', () => {
+  // [1, 2, 2, 4] is the position the bot used to give away: it left the
+  // opponent [1, 2, 2, 3], still won for them, where [2, 2, 2, 2] wins.
+  const startBoards: Board[] = [
+    [1, 2, 2, 4], [2, 2, 2, 3], [5, 5, 5, 5], [6, 6, 6, 6], [3, 4, 5, 6],
+    [5, 7, 9, 11], [12, 8, 6, 10], [9, 9, 9, 10], [24, 12, 6, 18], [11, 5, 8, 8]
+  ];
+
+  const winnerAgainstRandom = (startBoard: Board, smartSeat: 0 | 1) => runMatch({
+    gameplay: { moves },
+    strategies: smartSeat === 0
+      ? [smartBotStrategy, randomBotStrategy]
+      : [randomBotStrategy, smartBotStrategy],
+    startBoard
+  }).winnerIndex;
+
+  it.each(startBoards)('wins from %j as the role that can force it', (...startBoard) => {
+    const smartSeat = isLosingForMover(startBoard) ? 1 : 0;
+
+    // Both bots shuffle among their choices, so the board has to hold for every
+    // line the pair of them can produce.
+    for (let i = 0; i < 10; i++) {
+      expect(winnerAgainstRandom(startBoard, smartSeat)).toEqual(smartSeat);
+    }
   });
 });

--- a/src/components/games/pile-splitting-games/pile-splitter-4/bot-strategy.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter-4/bot-strategy.ts
@@ -6,68 +6,62 @@ export { randomBotStrategy } from '../bot-strategy';
 
 export const smartBotStrategy: Bot = ({ board }) => asTurn(getSmartBotStep(board));
 
+// Leaving all four piles odd is what the opponent cannot answer, and a turn
+// reaches it whenever one or two piles are even: cut one of them into two odd
+// halves, and discard the second even pile if there is one. Past two even piles
+// no turn reaches it and the position reduces instead — the same reductions
+// `isLosingForMover` reads it by.
 export const getSmartBotStep = (board: Board): BotStep => {
-  const start = random(0, 3);
-  let removedPileId = -1, splitPileId = -1;
+  const evenPileIds = range(4).filter(id => board[id] % 2 === 0);
 
-  const odds = board.filter(p => p % 2 === 1).length;
-
-  if (odds === 4) {
-    const notSinglePileIndices = range(4).filter(i => board[i] !== 1);
-    const first = sample(notSinglePileIndices)!;
-    removedPileId = (first + 1) % 4;
-    splitPileId = first;
-  }
-
-  if (odds === 3) {
-    const evenPileIndex = range(4).find(i => board[i] % 2 === 0)!;
-    removedPileId = (evenPileIndex + 1) % 4;
-    splitPileId = evenPileIndex;
-  }
-
-  if (odds === 2) {
-    const evenPileIndices = range(4).filter(i => board[i] % 2 === 0);
-    removedPileId = evenPileIndices[1];
-    splitPileId = evenPileIndices[0];
-  }
-
-  if (odds === 1) {
-    const oddPile = range(4).find(i => board[i] % 2 === 1)!;
-    // [1, 2, 2, 2] is the one position the reduction below cannot be read back
-    // off: topping the odd pile up gives four 2s, whose own branch picks the
-    // pile to split at random and so may pick the one that is really a single
-    // piece. The position is lost anyway, so any legal turn will do.
-    if (
-      board[oddPile] === 1 && board[(oddPile + 1) % 4] === 2 &&
-      board[(oddPile + 2) % 4] === 2 && board[(oddPile + 3) % 4] === 2
-    ) {
-      removedPileId = (oddPile + 2) % 4;
-      splitPileId = (oddPile + 1) % 4;
-    } else {
-      // Topping the lone odd pile up to even leaves the win/loss class alone
-      // (`isLosingForMover`), and the turn that beats the topped-up board beats
-      // this one unchanged: the piles it splits and discards are the same size
-      // here, bar the topped-up one, which comes back a piece short in whichever
-      // half it lands.
-      const modifiedBoard = [...board];
-      modifiedBoard[oddPile] += 1;
-      return getSmartBotStep(modifiedBoard);
-    }
-  }
-
-  if (odds === 0) {
-    if (board.every(size => size === 2)) {
-      removedPileId = (start + 1) % 4;
-      splitPileId = start;
-    } else {
-      const botStep = getSmartBotStep(board.map((x) => x / 2));
-      return { ...botStep, pieceCount: botStep.pieceCount * 2 };
-    }
-  }
-
-  return {
+  const cutInTwo = (splitPileId: number, removedPileId: number): BotStep => ({
     removedPileId,
     pileId: splitPileId,
     pieceCount: getOptimalDivision(board[splitPileId])
-  };
+  });
+
+  // Every pile odd: the position is lost whatever follows, so the turn only has
+  // to be legal — split whatever still has two pieces to give.
+  if (evenPileIds.length === 0) {
+    const splitPileId = sample(range(4).filter(id => board[id] !== 1))!;
+    return cutInTwo(splitPileId, (splitPileId + 1) % 4);
+  }
+
+  if (evenPileIds.length <= 2) {
+    const splitPileId = sample(evenPileIds)!;
+    // Discard the second even pile where there is one: leaving it standing is
+    // what would keep a pile of the wrong parity on the board.
+    const secondEvenPileIds = evenPileIds.filter(id => id !== splitPileId);
+    const removable = secondEvenPileIds.length > 0
+      ? secondEvenPileIds
+      : range(4).filter(id => id !== splitPileId);
+    return cutInTwo(splitPileId, sample(removable)!);
+  }
+
+  if (evenPileIds.length === 3) {
+    const oddPileId = range(4).find(id => board[id] % 2 === 1)!;
+    // [1, 2, 2, 2] is the one position the reduction below cannot be read back
+    // off: topping the odd pile up gives four 2s, whose branch picks the pile to
+    // split at random and so may pick the one that is really a single piece.
+    // The position is lost anyway, so any legal turn will do.
+    if (board[oddPileId] === 1 && board.filter(size => size === 2).length === 3) {
+      return cutInTwo((oddPileId + 1) % 4, (oddPileId + 2) % 4);
+    }
+    // Topping the lone odd pile up to even leaves the win/loss class alone, and
+    // the turn that beats the topped-up board beats this one unchanged: the
+    // piles it splits and discards are the same size here, bar the topped-up
+    // one, which comes back a piece short in whichever half it lands.
+    return getSmartBotStep(board.map((size, id) => id === oddPileId ? size + 1 : size));
+  }
+
+  // Every pile even, so halving is the same position one scale down — except
+  // for four 2s, which halves to a board nobody can move on and so is played
+  // out here instead.
+  if (board.every(size => size === 2)) {
+    const splitPileId = random(0, 3);
+    return cutInTwo(splitPileId, (splitPileId + 1) % 4);
+  }
+
+  const botStep = getSmartBotStep(board.map(size => size / 2));
+  return { ...botStep, pieceCount: botStep.pieceCount * 2 };
 };

--- a/src/components/games/pile-splitting-games/pile-splitter-4/bot-strategy.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter-4/bot-strategy.ts
@@ -33,6 +33,10 @@ export const getSmartBotStep = (board: Board): BotStep => {
 
   if (odds === 1) {
     const oddPile = range(4).find(i => board[i] % 2 === 1)!;
+    // [1, 2, 2, 2] is the one position the reduction below cannot be read back
+    // off: topping the odd pile up gives four 2s, whose own branch picks the
+    // pile to split at random and so may pick the one that is really a single
+    // piece. The position is lost anyway, so any legal turn will do.
     if (
       board[oddPile] === 1 && board[(oddPile + 1) % 4] === 2 &&
       board[(oddPile + 2) % 4] === 2 && board[(oddPile + 3) % 4] === 2
@@ -40,14 +44,14 @@ export const getSmartBotStep = (board: Board): BotStep => {
       removedPileId = (oddPile + 2) % 4;
       splitPileId = (oddPile + 1) % 4;
     } else {
+      // Topping the lone odd pile up to even leaves the win/loss class alone
+      // (`isLosingForMover`), and the turn that beats the topped-up board beats
+      // this one unchanged: the piles it splits and discards are the same size
+      // here, bar the topped-up one, which comes back a piece short in whichever
+      // half it lands.
       const modifiedBoard = [...board];
       modifiedBoard[oddPile] += 1;
-      const botStep = getSmartBotStep(modifiedBoard);
-      return {
-        removedPileId: botStep.removedPileId,
-        pileId: botStep.pileId,
-        pieceCount: botStep.pieceCount - 1
-      };
+      return getSmartBotStep(modifiedBoard);
     }
   }
 

--- a/src/components/games/pile-splitting-games/pile-splitter-4/gameplay.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter-4/gameplay.ts
@@ -1,5 +1,5 @@
-import { random, range, times } from 'lodash';
-import type { Board } from '../gameplay';
+import { random, times } from 'lodash';
+import { isLosingForMover, type Board } from '../gameplay';
 
 // Played on four piles; the rules are the shared pile-splitting ones unchanged.
 export { moves, type Board, type Piece, type Moves } from '../gameplay';
@@ -14,18 +14,19 @@ export const generateTestStartBoard = (): Board =>
 
 type BoardOptions = { pileMin?: number; pileMax?: number; remainingTrials?: number };
 
-// Draw boards until one falls on the wanted side of `canWin`, then vary its
-// shape: doubling, and doubling with one piece taken off, both leave the
-// win/loss class untouched (see `canWin`), so they widen the pool for free.
-// Every option has to be threaded through the retry — a retry that fell back to
-// the defaults is how the test variant used to end up with full-size boards.
+// Draw boards until one falls on the wanted side of `isLosingForMover`, then
+// vary its shape: doubling, and doubling with one piece taken off, both leave
+// the win/loss class untouched (see `isLosingForMover`), so they widen the pool
+// for free. Every option has to be threaded through the retry — a retry that
+// fell back to the defaults is how the test variant used to end up with
+// full-size boards.
 const generateStartBoardWonBy = (
   moverWins: boolean,
   { pileMin = 5, pileMax = 12, remainingTrials = 50 }: BoardOptions = {}
 ): Board => {
   const board = times(4, () => random(pileMin, pileMax));
 
-  if (canWin(board) !== moverWins) {
+  if (!isLosingForMover(board) !== moverWins) {
     if (remainingTrials === 0) return board;
     return generateStartBoardWonBy(
       moverWins, { pileMin, pileMax, remainingTrials: remainingTrials - 1 }
@@ -38,21 +39,4 @@ const generateStartBoardWonBy = (
   if (variation === 1) return doubled;
   doubled[random(0, 3)] -= 1;
   return doubled;
-};
-
-// Can the player to move force a win? Recursive parity normalisation.
-const canWin = (board: Board): boolean => {
-  const oddPileIndices = range(0, 4).filter(i => board[i] % 2 === 1);
-  const oddPileCount = oddPileIndices.length;
-
-  if (oddPileCount === 4) return true;
-  if (oddPileCount === 3 || oddPileCount === 2) return false;
-
-  if (oddPileCount === 1) {
-    const modifiedBoard = [...board];
-    modifiedBoard[oddPileIndices[0]] += 1;
-    return canWin(modifiedBoard);
-  } else { // oddPileCount === 0
-    return canWin(board.map(x => x / 2));
-  }
 };

--- a/src/components/games/pile-splitting-games/pile-splitter/bot-strategy.spec.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter/bot-strategy.spec.ts
@@ -1,0 +1,51 @@
+import { runMatch } from 'strategy-game-factory';
+import { botNextMoveArgs, makeCtx } from 'test-utils';
+import { isLosingForMover, moves, type Board } from '../gameplay';
+import { randomBotStrategy, smartBotStrategy } from './bot-strategy';
+
+// The bot picks the pile at random where the choice is free, so each board has
+// to hold for every draw it can make.
+const ITERATIONS = 20;
+
+// On two piles the turn is one decision: the pile named for removal fixes the
+// one to be split. Splitting leaves an odd half either way, so only an even
+// pile can be cut into two odd ones — which is the whole strategy.
+describe('pile-splitter smartBotStrategy', () => {
+  it.each([
+    { board: [3, 4], splitPileId: 1 },
+    { board: [6, 5], splitPileId: 0 },
+    // no even pile to prefer: split whichever one can be split at all
+    { board: [1, 3], splitPileId: 1 }
+  ])('discards the pile it cannot use, from $board', ({ board, splitPileId }) => {
+    for (let i = 0; i < ITERATIONS; i++) {
+      const [removedPileId] = botNextMoveArgs(smartBotStrategy({ board, ctx: makeCtx() }));
+      expect(removedPileId).toEqual(1 - splitPileId);
+    }
+  });
+});
+
+// A full-strength optimality check, end to end: from a position the mover can
+// win the smart bot must win as the mover, and from one it cannot every turn
+// loses, so it must win as the replier whatever the random bot throws at it.
+// See AGENTS.md § Testing.
+describe('pile-splitter smartBotStrategy against the random bot', () => {
+  const startBoards: Board[] = [
+    [4, 7], [10, 10], [2, 3], [1, 4], [6, 6], [3, 5], [9, 9], [1, 3]
+  ];
+
+  const winnerAgainstRandom = (startBoard: Board, smartSeat: 0 | 1) => runMatch({
+    gameplay: { moves },
+    strategies: smartSeat === 0
+      ? [smartBotStrategy, randomBotStrategy]
+      : [randomBotStrategy, smartBotStrategy],
+    startBoard
+  }).winnerIndex;
+
+  it.each(startBoards)('wins from %j as the role that can force it', (...startBoard) => {
+    const smartSeat = isLosingForMover(startBoard) ? 1 : 0;
+
+    for (let i = 0; i < ITERATIONS; i++) {
+      expect(winnerAgainstRandom(startBoard, smartSeat)).toEqual(smartSeat);
+    }
+  });
+});

--- a/src/components/games/pile-splitting-games/pile-splitter/gameplay.ts
+++ b/src/components/games/pile-splitting-games/pile-splitter/gameplay.ts
@@ -1,2 +1,4 @@
 // Played on two piles; the rules are the shared pile-splitting ones unchanged.
-export { moves, type Board, type Piece, type Moves } from '../gameplay';
+export {
+  isSplitAllowed, moves, withPileRemoved, type Board, type Moves, type Piece
+} from '../gameplay';

--- a/src/components/games/pile-splitting-games/pile-splitter/pile-splitter.tsx
+++ b/src/components/games/pile-splitting-games/pile-splitter/pile-splitter.tsx
@@ -7,8 +7,7 @@ import {
   useDeferredMove
 } from 'strategy-game-factory';
 import { smartBotStrategy, randomBotStrategy } from './bot-strategy';
-import { isSplitAllowed, withPileRemoved } from '../gameplay';
-import { moves, type Board, type Piece } from './gameplay';
+import { isSplitAllowed, moves, withPileRemoved, type Board, type Piece } from './gameplay';
 
 const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
   const { value: validHoveredPiece, hoverProps } = useHoverPreview<Piece>(ctx.moveCount);


### PR DESCRIPTION
This started as a refactor review of `pile-splitting-games/` and turned up two real
defects, so it is two commits: the correctness fix and the specs that pin it, then the
readability sweep. They read independently.

## The bot was not optimal

`pile-splitter-4`'s one-odd-pile branch tops that pile up to even, recurses, and then
took a piece off the returned `pieceCount` — unconditionally, including when the
recursion chose to split some *other* pile, where there is nothing to take off.

From `[1, 2, 2, 4]` it left the opponent `[1, 2, 2, 3]`, still won for them, where
`[2, 2, 2, 2]` wins. Played out from the boards the game actually deals, it gave up a
won position in roughly a quarter of its turns — so a visitor could beat the "optimal"
bot without playing optimally, against the checklist item that says they cannot.

The turn that beats the topped-up board beats the real one as it stands, so the fix is
to stop adjusting it. The `[1, 2, 2, 2]` special case stays, but re-commented for the
reason it is really there: topping up gives four 2s, whose branch picks a pile at random
and so may pick the one that is really a single piece.

The two- and three-pile bots were already optimal.

## `canWin` was inverted

The predicate the start-board generator classified boards with returned the exact
opposite of its name, on all 495 boards checked. Nothing downstream noticed, because the
generator draws the wanted class at random and so mixes 50/50 either way — but it could
not be reused as an oracle. It is replaced by `isLosingForMover` in the shared
`gameplay.ts`, where one characterisation is exact for two, three and four piles alike:
no even pile is lost, one or two even piles is won, all even halves, every pile but one
even tops the odd one up.

It lives in `gameplay.ts` rather than with the bot because the four-pile generator draws
against it — the exception AGENTS.md § Files in a game folder makes for a practice game.

## Why nothing caught either

The sweep asserts only that a match ends, and the bot specs read the shape of one step
(`botStep.pileId === 1`) rather than where it leads. Against a bot that plays at random,
a thrown-away win is usually not punished, so a match result says very little.

So the specs now assert consequences:

- every smart bot must hand the opponent a lost position from every won board, over the
  small boards exhaustively and over full-size ones sampled;
- each turn is checked against the game's own `validate` before it is applied, and a lost
  position still has to get a legal turn — which is what the reductions into three or
  four 2s are delicate about;
- each game wins from either side of a decided board, against the random bot;
- `isLosingForMover` is pinned against a search of every line rather than against the
  parity rule it is written from, which is the mistake the inverted copy embodied.

The first of these fails on the old bot and names `[1, 2, 2, 4]`.

`pile-splitter` had no bot spec at all and `pile-splitter-3` no generator spec; both now
do.

## Readability

Both parity dispatchers were a chain of independent `if`s over a pair of `let`s seeded to
`-1`, so nothing made them exhaustive — a class that fell through every branch would have
named pile `-1` and split it into `NaN` pieces. The four-pile one also drew a random
`start` that four of its five branches never read.

The three-pile branch spelled the rule out positionally, over `(start + 1) % 3` and
`(start + 2) % 3` nested four deep. It only ever said: cut an even pile into two odd
halves, and discard the second even pile if there is one — which is the rule the
four-pile game plays by too, and the one `isLosingForMover` reads a position by. Both now
say it that way, so a reader can check the bot against the predicate instead of against a
table of index arithmetic. The new specs license this: they assert where a turn leads
rather than which pile it names, so an equally-optimal choice is free to change.

Also: `pile-splitter` read its rules from both `./gameplay` and `../gameplay` in one file.

## Deliberately not changed

- **`pile-splitter`'s separate `BoardClient`**, which duplicates much of
  `board-client.tsx`. The two-pile turn is a genuinely different interaction — one click,
  no selection state — and merging it would drag styling differences and a UI review into
  an otherwise logic-only change.
- **`pile-splitter-3`'s Test variant inheriting the full 37-piece board.** Unlike its two
  siblings it has no smaller test generator, but its rule text fixes the game at 37
  pieces.

One existing assertion changed: `[2, 2, 2, 3]` now splits into 2+1 rather than 1+2. Same
partition, same resulting position — which half lands in the emptied slot was never the
bot's decision to make.

## Verification

`npm test` (1960 pass), `npm run lint` and `tsc --noEmit` clean, and `coverage:patch`
reports 100% of the 45 added non-JSX lines.

Played `PileSplitter4` to completion in a browser in both modes, since the bot's move
selection changed: the emptied pile reads `🗑️` rather than a bare `0` on the mover's own
deferred beat as well as the bot's, hover previews and cut labels render correctly, and
the bot wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162i2JPAqrjjvFzrTvbGo2M

---
_Generated by [Claude Code](https://claude.ai/code/session_0162i2JPAqrjjvFzrTvbGo2M)_