### PR TITLE
Assign agent-opened PRs to the user the agent works for

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,9 +263,12 @@ diff:
 A mechanical sweep that follows a merged design PR is fine at any size — it is
 skimmable precisely because the pattern was already reviewed.
 
-When an agent opens a pull request, it should assign `czeildi` to it (the
-`assignees` field via the GitHub API), so agent-opened PRs land in their review
-queue instead of going unnoticed.
+When an agent opens a pull request, it should assign the person it is working
+for (the `assignees` field via the GitHub API), so agent-opened PRs land in
+that person's queue instead of going unnoticed. Identify them from the session
+context — the user's email, or `git config user.email` — matched against the
+repository's collaborator logins, and leave the PR unassigned rather than
+guess when there is no confident match.
 
 ## Maintenance philosophy
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,6 +263,10 @@ diff:
 A mechanical sweep that follows a merged design PR is fine at any size — it is
 skimmable precisely because the pattern was already reviewed.
 
+When an agent opens a pull request, it should assign `czeildi` to it (the
+`assignees` field via the GitHub API), so agent-opened PRs land in their review
+queue instead of going unnoticed.
+
 ## Maintenance philosophy
 
 This is a volunteer side-project with limited time. Prefer simple, consistent,


### PR DESCRIPTION
Adds a rule to `AGENTS.md`: when an agent opens a pull request, it assigns the person it is working for, identified from the session context (user email, or `git config user.email`) and matched against the repository's collaborator logins. When there is no confident match, the PR is left unassigned rather than guessed.

The rule is deliberately per-user rather than naming a fixed maintainer, so each contributor's own agent instance assigns them — not the same person on every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013KvhHEcdVPCBJJwX5y2NCa

---
_Generated by [Claude Code](https://claude.ai/code/session_013KvhHEcdVPCBJJwX5y2NCa)_