### PR TITLE
Attribute web-session commits to Claude, with an opt-in co-author trailer

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -9,15 +9,21 @@ fi
 
 cd "$CLAUDE_PROJECT_DIR"
 
-# Attribution for web sessions: the agent writes the code, so it is the author,
-# and the human rides along as a co-author. GitHub counts a co-author towards
-# the contribution graph the same as an author, so nothing is lost by the split,
-# and `git log` stays honest about which commits an agent wrote. Set before the
-# Node block below so a failed install cannot leave commits misattributed.
+# Attribution for web sessions: the agent writes the code, so it is the author.
+# Set before the Node block below so a failed install cannot leave commits
+# misattributed.
 git config user.name "Claude"
 git config user.email "noreply@anthropic.com"
-git config claude.coauthor \
-  "${CLAUDE_COMMIT_COAUTHOR:-Ildikó Czeller <czeildi@users.noreply.github.com>}"
+
+# Whoever wants the credit names themselves in CLAUDE_COMMIT_COAUTHOR, in their
+# own cloud environment. There is deliberately no default: a name hardcoded here
+# would be appended to every other contributor's web session too, crediting them
+# for work they did not do. Unset first, so that a reused container cannot carry
+# a previous session's value into one that sets nothing.
+git config --unset claude.coauthor 2> /dev/null || true
+if [ -n "${CLAUDE_COMMIT_COAUTHOR:-}" ]; then
+  git config claude.coauthor "$CLAUDE_COMMIT_COAUTHOR"
+fi
 
 # `git commit -m` ignores commit.template and every commit here is made with -m,
 # so the trailer has to be appended by a hook instead. .git/hooks is not part of

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -9,6 +9,45 @@ fi
 
 cd "$CLAUDE_PROJECT_DIR"
 
+# Attribution for web sessions: the agent writes the code, so it is the author,
+# and the human rides along as a co-author. GitHub counts a co-author towards
+# the contribution graph the same as an author, so nothing is lost by the split,
+# and `git log` stays honest about which commits an agent wrote. Set before the
+# Node block below so a failed install cannot leave commits misattributed.
+git config user.name "Claude"
+git config user.email "noreply@anthropic.com"
+git config claude.coauthor \
+  "${CLAUDE_COMMIT_COAUTHOR:-Ildikó Czeller <czeildi@users.noreply.github.com>}"
+
+# `git commit -m` ignores commit.template and every commit here is made with -m,
+# so the trailer has to be appended by a hook instead. .git/hooks is not part of
+# the checkout, so it is written per session rather than committed. The hook
+# reads the co-author back out of git config so that this heredoc stays quoted.
+mkdir -p .git/hooks
+cat > .git/hooks/prepare-commit-msg << 'HOOK'
+#!/bin/bash
+set -euo pipefail
+
+# $2 is the message source. Merges and squashes take their message from git
+# rather than from the agent, so they are left alone; an amend re-runs this hook
+# over a message that already carries the trailer, which addIfDifferent skips.
+case "${2:-}" in
+  merge|squash) exit 0 ;;
+esac
+
+coauthor=$(git config claude.coauthor || true)
+[ -n "$coauthor" ] || exit 0
+
+# addIfDifferent rather than doNothing: a Co-authored-by trailer naming Claude
+# is often already present, and doNothing keys off the token alone, which would
+# drop the human's line whenever it is.
+git interpret-trailers --in-place --if-exists addIfDifferent \
+  --trailer "Co-authored-by: $coauthor" "$1" ||
+  # Attribution is not worth blocking a commit over.
+  echo "prepare-commit-msg: could not append the co-author trailer" >&2
+HOOK
+chmod +x .git/hooks/prepare-commit-msg
+
 # The web container is not the devcontainer, so nothing there pins Node: it
 # ships whatever its image has, and an npm of the wrong major resolves this
 # lockfile differently and fails `npm ci` outright. nvm is in the image, so


### PR DESCRIPTION
Extends the existing `SessionStart` hook so that commits made from Claude Code on the web are authored by Claude, with the human who ran the session credited as a co-author.

The agent writes the code, so it is the author, and `git log` stays honest about which commits came from an agent. Nothing is lost by the split: GitHub counts a co-author toward the contribution graph the same as an author.

## What the hook does

In web sessions only — the existing `CLAUDE_CODE_REMOTE` guard already scopes this, so local commits keep the developer's own identity:

- sets the git identity to `Claude <noreply@anthropic.com>`
- generates `.git/hooks/prepare-commit-msg`, which appends a `Co-authored-by` trailer

The trailer needs a git hook because `git commit -m` ignores `commit.template`, and every commit here is made with `-m`. `.git/hooks` is not part of the checkout, so it is written per session rather than committed.

The attribution block runs before the Node setup, so a failed dependency install cannot leave commits misattributed.

## The co-author is opt-in

There is deliberately no default name. A hardcoded one would be appended to every contributor's web session, crediting someone for work they did not do. Whoever wants the credit names themselves in their own cloud environment:

```
CLAUDE_COMMIT_COAUTHOR = Your Name <you@users.noreply.github.com>
```

A session that sets nothing appends no trailer. The value is also unset up front, so a reused container cannot carry one session's co-author into the next.

## Testing

The generated hook was driven directly, so no test commits are in history:

| Case | Result |
| --- | --- |
| No variable set | no trailer |
| Variable set | trailer appended |
| Re-run over its own output (amend) | one line, no duplicate |
| Merge commit | message untouched |
| Container reuse after a session that set it | value gone |

`npm run lint` and the `coins-in-3-piles` specs pass; the hook itself is shell, which eslint does not cover, so it was checked with `bash -n`.

One caveat worth flagging: the environment variable only reaches sessions started after it is set, so the trailer was verified by injecting the value rather than by a live session. The first commit on this branch predates the opt-in rule and still carries a hardcoded trailer.

This takes effect for new sessions once merged into `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVfszNoT8rqT52f8P8hBv6

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVfszNoT8rqT52f8P8hBv6)_