### PR TITLE
Shark chase: stop the researchers' script naming an illegal move

### DIFF
--- a/src/components/games/shark-chase/shark-4-by-4/bot-strategy.spec.ts
+++ b/src/components/games/shark-chase/shark-4-by-4/bot-strategy.spec.ts
@@ -1,6 +1,6 @@
 import { cloneDeep } from 'lodash';
 import { runMatch } from 'strategy-game-factory';
-import { forcedWinnerIndex } from 'test-utils';
+import { botNextMove, forcedWinnerIndex, makeCtx, moveValidator } from 'test-utils';
 import { getNextSharkPositionByAI, randomBotStrategy, smartBotStrategy } from './bot-strategy';
 import { RESEARCHERS, type Board } from '../gameplay';
 import { moves, startBoard } from './gameplay';
@@ -122,5 +122,23 @@ describe('the researchers\' scripted line', () => {
     expect(forcedWinnerIndex({
       gameplay: { moves }, botStrategy: smartBotStrategy, startBoard
     })).toBe(RESEARCHERS);
+  });
+
+  it('still names a legal move where the table has no entry', () => {
+    // The table stops at day 10, and the last day is 11. The two tests above say
+    // the shark cannot reach that day, so this is the position the script is not
+    // written for — reached by hand, since the point is what happens if it ever
+    // is: the bot used to name `undefined` here and throw inside the engine's
+    // timeout, leaving the board frozen for good.
+    const submarines = Array(16).fill(0);
+    submarines[0] = 1;
+    const board = makeBoard(submarines, 15, 11);
+    const { move, args } = botNextMove(smartBotStrategy({
+      board, ctx: makeCtx({ currentPlayer: RESEARCHERS, chosenRoleIndex: 1 })
+    }));
+    expect(move).toBe('moveSubmarine');
+    expect(moveValidator(moves.moveSubmarine, makeCtx({ currentPlayer: RESEARCHERS }))(
+      board, ...args as [{ from: number; to: number }]
+    )).toBe(true);
   });
 });

--- a/src/components/games/shark-chase/shark-4-by-4/bot-strategy.ts
+++ b/src/components/games/shark-chase/shark-4-by-4/bot-strategy.ts
@@ -1,6 +1,6 @@
 import { sample } from 'lodash';
 import type { BotMove, BotStrategy } from 'strategy-game-factory';
-import type { Board } from '../gameplay';
+import { isSubmarineMoveAllowed, type Board } from '../gameplay';
 import { makeGeometry } from '../bot-geometry';
 import type { Moves } from './gameplay';
 
