### PR TITLE
Shark chase: one copy of the rules

### DIFF
--- a/src/components/games/shark-chase/gameplay.ts
+++ b/src/components/games/shark-chase/gameplay.ts
@@ -1,3 +1,6 @@
+import { cloneDeep } from 'lodash';
+import type { Ctx, MoveOutcome } from 'strategy-game-factory';
+
 // Both variants play the same chase, differing only in how many sectors a side
 // of the lake has (4 vs 5) and how many days the shark must survive.
 export type Board = { submarines: number[]; shark: number; turn: number; sharkMovesInTurn: number }
@@ -29,3 +32,60 @@ export const isSubmarineMoveAllowed = (board: Board, from: number, to: number): 
 // gives up the second half of its night.
 export const isSharkMoveAllowed = (board: Board, to: number): boolean =>
   isSector(board, to) && distance(board.shark, to, sideLength(board)) <= 1;
+
+// The rules are the same chase on both lakes; only the last day differs, so it
+// is the one thing the moves are built with. The lake's size they read off the
+// board.
+export const makeGameplay = (maxTurn: number) => {
+  const isGameEnd = (board: Board): boolean =>
+    board.submarines[board.shark] >= 1 || board.turn > maxTurn;
+
+  const getWinnerIndex = (board: Board): number =>
+    board.submarines[board.shark] >= 1 ? RESEARCHERS : SHARK;
+
+  const moves = {
+    moveSubmarine: {
+      validate: (board: Board, { ctx }: { ctx: Ctx }, move: { from: number; to: number }) =>
+        ctx.currentPlayer === RESEARCHERS && !!move && isSubmarineMoveAllowed(board, move.from, move.to),
+      apply: (
+        board: Board, _, { from, to }: { from: number; to: number }
+      ): MoveOutcome<Board> => {
+        const nextBoard = cloneDeep(board);
+        nextBoard.submarines[from] -= 1;
+        nextBoard.submarines[to] += 1;
+        if (isGameEnd(nextBoard)) {
+          return { nextBoard, gameEnd: { winnerIndex: getWinnerIndex(nextBoard) } };
+        }
+        return { nextBoard, isTurnEnd: true };
+      }
+    },
+    moveShark: {
+      validate: (board: Board, { ctx }: { ctx: Ctx }, to: number) =>
+        ctx.currentPlayer === SHARK && isSharkMoveAllowed(board, to),
+      apply: (board: Board, _, to: number): MoveOutcome<Board> => {
+        const nextBoard = cloneDeep(board);
+        nextBoard.shark = to;
+
+        const isAnotherSharkMoveAllowed = (
+          board.submarines[to] === 0 &&
+            to !== board.shark &&
+            board.sharkMovesInTurn === 0
+        );
+        // A free first step earns a second one, so the turn stays open.
+        if (isAnotherSharkMoveAllowed) {
+          nextBoard.sharkMovesInTurn = 1;
+          return { nextBoard };
+        }
+
+        nextBoard.turn += 1;
+        nextBoard.sharkMovesInTurn = 0;
+        if (isGameEnd(nextBoard)) {
+          return { nextBoard, gameEnd: { winnerIndex: getWinnerIndex(nextBoard) } };
+        }
+        return { nextBoard, isTurnEnd: true };
+      }
+    }
+  };
+
+  return { isGameEnd, getWinnerIndex, moves };
+};

--- a/src/components/games/shark-chase/shark-4-by-4/gameplay.ts
+++ b/src/components/games/shark-chase/shark-4-by-4/gameplay.ts
@@ -1,65 +1,20 @@
-import type { Ctx, MoveOutcome } from 'strategy-game-factory';
-import { cloneDeep } from 'lodash';
-import { RESEARCHERS, SHARK, isSharkMoveAllowed, isSubmarineMoveAllowed, type Board } from '../gameplay';
+import { makeGameplay, type Board } from '../gameplay';
 
 // The shark wins by surviving to the end of day 11.
 export const MAX_TURN = 11;
 
-export const isGameEnd = (board: Board): boolean =>
-  board.submarines[board.shark] >= 1 || board.turn > MAX_TURN;
-
-export const getWinnerIndex = (board: Board): number =>
-  board.submarines[board.shark] >= 1 ? 0 : 1;
-
 export const startBoard: Board = {
-submarines: [0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0],
-shark: 12,
-turn: 1,
-sharkMovesInTurn: 0
+  submarines: [
+    [0, 0, 1, 1],
+    [0, 0, 0, 1],
+    [0, 0, 0, 0],
+    [0, 0, 0, 0]
+  ].flat(),
+  shark: 12,
+  turn: 1,
+  sharkMovesInTurn: 0
 };
 
-export const moves = {
-  moveSubmarine: {
-    validate: (board: Board, { ctx }: { ctx: Ctx }, move: { from: number; to: number }) =>
-      ctx.currentPlayer === RESEARCHERS && !!move && isSubmarineMoveAllowed(board, move.from, move.to),
-    apply: (
-      board: Board, _, { from, to }: { from: number; to: number }
-    ): MoveOutcome<Board> => {
-      const nextBoard = cloneDeep(board);
-      nextBoard.submarines[from] -= 1;
-      nextBoard.submarines[to] += 1;
-      if (isGameEnd(nextBoard)) {
-        return { nextBoard, gameEnd: { winnerIndex: getWinnerIndex(nextBoard) } };
-      }
-      return { nextBoard, isTurnEnd: true };
-    }
-  },
-  moveShark: {
-    validate: (board: Board, { ctx }: { ctx: Ctx }, to: number) =>
-      ctx.currentPlayer === SHARK && isSharkMoveAllowed(board, to),
-    apply: (board: Board, _, to: number): MoveOutcome<Board> => {
-      const nextBoard = cloneDeep(board);
-      nextBoard.shark = to;
-
-      const isAnotherSharkMoveAllowed = (
-        board.submarines[to] === 0 &&
-          to !== board.shark &&
-          board.sharkMovesInTurn === 0
-      );
-      // A free first step earns a second one, so the turn stays open.
-      if (isAnotherSharkMoveAllowed) {
-        nextBoard.sharkMovesInTurn = 1;
-        return { nextBoard };
-      }
-
-      nextBoard.turn += 1;
-      nextBoard.sharkMovesInTurn = 0;
-      if (isGameEnd(nextBoard)) {
-        return { nextBoard, gameEnd: { winnerIndex: getWinnerIndex(nextBoard) } };
-      }
-      return { nextBoard, isTurnEnd: true };
-    }
-  }
-}
+export const { isGameEnd, getWinnerIndex, moves } = makeGameplay(MAX_TURN);
 
 export type Moves = typeof moves;

