### PR TITLE
Shark chase: derive the shark's location preference

### DIFF
--- a/src/components/games/shark-chase/bot-search.spec.ts
+++ b/src/components/games/shark-chase/bot-search.spec.ts
@@ -1,0 +1,34 @@
+import { preferenceRings } from './bot-search';
+
+// Both lakes used to carry their preference order as a literal list, one per
+// bot. They are not arbitrary: each is the sectors grouped by distance from the
+// centre, which is what `preferenceRings` derives. These are the two lists as
+// they were written, so a change to the derivation has to answer for them.
+describe('preferenceRings', () => {
+  it('is the middle of the 4 × 4 lake, then its edges, then its corners', () => {
+    expect(preferenceRings(4)).toEqual([
+      [5, 6, 9, 10],
+      [1, 2, 4, 7, 8, 11, 13, 14],
+      [0, 3, 12, 15]
+    ]);
+  });
+
+  it('works out from the centre sector of the 5 × 5 lake', () => {
+    expect(preferenceRings(5)).toEqual([
+      [12],
+      [7, 11, 13, 17],
+      // Two steps out diagonally comes before two steps out in a straight line
+      [6, 8, 16, 18],
+      [2, 10, 14, 22],
+      [1, 3, 5, 9, 15, 19, 21, 23],
+      [0, 4, 20, 24]
+    ]);
+  });
+
+  it('covers every sector exactly once', () => {
+    for (const size of [4, 5]) {
+      expect(preferenceRings(size).flat().sort((a, b) => a - b))
+        .toEqual(Array.from({ length: size * size }, (_, i) => i));
+    }
+  });
+});

--- a/src/components/games/shark-chase/bot-search.ts
+++ b/src/components/games/shark-chase/bot-search.ts
@@ -1,21 +1,37 @@
-import { range, sample } from 'lodash';
+import { range, sample, sortBy } from 'lodash';
 import type { BotMove, BotStrategy } from 'strategy-game-factory';
 import { isSubmarineMoveAllowed, type Board, type Moves } from './gameplay';
 import { makeGeometry } from './bot-geometry';
 
 type Bot = BotStrategy<Board, Moves>
 
+// Where the shark would rather be when nothing it can reach is safe: the middle
+// of the lake first, then outwards. The rings are the sectors grouped by how far
+// they are from the centre — Manhattan distance, with Chebyshev separating the
+// diagonal ring from the straight one where both are two steps out — which is
+// exactly the two hand-written lists this replaces (bot-search.spec.ts pins that).
+export const preferenceRings = (size: number): number[][] => {
+  const centre = (size - 1) / 2;
+  const rings: { manhattan: number; chebyshev: number; cells: number[] }[] = [];
+
+  for (const cell of range(size * size)) {
+    const row = Math.abs(Math.floor(cell / size) - centre);
+    const column = Math.abs((cell % size) - centre);
+    const [manhattan, chebyshev] = [row + column, Math.max(row, column)];
+    const ring = rings.find(r => r.manhattan === manhattan && r.chebyshev === chebyshev);
+    if (ring) ring.cells.push(cell); else rings.push({ manhattan, chebyshev, cells: [cell] });
+  }
+
+  return sortBy(rings, ['manhattan', 'chebyshev']).map(ring => ring.cells);
+};
+
 // Both bots of both lakes. What is genuinely per-variant is passed in: the size
 // of the lake, the day the shark has to reach, the researchers' scripted line,
 // and — on 5×5 — the precomputed answer that spares the live search on the early
 // days it is too slow for.
