### PR TITLE
Shark chase: clean up the board client

### DIFF
--- a/src/components/games/shark-chase/board-client.tsx
+++ b/src/components/games/shark-chase/board-client.tsx
@@ -1,61 +1,116 @@
-import { useState } from 'react';
 import { range } from 'lodash';
 
 import { SharkSvg } from './assets/shark-chase-shark-svg';
 import { SubmarineSvg } from './assets/shark-chase-submarine-svg';
 import { useTranslation } from 'language';
 import { type Board, RESEARCHERS, SHARK, sideLength } from './gameplay';
-import { GameBoard, type BoardClientProps } from 'strategy-game-factory';
+import { GameBoard, type BoardClientProps, useMoveScopedState } from 'strategy-game-factory';
 
 // Tailwind scans for whole class names, so the grid width cannot be built by
 // interpolation even though the side length is on the board.
 const gridColumns: Record<number, string> = { 4: 'grid-cols-4', 5: 'grid-cols-5' };
 
+// A piece drawn over a sector: SubmarineSvg/SharkSvg define the two symbols
+// once for the whole board, so a piece is only ever a `use` of one of them.
+const Piece = ({ symbol, className }: { symbol: 'shark' | 'submarine'; className: string }) => (
+  <svg className={`aspect-square absolute ${className}`}>
+    <use xlinkHref={`#${symbol}`} />
+  </svg>
+);
+
+const topsByCount: Record<number, string[]> = {
+  1: ['top-0'],
+  2: ['top-[-10%]', 'top-[10%]'],
+  3: ['top-[-10%]', 'top-0', 'top-[10%]'],
+  4: ['top-[-15%]', 'top-[-5%]', 'top-[5%]', 'top-[15%]']
+};
+
+const SubmarinesInCell = ({ count }: { count: number }) => (
+  <>
+    {(topsByCount[count] ?? []).map(top => (
+      <Piece key={top} symbol="submarine" className={`${top} z-20 opacity-80`} />
+    ))}
+  </>
+);
+
+// Where the ghost of the arriving submarine sits, chosen to fall between the
+// ones already there rather than over one of them — the sectors it can reach
+// keep the layout `topsByCount` gives them, since only the ghost is new.
+const optionalNextTopByCount: Record<number, string> = {
+  0: 'top-0',
+  1: 'top-[10%]',
+  2: 'top-0',
+  3: 'top-[25%]'
+};
+
+const OptionalNextSubmarine = ({ existingSubmarineCount }: { existingSubmarineCount: number }) => (
+  <Piece
+    symbol="submarine"
+    className={`z-40 opacity-50 ${optionalNextTopByCount[existingSubmarineCount] ?? 'top-[25%]'}`}
+  />
+);
+
 // The two variants differ only in the size of the lake, which the board carries,
 // and in how many days the shark has to survive, which it does not.