--- a/src/components/games/shark-chase/shark-5-by-5/gameplay.ts
+++ b/src/components/games/shark-chase/shark-5-by-5/gameplay.ts
@@ -1,71 +1,21 @@
-import type { Ctx, MoveOutcome } from 'strategy-game-factory';
-import { cloneDeep } from 'lodash';
-import { RESEARCHERS, SHARK, isSharkMoveAllowed, isSubmarineMoveAllowed, type Board } from '../gameplay';
+import { makeGameplay, type Board } from '../gameplay';
 
 // The shark wins by surviving to the end of day 15.
 export const MAX_TURN = 15;
 
-export const isGameEnd = (board: Board): boolean =>
-  board.submarines[board.shark] >= 1 || board.turn > MAX_TURN;
-
-export const getWinnerIndex = (board: Board): number =>
-  board.submarines[board.shark] >= 1 ? 0 : 1;
-
 export const startBoard: Board = {
-submarines: [
-  [0, 0, 0, 1, 1],
-  [0, 0, 0, 1, 1],
-  [0, 0, 0, 0, 0],
-  [0, 0, 0, 0, 0],
-  [0, 0, 0, 0, 0]
-].flat(),
-shark: 20,
-turn: 1,
-sharkMovesInTurn: 0
+  submarines: [
+    [0, 0, 0, 1, 1],
+    [0, 0, 0, 1, 1],
+    [0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0]
+  ].flat(),
+  shark: 20,
+  turn: 1,
+  sharkMovesInTurn: 0
 };
 
-export const moves = {
-  moveSubmarine: {
-    validate: (board: Board, { ctx }: { ctx: Ctx }, move: { from: number; to: number }) =>
-      ctx.currentPlayer === RESEARCHERS && !!move && isSubmarineMoveAllowed(board, move.from, move.to),
-    apply: (
-      board: Board, _, { from, to }: { from: number; to: number }
-    ): MoveOutcome<Board> => {
-      const nextBoard = cloneDeep(board);
-      nextBoard.submarines[from] -= 1;
-      nextBoard.submarines[to] += 1;
-      if (isGameEnd(nextBoard)) {
-        return { nextBoard, gameEnd: { winnerIndex: getWinnerIndex(nextBoard) } };
-      }
-      return { nextBoard, isTurnEnd: true };
-    }
-  },
-  moveShark: {
-    validate: (board: Board, { ctx }: { ctx: Ctx }, to: number) =>
-      ctx.currentPlayer === SHARK && isSharkMoveAllowed(board, to),
-    apply: (board: Board, _, to: number): MoveOutcome<Board> => {
-      const nextBoard = cloneDeep(board);
-      nextBoard.shark = to;
-
-      const isAnotherSharkMoveAllowed = (
-        board.submarines[to] === 0 &&
-          to !== board.shark &&
-          board.sharkMovesInTurn === 0
-      );
-      // A free first step earns a second one, so the turn stays open.
-      if (isAnotherSharkMoveAllowed) {
-        nextBoard.sharkMovesInTurn = 1;
-        return { nextBoard };
-      }
-
-      nextBoard.turn += 1;
-      nextBoard.sharkMovesInTurn = 0;
-      if (isGameEnd(nextBoard)) {
-        return { nextBoard, gameEnd: { winnerIndex: getWinnerIndex(nextBoard) } };
-      }
-      return { nextBoard, isTurnEnd: true };
-    }
-  }
-}
+export const { isGameEnd, getWinnerIndex, moves } = makeGameplay(MAX_TURN);
 
 export type Moves = typeof moves;


### PR DESCRIPTION
**3 of 5**, on #486. Three files, and nothing but movement.

The two variant folders held the same `gameplay.ts` twice, differing only in
`MAX_TURN` and `startBoard` — the moves, `isGameEnd` and `getWinnerIndex` were
identical text.

`makeGameplay(maxTurn)` in the shared `gameplay.ts` takes them, as
`makeGeometry(size)` already takes the lake's size. A variant states the two
things that are its own and takes the rest:

```ts
export const { isGameEnd, getWinnerIndex, moves } = makeGameplay(MAX_TURN);
```

**How to check it without reading the moves twice:** diff the two old
`gameplay.ts` files against each other — `11`/`15` and the start board are the
whole of the difference — then read the extraction as the 4 × 4 copy with `11`
replaced by the parameter.

The bots are untouched, and every existing spec imports the same names from the
same places as before.

## Testing

`npm run lint`, `npm run typecheck`, `npm run test:unit` all pass, with no spec
changed — which is the argument that the extraction is faithful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8Fu7Uxzc9iYYoyCb8tSyu

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8Fu7Uxzc9iYYoyCb8tSyu)_