-export const makeSharkBots = ({
-  size, maxTurn, preferenceRings, scriptedSubmarineMove, survivingSectors
-}: {
+export const makeSharkBots = ({ size, maxTurn, scriptedSubmarineMove, survivingSectors }: {
   size: number
   maxTurn: number
-  // sectors the shark prefers when nothing it can reach is safe, best group first
-  preferenceRings: number[][]
   scriptedSubmarineMove: (board: Board) => { from: number; to: number } | undefined
   survivingSectors?: (board: Board, reachable: number[]) => number[] | undefined
 }) => {
@@ -113,6 +129,8 @@ export const makeSharkBots = ({
     return undefined;
   };
 
+  const rings = preferenceRings(size);
+
   // Greedy fallback used only when no move guarantees survival (game is already
   // lost): picks the reachable sector with the largest "safe" connected component
   // (sectors not adjacent to any submarine), preferring the middle of the lake.
@@ -128,7 +146,7 @@ export const makeSharkBots = ({
       pool.filter(i => ring.includes(i) && componentSizes[i] === maxi);
 
     let possibleMoves: number[] = [];
-    for (const ring of preferenceRings) {
+    for (const ring of rings) {
       possibleMoves = matching(ring);
       if (possibleMoves.length > 0) break;
     }

--- a/src/components/games/shark-chase/shark-4-by-4/bot-strategy.ts
+++ b/src/components/games/shark-chase/shark-4-by-4/bot-strategy.ts
@@ -47,14 +47,10 @@ const getOptimalSubmarineMoveByBot = (board: Board): { from: number; to: number 
   return undefined;
 };
 
-// The middle of the lake first, then its edges, then its corners.
-const preferenceRings = [[5, 6, 9, 10], [1, 2, 4, 7, 8, 11, 13, 14], [0, 3, 12, 15]];
-
 export const {
   randomBotStrategy, smartBotStrategy, getNextSharkPositionByAI
 } = makeSharkBots({
   size: 4,
   maxTurn: MAX_TURN,
-  preferenceRings,
   scriptedSubmarineMove: getOptimalSubmarineMoveByBot
 });

--- a/src/components/games/shark-chase/shark-5-by-5/bot-strategy.ts
+++ b/src/components/games/shark-chase/shark-5-by-5/bot-strategy.ts
@@ -83,22 +83,11 @@ const precomputedSurvivingSectors = (board: Board, reachable: number[]): number[
   return exception === undefined ? reachable : [exception];
 };
 
-// The centre sector first, then working outwards.
-const preferenceRings = [
-  [12],
-  [7, 11, 13, 17],
-  [6, 8, 16, 18],
-  [2, 10, 14, 22],
-  [1, 3, 5, 9, 15, 19, 21, 23],
-  [0, 4, 20, 24]
-];
-
 export const {
   randomBotStrategy, smartBotStrategy, getNextSharkPositionByAI
 } = makeSharkBots({
   size: 5,
   maxTurn: MAX_TURN,
-  preferenceRings,
   scriptedSubmarineMove: getOptimalSubmarineMoveByBot,
   survivingSectors: precomputedSurvivingSectors
 });


### PR DESCRIPTION
**5 of 5**, on #488. Four files, +59/−22 — the only idea in the dedup half that
is not movement.

The two ring lists the bots pass in are not arbitrary: each is exactly the
sectors of its lake grouped by distance from the centre — Manhattan first, with
Chebyshev separating the diagonal ring from the straight one where both are two
steps out. `preferenceRings(size)` derives them, so the rule is written once
instead of as two lists nobody can check by eye.

`bot-search.spec.ts` asserts the derived rings against both lists as they were
written, which is the whole of the argument that this changes no behaviour.

**That spec earns its place**: I broke the derivation on purpose — dropped the
Chebyshev tiebreak — and it fails while **nothing else in the suite does**, 56
other tests green. The preference only decides where the shark swims once it has
already lost, so no played-out match notices. This is the one part of the dedup
a reviewer cannot check by eye, and it is the part with a test.

## Testing

| Check | Result |
| --- | --- |
| `npm run lint`, `npm run typecheck` | pass |
| `npm run test:unit` | 1970 pass |
| `npm run coverage:patch` | 99% of the added lines |
| 6000 headless matches across both variants and both start positions | no illegal moves, no shark wins |
| Both variants played to the last day in a browser | researchers win, as before |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8Fu7Uxzc9iYYoyCb8tSyu

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8Fu7Uxzc9iYYoyCb8tSyu)_