-export const makeBoardClient = (maxTurn: number) =>
-  ({ board, ctx, moves }: BoardClientProps<Board>) => {
+export const makeBoardClient = (maxTurn: number) => {
+  const BoardClient = ({ board, ctx, moves }: BoardClientProps<Board>) => {
     const { t } = useTranslation();
-    const [chosenPiece, setChosenPiece] = useState<number | null>(null);
+    const [chosenPiece, setChosenPiece] = useMoveScopedState<number | null>(ctx.moveCount, null);
     const isCurrentPlayerResearcher = ctx.currentPlayer === RESEARCHERS;
     const isCurrentPlayerShark = ctx.currentPlayer === SHARK;
+    const canInteract = ctx.isClientMoveAllowed;
 
-    const isAllowed_choosePiece = (id: number): boolean => {
-      if (!ctx.isClientMoveAllowed) return false;
+    const canSelect = (id: number): boolean => {
+      if (!canInteract) return false;
       if (isCurrentPlayerResearcher) return board.submarines[id] >= 1;
       if (isCurrentPlayerShark) return board.shark === id;
       return false;
     };
 
-    const isAllowed_movePiece = (id: number): boolean => (isCurrentPlayerShark
+    const canMoveTo = (id: number): boolean => (isCurrentPlayerShark
       ? moves.moveShark.isAllowed(board, id)
       : chosenPiece !== null && moves.moveSubmarine.isAllowed(board, { from: chosenPiece, to: id }));
 
-    const possibleMoves = range(board.submarines.length).filter(isAllowed_movePiece);
+    const possibleMoves = new Set(range(board.submarines.length).filter(canMoveTo));
 
     // The click handler keeps its guards: a rejected click must leave the local
     // piece selection alone, which the engine's silent gating cannot do for us.
     const clickField = (id: number) => {
-      if (!ctx.isClientMoveAllowed) return;
-      if (isCurrentPlayerResearcher) {
-        if (chosenPiece === null) {
-          if (!isAllowed_choosePiece(id)) return;
-          setChosenPiece(id)
-        } else {
-          if (!isAllowed_movePiece(id)) {
-            if (id === chosenPiece) {
-              setChosenPiece(null);
-            }
-            return;
-          };
-          moves.moveSubmarine(board, { from: chosenPiece, to: id });
-          setChosenPiece(null);
-        }
-      }
+      if (!canInteract) return;
       if (isCurrentPlayerShark) {
-        if (!isAllowed_movePiece(id)) return;
+        if (!canMoveTo(id)) return;
         moves.moveShark(board, id);
+        return;
       }
+      if (!isCurrentPlayerResearcher) return;
+      if (chosenPiece !== null && canMoveTo(id)) {
+        moves.moveSubmarine(board, { from: chosenPiece, to: id });
+        setChosenPiece(null);
+        return;
+      }
+      // Clicking the chosen submarine gives it up, and clicking another one
+      // takes that one instead — a submarine out of reach of the chosen one is
+      // a change of mind, not a move.
+      setChosenPiece(id === chosenPiece || !canSelect(id) ? null : id);
+    };
+
+    // A sector holds nothing but SVG symbols, so each button needs a name of its
+    // own to be usable without seeing the board.
+    const cellLabel = (id: number): string => {
+      const count = board.submarines[id];
+      const contents: string[] = [];
+      if (count >= 1) {
+        contents.push(t({
+          hu: `${count} tengeralattjáró`,
+          en: `${count} submarine${count > 1 ? 's' : ''}`
+        }));
+      }
+      if (board.shark === id) contents.push(t({ hu: 'cápa', en: 'shark' }));
+      if (board.shark === id && isCurrentPlayerShark && canInteract) {
+        contents.push(t({ hu: 'itt maradok', en: 'stay here' }));
+      }
+      const sector = t({ hu: `${id + 1}. szektor`, en: `Sector ${id + 1}` });
+      return contents.length > 0 ? `${sector}: ${contents.join(', ')}` : sector;
     };
 
     return (
@@ -70,32 +125,39 @@ export const makeBoardClient = (maxTurn: number) =>
           <button
             key={id}
             onClick={() => clickField(id)}
-            disabled={!isAllowed_choosePiece(id) && !isAllowed_movePiece(id)}
+            disabled={!canSelect(id) && !canMoveTo(id)}
+            aria-label={cellLabel(id)}
+            aria-pressed={isCurrentPlayerResearcher && canSelect(id) ? chosenPiece === id : undefined}
             className={`
               aspect-square border-r-2 border-b-2 p-2 relative flex justify-center items-center
               disabled:cursor-default enabled:hocus:bg-blue-50 dark:enabled:hocus:bg-blue-950
-              ${possibleMoves.includes(id) && isCurrentPlayerShark && board.submarines[id]
+              ${/* the ghosts say where the chosen submarine may go, but only the
+                    pointer says which one is chosen — which leaves a touch or
+                    keyboard player nothing to read */
+                chosenPiece === id ? 'ring-2 ring-inset ring-blue-500' : ''}
+              ${/* swimming into a submarine is a legal move, and loses on the spot */
+                possibleMoves.has(id) && isCurrentPlayerShark && board.submarines[id]
                 ? 'ring-2 ring-inset ring-red-600' : ''}
             `}
           >
             {board.submarines[id] >= 1 && (
               <SubmarinesInCell count={board.submarines[id]} />
             )}
-            {possibleMoves.includes(id) && isCurrentPlayerResearcher && (
+            {possibleMoves.has(id) && isCurrentPlayerResearcher && (
               <OptionalNextSubmarine existingSubmarineCount={board.submarines[id]} />
             )}
-            {board.shark === id && (
-              <svg className="aspect-square top-0 absolute z-10">
-                <use xlinkHref="#shark" />
-              </svg>
+            {board.shark === id && <Piece symbol="shark" className="top-0 z-10" />}
+            {possibleMoves.has(id) && isCurrentPlayerShark && (
+              <Piece symbol="shark" className="top-0 z-40 opacity-50" />
             )}
-            {possibleMoves.includes(id) && isCurrentPlayerShark && (
-              <OptionalNextShark />
-            )}
-            {board.shark === id && isCurrentPlayerShark && ctx.isClientMoveAllowed && (
-              <button
-                className="absolute bottom-1 z-50 w-[95%] secondary-button text-xs p-0.5"
-              >{t({ hu: 'Itt maradok', en: 'Stay here' })}</button>
+            {board.shark === id && isCurrentPlayerShark && canInteract && (
+              // A label for what the sector button already does, not a control
+              // of its own: a button may not hold another one, and a second tab
+              // stop over the same action would only be in the way.
+              <span
+                className="absolute bottom-1 z-50 w-[95%] secondary-button text-xs p-0.5
+                  pointer-events-none"
+              >{t({ hu: 'Itt maradok', en: 'Stay here' })}</span>
             )}
         </button>
         ))}
@@ -104,42 +166,5 @@ export const makeBoardClient = (maxTurn: number) =>
     );
   };
 
-const OptionalNextShark = () => {
-  return <svg className="aspect-square top-0 absolute z-40 opacity-50">
-    <use xlinkHref="#shark" />
-  </svg>;
+  return BoardClient;
 };
-
-const OptionalNextSubmarine = ({ existingSubmarineCount }) => (
-  <svg
-    className={`
-      aspect-square absolute z-40 opacity-50
-      ${optionalNextTopByCount[existingSubmarineCount]}
-    `}>
-    <use xlinkHref="#submarine" />
-  </svg>
-);
-
-const optionalNextTopByCount: Record<number, string> = {
-  0: 'top-0',
-  1: 'top-[10%]',
-  2: 'top-0',
-  3: 'top-[25]%'
-}
-
-const topsByCount: Record<number, string[]> = {
-  1: ['top-0'],
-  2: ['top-[-10%]', 'top-[10%]'],
-  3: ['top-[-10%]', 'top-0', 'top-[10%]'],
-  4: ['top-[-15%]', 'top-[-5%]', 'top-[5%]', 'top-[15%]']
-};
-
-const SubmarinesInCell = ({ count }) => (
-  <>
-    {(topsByCount[count] ?? []).map(pos => (
-      <svg key={pos} className={`aspect-square ${pos} absolute z-20 opacity-80`}>
-        <use xlinkHref="#submarine" />
-      </svg>
-    ))}
-  </>
-);

--- a/src/components/games/shark-chase/board-client.tsx
+++ b/src/components/games/shark-chase/board-client.tsx
@@ -40,13 +40,13 @@ const optionalNextTopByCount: Record<number, string> = {
   0: 'top-0',
   1: 'top-[10%]',
   2: 'top-0',
-  3: 'top-[25%]'
+  3: 'top-[20%]'
 };
 
 const OptionalNextSubmarine = ({ existingSubmarineCount }: { existingSubmarineCount: number }) => (
   <Piece
     symbol="submarine"
-    className={`z-40 opacity-50 ${optionalNextTopByCount[existingSubmarineCount] ?? 'top-[25%]'}`}
+    className={`z-40 opacity-50 ${optionalNextTopByCount[existingSubmarineCount]}`}
   />
 );
 


### PR DESCRIPTION
First of three stacked PRs from a review of `shark-chase` for code smells,
focused on the board client. This one is the board client alone; #479 fixes the
researchers' scripted line on top of it, and #475 removes the duplication
between the two variant folders on top of that.

`board-client.tsx` was the outlier of `games/` in several ways.

**"Itt maradok / Stay here" was a `<button>` inside the sector `<button>`.** It
has no `onClick` of its own — it only ever worked because the click bubbled to
the button it is nested in, which `<button>`'s content model does not allow, at
the cost of a second tab stop that does nothing on its own. It is a `<span>`
now, labelling what the enclosing button already does.

**`top-[25]%` is not a class Tailwind emits.** The ghost of a submarine arriving
over three others lost its offset and landed on them. Reachable on 5 × 5 only,
where four submarines can stack.

**Clicking a submarine out of reach of the chosen one did nothing**, though its
button was enabled and said otherwise. It re-selects now — a destination still
wins over re-selection, so stacking onto an adjacent submarine is unchanged —
which also makes the `disabled` state honest.

**Only the pointer said which submarine was chosen.** Found by playing it: the
ghosts show where the selection may go, but nothing marked the selection itself,
so touch and keyboard players had nothing to read. It has a ring now.

**No sector had an accessible name.** They hold nothing but SVG symbols, so all
16/25 buttons announced as a bare "button". Each carries an `aria-label` naming
the sector and what is in it.

The rest is convention: `useMoveScopedState` (this was the last client holding a
mid-turn selection in raw `useState`), typed props on the two sub-components
(they only compiled because `noImplicitAny` is off), house naming in place of
`isAllowed_choosePiece` (the only snake_case in `src/`), one `Piece` for four
copies of the same `<svg><use>`, and a `Set` for the reachable sectors.

## Testing

| Check | Result |
| --- | --- |
| `npm run lint`, `npm run typecheck` | pass |
| `npm run test:unit` | pass |
| Played in a browser: both variants, both roles, `vsComputer` and `vsHuman`, light and dark | selection, re-selection, deselection, the stacking ghost, "Stay here" by click and by Enter, one tab stop per sector |

Nothing in the suite clicks a board, so none of this is reachable by a spec —
the selection ring and the dead re-selection click were found by playing the
game, which is also where the `top-[25]%` fix was checked before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8Fu7Uxzc9iYYoyCb8tSyu