@@ -51,13 +51,30 @@ export const randomBotStrategy: Bot = ({ board, ctx }) => {
 
 export const smartBotStrategy: Bot = ({ board, ctx }) => {
   if (ctx.chosenRoleIndex === 0) {
-    const finalPos = getNextSharkPositionByAI(board)!;
+    const finalPos = getNextSharkPositionByAI(board);
     const firstPos = getIntermediateSharkPosition(board.submarines, board.shark, finalPos);
     return asSharkRoute(board.shark, firstPos, finalPos);
-  } else {
-    const { from, to } = getOptimalSubmarineMoveByBot(board)!;
-    return { move: 'moveSubmarine', args: [{ from, to }] };
   }
+  const move = getSubmarineMove(board);
+  // Nothing left that wins: the position is already lost, and a bot that plays
+  // on beats one that throws inside the engine's timeout, where nothing catches
+  // it and the board never moves again.
+  return move
+    ? { move: 'moveSubmarine', args: [move] }
+    : randomBotStrategy({ board, ctx });
+};
+
+// `getOptimalSubmarineMoveByBot` is a table, not a search: it has no entry for
+// the last day, and a shark stepping between its two branches would leave it
+// naming a submarine that is not on that sector. Both are positions the shark
+// only reaches by playing badly, so rather than write more table for them, ask
+// the search for a move that still wins. It is cheap here: the table covers
+// every day up to the first branch, so the search only ever runs with few days
+// left.
+const getSubmarineMove = (board: Board): { from: number; to: number } | undefined => {
+  const scripted = getOptimalSubmarineMoveByBot(board);
+  if (scripted && isSubmarineMoveAllowed(board, scripted.from, scripted.to)) return scripted;
+  return findWinningSubmarineMove(board);
 };
 
 const getOptimalSubmarineMoveByBot = (board: Board): { from: number; to: number } | undefined => {
@@ -192,7 +209,32 @@ const canSharkSurviveSharkTurn = (
 // remain valid and are worth keeping.
 const sharkSurvivalMemo = new Map<string, boolean>();
 
-export const getNextSharkPositionByAI = (board: Board): number | undefined => {
+// The move the researchers want wherever the script does not apply: the one
+// after which the shark has no reply that survives the remaining days. This is
+// `canSharkSurviveSubmarineTurn`'s own loop, asked for the move it stops at
+// rather than for whether one exists.
+const findWinningSubmarineMove = (board: Board): { from: number; to: number } | undefined => {
+  const { submarines, shark, turn } = board;
+  for (let from = 0; from < 16; from++) {
+    if (submarines[from] === 0) continue;
+    for (const to of getAdjacentCells(from)) {
+      const nextSubmarines = submarines.slice();
+      nextSubmarines[from] -= 1;
+      nextSubmarines[to] += 1;
+      // The search plays on from a live position, so catching the shark — which
+      // ends the game there and then — is asked separately.
+      if (nextSubmarines[shark] >= 1) return { from, to };
+      if (!canSharkSurviveSharkTurn(nextSubmarines, shark, turn, sharkSurvivalMemo)) {
+        return { from, to };
+      }
+    }
+  }
+  return undefined;
+};
+
+// Always a sector: the shark's own one is reachable whenever the game is still
+// running, so the pool the preference falls back on is never empty.
+export const getNextSharkPositionByAI = (board: Board): number => {
   const { submarines, shark, turn } = board;
   const reachable: number[] = [];
   for (let i = 0; i < 16; i++) {

--- a/src/components/games/shark-chase/shark-5-by-5/bot-strategy.spec.ts
+++ b/src/components/games/shark-chase/shark-5-by-5/bot-strategy.spec.ts
@@ -1,5 +1,7 @@
-import { forcedWinnerIndex } from 'test-utils';
-import { getNextSharkPositionByAI, smartBotStrategy } from './bot-strategy';
+import { cloneDeep } from 'lodash';
+import { runMatch } from 'strategy-game-factory';
+import { botNextMove, forcedWinnerIndex, makeCtx, moveValidator } from 'test-utils';
+import { getNextSharkPositionByAI, randomBotStrategy, smartBotStrategy } from './bot-strategy';
 import { RESEARCHERS, type Board } from '../gameplay';
 import { moves, startBoard } from './gameplay';
 
@@ -41,13 +43,71 @@ describe('getNextSharkPositionByAI', () => {
   });
 });
 
-// The same property the 4 × 4 spec pins. The run against a randomly fleeing
-// shark is missing on purpose: this script does not survive one — a bug in the
-// script rather than in the spec, and its own change to make.
+// The same property the 4 × 4 spec pins, and now the run against a randomly
+// fleeing shark too — the one this script used not to survive. Both positions
+// it got wrong are here: the day its table names a submarine that is not there,
+// and a day it has no entry for at all.
+//
+// Nothing else plays this line: `plays-to-an-end.spec.ts` skips SharkChase5[1]
+// for the cost of its shark, leaving the scripted researchers to this file.
 describe('the researchers\' scripted line', () => {
+  const catchesTheShark = () => runMatch({
+    gameplay: { moves },
+    strategies: [smartBotStrategy, randomBotStrategy],
+    startBoard: cloneDeep(startBoard)
+  }).winnerIndex;
+
+  it('catches a shark that flees at random, whichever line it takes', () => {
+    // Long enough to reach the late days: a random shark is usually caught well
+    // before them, so a run of 60 matches — which is what the 4 × 4 spec needs —
+    // reached day 12 in only about half of its executions, and the bug this file
+    // covers lives there. 400 is still under a second, since the random shark
+    // does no searching and the researchers' half is table lookups.
+    const winners = new Set(Array.from({ length: 400 }, catchesTheShark));
+    expect([...winners]).toEqual([RESEARCHERS]);
+  });
+
   it('catches the optimal shark from the start board', () => {
     expect(forcedWinnerIndex({
       gameplay: { moves }, botStrategy: smartBotStrategy, startBoard
     })).toBe(RESEARCHERS);
+  });
+
+  it('wins on from the day the table names a submarine that is not there', () => {
+    // The table's own opening reaches this after 9 → 14 → 19 on the second
+    // branch, and its day-12 entry there is `from 0`, a sector that has never
+    // held a submarine. Every shark that lives to day 12 down that branch used
+    // to land here, and the move was rejected as illegal.
+    const board = makeBoard([
+      0, 0, 0, 1, 0,
+      0, 0, 0, 0, 0,
+      0, 0, 1, 0, 0,
+      0, 0, 0, 0, 1,
+      0, 1, 0, 0, 0
+    ], 23, 12);
+    const winners = new Set(Array.from({ length: 20 }, () => runMatch({
+      gameplay: { moves },
+      strategies: [smartBotStrategy, randomBotStrategy],
+      startBoard: cloneDeep(board)
+    }).winnerIndex));
+    expect([...winners]).toEqual([RESEARCHERS]);
+  });
+
+  it('still names a legal move where the table has no entry', () => {
+    // The table stops at day 14, and the last day is 15. The two tests above say
+    // the shark cannot reach that day, so this is the position the script is not
+    // written for — reached by hand, since the point is what happens if it ever
+    // is: the bot used to name `undefined` here and throw inside the engine's
+    // timeout, leaving the board frozen for good.
+    const submarines = Array(25).fill(0);
+    submarines[0] = 1;
+    const board = makeBoard(submarines, 24, 15);
+    const { move, args } = botNextMove(smartBotStrategy({
+      board, ctx: makeCtx({ currentPlayer: RESEARCHERS, chosenRoleIndex: 1 })
+    }));
+    expect(move).toBe('moveSubmarine');
+    expect(moveValidator(moves.moveSubmarine, makeCtx({ currentPlayer: RESEARCHERS }))(
+      board, ...args as [{ from: number; to: number }]
+    )).toBe(true);
   });
 });

--- a/src/components/games/shark-chase/shark-5-by-5/bot-strategy.ts
+++ b/src/components/games/shark-chase/shark-5-by-5/bot-strategy.ts
@@ -1,6 +1,6 @@
 import { sample } from 'lodash';
 import type { BotMove, BotStrategy } from 'strategy-game-factory';
-import type { Board } from '../gameplay';
+import { isSubmarineMoveAllowed, type Board } from '../gameplay';
 import { makeGeometry } from '../bot-geometry';
 import type { Moves } from './gameplay';
 
@@ -52,13 +52,30 @@ export const randomBotStrategy: Bot = ({ board, ctx }) => {
 
 export const smartBotStrategy: Bot = ({ board, ctx }) => {
   if (ctx.chosenRoleIndex === 0) {
-    const finalPos = getNextSharkPositionByAI(board)!;
+    const finalPos = getNextSharkPositionByAI(board);
     const firstPos = getIntermediateSharkPosition(board.submarines, board.shark, finalPos);
     return asSharkRoute(board.shark, firstPos, finalPos);
-  } else {
-    const { from, to } = getOptimalSubmarineMoveByBot(board)!;
-    return { move: 'moveSubmarine', args: [{ from, to }] };
   }
+  const move = getSubmarineMove(board);
+  // Nothing left that wins: the position is already lost, and a bot that plays
+  // on beats one that throws inside the engine's timeout, where nothing catches
+  // it and the board never moves again.
+  return move
+    ? { move: 'moveSubmarine', args: [move] }
+    : randomBotStrategy({ board, ctx });
+};
+
+// `getOptimalSubmarineMoveByBot` is a table, not a search: it has no entry for
+// the last day, and a shark stepping between its two branches leaves it naming
+// a submarine that is not on that sector — from day 12 its second branch names
+// sector 0, which never holds one. Both are positions the shark only reaches by
+// playing badly, so rather than write more table for them, ask the search for a
+// move that still wins. It is cheap here: the table covers every day up to the
+// first branch, so the search only ever runs with few days left.
+const getSubmarineMove = (board: Board): { from: number; to: number } | undefined => {
+  const scripted = getOptimalSubmarineMoveByBot(board);
+  if (scripted && isSubmarineMoveAllowed(board, scripted.from, scripted.to)) return scripted;
+  return findWinningSubmarineMove(board);
 };
 
 const getOptimalSubmarineMoveByBot = (board: Board): { from: number; to: number } | undefined => {
@@ -225,8 +242,32 @@ const exceptionKey = (submarines: number[], shark: number, turn: number): string
 // remain valid and are worth keeping.
 const sharkSurvivalMemo = new Map<string, boolean>();
 
+// The move the researchers want wherever the script does not apply: the one
+// after which the shark has no reply that survives the remaining days. This is
+// `canSharkSurviveSubmarineTurn`'s own loop, asked for the move it stops at
+// rather than for whether one exists.
+const findWinningSubmarineMove = (board: Board): { from: number; to: number } | undefined => {
+  const { submarines, shark, turn } = board;
+  for (let from = 0; from < 25; from++) {
+    if (submarines[from] === 0) continue;
+    for (const to of getAdjacentCells(from)) {
+      const nextSubmarines = submarines.slice();
+      nextSubmarines[from] -= 1;
+      nextSubmarines[to] += 1;
+      // The search plays on from a live position, so catching the shark — which
+      // ends the game there and then — is asked separately.
+      if (nextSubmarines[shark] >= 1) return { from, to };
+      if (!canSharkSurviveSharkTurn(nextSubmarines, shark, turn, sharkSurvivalMemo)) {
+        return { from, to };
+      }
+    }
+  }
+  return undefined;
+};
 
-export const getNextSharkPositionByAI = (board: Board): number | undefined => {
+// Always a sector: the shark's own one is reachable whenever the game is still
+// running, so the pool the preference falls back on is never empty.
+export const getNextSharkPositionByAI = (board: Board): number => {
   const { submarines, shark, turn } = board;
   const reachable: number[] = [];
   for (let i = 0; i < 25; i++) {


### PR DESCRIPTION
**2 of 5**, on #485 — the spec that pins the 5 × 5 script against everything but
a randomly fleeing shark, because it does not survive one. This is why.

`getOptimalSubmarineMoveByBot` is a table of moves per day, and both callers
read it as total: `getOptimalSubmarineMoveByBot(board)!`. It is not.

- It has **no entry for the last day** — 11 on 4 × 4, 15 on 5 × 5.
- On 5 × 5 its **second branch is wrong from day 12 on**: after its own opening
  (… 9 → 14, 14 → 19) it says to move a submarine from sector 0, which never
  holds one.

Naming `undefined` throws inside the engine's bot timeout, where nothing catches
it; an illegal move is refused by the reducer. Either way the board never moves
again, and the shark only has to live to day 12 down that branch to get there.

## The fix

Both are positions the shark reaches by playing badly, so rather than write more
table for them, the bot asks the search its own shark half already runs, from
the other side: the move after which the shark has no reply that survives the
remaining days. That is cheap, because the table covers every day up to its
first branch, so the search only ever runs with few days left. A scripted move
is used only if it is legal, and if nothing wins the bot plays on with the
random researcher rather than freezing the game.

Also drops the `!` on `getNextSharkPositionByAI`, which cannot return
`undefined` — the shark's own sector is always reachable.

## What each new spec is worth

Measured, by putting the old strategy files back under the new specs:

| Spec | On the old code | Reliability |
| --- | --- | --- |
| 5 × 5 day-12 position, played out 20 times | `illegal move moveSubmarine([{"from":0,"to":4}])` | every run |
| 5 × 5 random-shark run | the same illegal move | every run at 400 matches (3 of 6 at 60) |
| 4 × 4 "no entry" day | `TypeError: Cannot destructure property 'from' … as it is undefined` | every run |
| 5 × 5 "no entry" day | the same TypeError | every run |

The random-shark run went from 60 matches to 400 for that reason: a random shark
is usually caught well before the late days, so 60 reached day 12 in only about
half of its executions. 400 costs ~100 ms.

## Testing

| Check | Result |
| --- | --- |
| `npm run lint`, `npm run typecheck`, `npm run test:unit` | pass |
| 3000 headless matches per variant, from the start board and from the day-12 position | no illegal moves, no shark wins |
| A 5 × 5 game played to the last day in a browser | researchers win |

The day-12 bug reproduces at the spec level, where `runMatch` prints the
rejected move and the board it was rejected on. I could not steer a browser game
into that branch by hand to watch the board freeze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8Fu7Uxzc9iYYoyCb8tSyu

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8Fu7Uxzc9iYYoyCb8tSyu)_