### PR TITLE
Clarify PR scope guidance in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,10 +239,17 @@ unwanted should be dropped instead — trailing parameters can simply be left of
 destructuring, which is why bots and `getPlayerStepDescription` write
 `({ board })` rather than underscoring `ctx`.
 
-## Pull request size
+## Pull request scope
 
 Reviewer time is the scarcest resource here, so plan the split **before**
-starting, not after the diff has grown. Two rules cover most cases:
+starting, not after the diff has grown. What decides the split is
+**atomicity, not diff size**: one PR per independent change, so a reviewer
+can accept or reject each on its own. A mechanical change is one PR however
+many files it touches; unrelated fixes to a game's board client and its bot
+strategy are two PRs even though both are small and live in one folder.
+
+Two rules cover the case where a single design change implies a repo-wide
+diff:
 
 - **Separate the design from the sweep.** A change to the `strategyGameFactory`
   contract touches every game, but only the engine, the new shape and a pilot


### PR DESCRIPTION
# Description

## Motivation

The "Pull request size" section in AGENTS.md was ambiguous about what actually determines how to split work across PRs. This clarification makes it explicit that **atomicity** (independent changes) is the deciding factor, not diff size, and provides concrete examples to guide contributors.

## Key changes

- Renamed section from "Pull request size" to "Pull request scope" to better reflect the actual guidance
- Added explicit principle: one PR per independent change, allowing reviewers to accept/reject each separately
- Provided concrete examples: mechanical changes are one PR regardless of file count; unrelated fixes in the same folder are separate PRs
- Reorganized content to separate the core principle from the two specific rules that apply to repo-wide design changes

## Details

**Prior logic:** The section focused on "two rules" for splitting PRs but didn't clearly state the underlying principle, leaving it ambiguous whether diff size or change independence was the deciding factor.

**Current logic:** The guidance now explicitly states that atomicity is what matters—each PR should represent one independent change that can be reviewed and accepted/rejected on its own merits. This is illustrated with examples showing that a mechanical refactor touching many files is one PR, while two unrelated fixes in the same folder are two PRs.

The two existing rules are preserved but repositioned as specific guidance for the common case where a single design change implies a repo-wide diff.

https://claude.ai/code/session_019gj6ryonJeG7oaeR3zB3X6