### PR TITLE
Fix a one-in-500 flake in the endOfTurnMove specs

### DIFF
--- a/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
@@ -317,7 +317,15 @@ describe('strategyGameFactory endOfTurnMove', () => {
     };
 
     const { getByTestId } = renderGame(minimalConfig({ moves, endOfTurnMove: 'autoMove' }));
-    fireEvent.click(getByTestId('role-btn-0'));
+    // human-vs-human as in the test above, and here it is what makes the test
+    // deterministic: `mainMove` passes the turn, so against the computer the
+    // bot's own beat is on the schedule too. That beat is spread over
+    // 750-1250ms, so advancing 750 fires it on the roll that lands at the low
+    // end — one run in 500 — and `minimalConfig`'s bot names no move, which is
+    // a dev-mode throw. Without a bot, the only thing that could be scheduled
+    // is the endOfTurnMove under test.
+    fireEvent.click(getByTestId('mode-vsHuman'));
+    fireEvent.click(getByTestId('start-hh-game-0'));
     fireEvent.click(getByTestId('move-btn'));
     act(() => { vi.advanceTimersByTime(750); });
 


### PR DESCRIPTION
Independent of the shark-chase stack — it just took CI down on #485, which
touches nothing this test covers.

`does not call endOfTurnMove when a move does not return autoEndOfTurn` plays
against the computer, and its `mainMove` passes the turn — so the bot's own beat
is on the schedule beside the `endOfTurnMove` it is watching for. `stepDelay()`
spreads that beat over 750–1250 ms and the test advances the timers by 750, so
the roll that lands at the low end fires the bot's turn. `minimalConfig`'s bot
names no move, which the engine treats as a bug in the strategy and throws for
in dev:

```
Error: strategyGameFactory: botStrategy named no move to play
 ❯ askBot src/components/strategy-game-factory/strategy-game-factory.tsx:306:40
```

**One run in 500.**

The test directly above it already plays in human-vs-human mode, with a comment
saying why: with no bot, there is nothing on the schedule but the move under
test. This one now does the same.

## How it was checked

The flake is too rare to confirm by re-running, so it was made deterministic:
pinning `Math.random` to 0 — which is exactly the beat that breaks it, and what
the sibling test already does for its own reason — reproduces the CI error every
time before the change, and passes every time after.

The other two places in this file that advance by 750 are unaffected: both pin
the beat themselves, and the one bot involved names real moves.

`npm run lint`, `npm run typecheck`, `npm run test:unit` (1960) all pass.

## Not done here

`minimalConfig`'s default bot is `() => []`, so *any* stray beat in a
vsComputer test is a dev-mode throw waiting to happen. Giving it a bot that
names a real move would close the class rather than this instance, but several
tests rely on the do-nothing bot, so it is a bigger change than a flake fix
should carry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8Fu7Uxzc9iYYoyCb8tSyu

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8Fu7Uxzc9iYYoyCb8tSyu)_