### PR TITLE
Shark chase: pin what the researchers' scripted line does

### DIFF
--- a/src/components/games/shark-chase/shark-4-by-4/bot-strategy.spec.ts
+++ b/src/components/games/shark-chase/shark-4-by-4/bot-strategy.spec.ts
@@ -1,5 +1,9 @@
-import { getNextSharkPositionByAI } from './bot-strategy';
-import type { Board } from '../gameplay';
+import { cloneDeep } from 'lodash';
+import { runMatch } from 'strategy-game-factory';
+import { forcedWinnerIndex } from 'test-utils';
+import { getNextSharkPositionByAI, randomBotStrategy, smartBotStrategy } from './bot-strategy';
+import { RESEARCHERS, type Board } from '../gameplay';
+import { moves, startBoard } from './gameplay';
 
 const makeBoard = (submarines: number[], shark: number, turn: number): Board => ({
   submarines, shark, turn, sharkMovesInTurn: 0
@@ -91,5 +95,32 @@ describe('getNextSharkPositionByAI', () => {
     const shark = 10;
     const position = getNextSharkPositionByAI(makeBoard(submarines, shark, 6));
     expect(position).toEqual(14);
+  });
+});
+
+// The researchers' half is not a search but a table of moves per day, branching
+// on where the shark is, and nothing played it before this: the sweep in
+// plays-to-an-end.spec.ts asks only that a match ends, so a script that wins
+// and one that merely finishes read the same there. `runMatch` throws on a move
+// the game's own `validate` rejects, so these pin that the table names a legal
+// move on every line as well as that it wins.
+describe('the researchers\' scripted line', () => {
+  const catchesTheShark = () => runMatch({
+    gameplay: { moves },
+    strategies: [smartBotStrategy, randomBotStrategy],
+    startBoard: cloneDeep(startBoard)
+  }).winnerIndex;
+
+  it('catches a shark that flees at random, whichever line it takes', () => {
+    // A match is ~30 moves of table lookups, so a run of them stays in the
+    // milliseconds (AGENTS.md § Testing) while covering many escape lines.
+    const winners = new Set(Array.from({ length: 60 }, catchesTheShark));
+    expect([...winners]).toEqual([RESEARCHERS]);
+  });
+
+  it('catches the optimal shark from the start board', () => {
+    expect(forcedWinnerIndex({
+      gameplay: { moves }, botStrategy: smartBotStrategy, startBoard
+    })).toBe(RESEARCHERS);
   });
 });

--- a/src/components/games/shark-chase/shark-5-by-5/bot-strategy.spec.ts
+++ b/src/components/games/shark-chase/shark-5-by-5/bot-strategy.spec.ts
@@ -1,5 +1,7 @@
-import { getNextSharkPositionByAI } from './bot-strategy';
-import type { Board } from '../gameplay';
+import { forcedWinnerIndex } from 'test-utils';
+import { getNextSharkPositionByAI, smartBotStrategy } from './bot-strategy';
+import { RESEARCHERS, type Board } from '../gameplay';
+import { moves, startBoard } from './gameplay';
 
 const makeBoard = (submarines: number[], shark: number, turn: number): Board => ({
   submarines, shark, turn, sharkMovesInTurn: 0
@@ -36,5 +38,16 @@ describe('getNextSharkPositionByAI', () => {
     const shark = 0;
     const position = getNextSharkPositionByAI(makeBoard(submarines, shark, 8));
     expect(position).toEqual(5);
+  });
+});
+
+// The same property the 4 × 4 spec pins. The run against a randomly fleeing
+// shark is missing on purpose: this script does not survive one — a bug in the
+// script rather than in the spec, and its own change to make.
+describe('the researchers\' scripted line', () => {
+  it('catches the optimal shark from the start board', () => {
+    expect(forcedWinnerIndex({
+      gameplay: { moves }, botStrategy: smartBotStrategy, startBoard
+    })).toBe(RESEARCHERS);
   });
 });


### PR DESCRIPTION
**1 of 5**, and the only one that touches no source: specs only, green before
and after.

The stack, bottom first — each is one idea, and the diffs get smaller as they go
up except for the movement one:

1. **#485** (this) — pin what the researchers' script does today
2. **#486** — the bug: the script names an illegal move from day 12
3. **#487** — `makeGameplay`, one copy of the rules
4. **#488** — `makeSharkBots`, one copy of the bots (movement, the big diff)
5. **#489** — derive the shark's location preference

Nothing played the researchers' scripted line before this. A bot spec reads a
bot's decisions, and neither variant had one for the researchers' half; the
sweep in `plays-to-an-end.spec.ts` asks only that a match ends, so a script that
wins and one that merely finishes read the same there.

Two properties, both true today:

- the researchers catch a shark that flees at random, whichever line it takes.
  `runMatch` throws on a move the game's own `validate` rejects, so this pins
  that the table names a legal move on every line as well as that it wins
- they catch the optimal shark from the start board (`forcedWinnerIndex`)

The 5 × 5 spec gets only the second. **Its script does not survive a run against
a randomly fleeing shark** — a bug in the script, and the subject of #486.

## Testing

`npm run lint`, `npm run typecheck`, `npm run test:unit` all pass. Every added
test passes against unmodified source, which is the point of this step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8Fu7Uxzc9iYYoyCb8tSyu