### PR TITLE
Fix bot strategy default to play first legal move

### DIFF
--- a/src/components/strategy-game-factory/spec-helpers.tsx
+++ b/src/components/strategy-game-factory/spec-helpers.tsx
@@ -32,10 +32,24 @@ export const defaultGameplay: Gameplay<Board> = {
   }
 };
 
+// Naming no move is a bug in a strategy, so the engine throws for it in dev
+// (see src/components/CLAUDE.md § Bot contract). A do-nothing default therefore
+// left every vsComputer spec one stray scheduled beat away from failing on a
+// strategy it never meant to test — which is exactly how #490 came about. The
+// default plays instead: whatever gameplay the config carries, it names the
+// first move the position allows. A spec that cares what the bot plays passes
+// its own.
+const playsFirstLegalMove = (gameplay: Gameplay<Board>): BotStrategy<Board> =>
+  ({ board, ctx }) => {
+    const name = Object.keys(gameplay.moves)
+      .find(key => gameplay.moves[key]!.validate?.(board, { ctx }) ?? true);
+    return name ? [{ move: name }] : [];
+  };
+
 export const makeConfig = ({
   BoardClient = MinimalBoardClient,
   gameplay = defaultGameplay,
-  botStrategy = (() => []) as BotStrategy<Board>,
+  botStrategy = playsFirstLegalMove(gameplay),
   variants
 }: {
   BoardClient?: StrategyGameConfig<Board>['BoardClient']
@@ -51,7 +65,7 @@ export const makeConfig = ({
 
 export const minimalConfig = (gameplay: Gameplay<Board>) => makeConfig({ gameplay });
 
-export const ctxAwareConfig = (botStrategy: BotStrategy<Board> = () => []) =>
+export const ctxAwareConfig = (botStrategy?: BotStrategy<Board>) =>
   makeConfig({ BoardClient: CtxAwareBoardClient, botStrategy });
 
 // The factory both reads and writes `?variant=`, so the harness shows the URL

--- a/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
+++ b/src/components/strategy-game-factory/strategy-game-factory.spec.tsx
@@ -64,6 +64,17 @@ describe('Bot behavior by mode', () => {
       .toThrow(/named unknown move 'mianMove' \(this game has: mainMove\)/);
   });
 
+  // What keeps a stray beat from failing a spec that is watching for something
+  // else: the helpers' default bot names a move rather than nothing, so the
+  // turn comes back instead of throwing (#490).
+  it('plays a legal move when the config leaves the bot to the spec helpers', () => {
+    const { getByTestId } = renderGame(ctxAwareConfig());
+    fireEvent.click(getByTestId('role-btn-0'));
+    fireEvent.click(getByTestId('move-btn')); // endTurn → bot's turn
+    act(() => { vi.advanceTimersByTime(1500); }); // must not throw
+    expect((getByTestId('move-btn') as HTMLButtonElement).disabled).toBe(false);
+  });
+
   it('calls botStrategy when it becomes the computer turn', () => {
     const botStrategy = vi.fn((): BotMove => ({ move: 'mainMove' }));
     const { getByTestId } = renderGame(ctxAwareConfig(botStrategy));
@@ -319,11 +330,10 @@ describe('strategyGameFactory endOfTurnMove', () => {
     const { getByTestId } = renderGame(minimalConfig({ moves, endOfTurnMove: 'autoMove' }));
     // human-vs-human as in the test above, and here it is what makes the test
     // deterministic: `mainMove` passes the turn, so against the computer the
-    // bot's own beat is on the schedule too. That beat is spread over
-    // 750-1250ms, so advancing 750 fires it on the roll that lands at the low
-    // end — one run in 500 — and `minimalConfig`'s bot names no move, which is
-    // a dev-mode throw. Without a bot, the only thing that could be scheduled
-    // is the endOfTurnMove under test.
+    // bot's own beat would be on the schedule too, spread over 750-1250ms —
+    // and advancing 750 fires it on the roll that lands at the low end.
+    // Without a bot, the only thing that can be scheduled is the endOfTurnMove
+    // under test.
     fireEvent.click(getByTestId('mode-vsHuman'));
     fireEvent.click(getByTestId('start-hh-game-0'));
     fireEvent.click(getByTestId('move-btn'));
@@ -553,7 +563,7 @@ describe('umami game-finished event', () => {
 });
 
 describe('move validate enforcement', () => {
-  const guardedConfig = (botStrategy: BotStrategy<Board> = () => []) => makeConfig({
+  const guardedConfig = (botStrategy?: BotStrategy<Board>) => makeConfig({
     BoardClient: ({ board, moves }: BoardClientProps<Board>) => (
       <>
         <button data-testid="legal-btn" onClick={() => moves.guarded(board, 'ok')}>legal</button>
@@ -646,6 +656,24 @@ describe('move validate enforcement', () => {
       fireEvent.click(getByTestId('hand-over-btn')); // → bot's turn
       act(() => { vi.advanceTimersByTime(1500); });
       expect(Object.keys(seen[0]!)).toEqual(['board', 'ctx']);
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  // The default bot names the first move the position allows, so it has to ask
+  // `validate` rather than pick blindly: `guarded` is illegal with no args,
+  // which leaves `handOver`.
+  it('leaves the default bot naming the first move a validator does allow', () => {
+    vi.useFakeTimers();
+    try {
+      const { getByTestId } = renderGame(guardedConfig());
+      fireEvent.click(getByTestId('role-btn-0'));
+      fireEvent.click(getByTestId('hand-over-btn')); // → bot's turn
+      act(() => { vi.advanceTimersByTime(1500); });
+      expect(getByTestId('board').textContent).toBe('initial'); // handOver, not guarded
+      expect(getByTestId('can-ok').textContent).toBe('true'); // and the turn came back
     } finally {
       vi.clearAllTimers();
       vi.useRealTimers();
@@ -1011,7 +1039,7 @@ describe('outcome-returning moves (apply)', () => {
   });
 
   describe('validate on outcome-returning moves', () => {
-    const guardedV2Config = (botStrategy: BotStrategy<Board> = () => []) => makeConfig({
+    const guardedV2Config = (botStrategy?: BotStrategy<Board>) => makeConfig({
       BoardClient: ({ board, moves }: BoardClientProps<Board>) => (
         <>
           <button data-testid="legal-btn" onClick={() => moves.guarded(board, 'ok')}>legal</button>


### PR DESCRIPTION
# Description

## Motivation

The test helpers' default bot strategy was returning an empty move list, which caused the engine to throw an error in dev mode (as per the bot contract). This left every vsComputer spec vulnerable to failing on stray scheduled bot turns that had nothing to do with what the spec was actually testing. Issue #490 surfaced this problem.

## Key changes

- Changed `makeConfig`'s default `botStrategy` from a no-op (`() => []`) to `playsFirstLegalMove(gameplay)`, which names the first move the position allows
- Updated `ctxAwareConfig` and `guardedConfig` signatures to accept optional `botStrategy` parameter (defaulting to the new behavior)
- Added helper function `playsFirstLegalMove` that respects move validators when selecting a move
- Updated test comments to reflect the new default behavior
- Added two new test cases:
  - `'plays a legal move when the config leaves the bot to the spec helpers'` — verifies the default bot doesn't throw on stray turns
  - `'leaves the default bot naming the first move a validator does allow'` — verifies validator enforcement in the default strategy

## Details

**Prior logic:** The default bot strategy returned an empty move list, which violated the bot contract and caused dev-mode throws. Specs that didn't explicitly provide a bot strategy were one stray scheduled beat away from failing unexpectedly.

**Current logic:** The default bot strategy now plays the first move that passes validation (if any). This ensures:
1. Stray scheduled bot turns complete successfully instead of throwing
2. Specs that care what the bot plays can still provide their own strategy
3. The default respects move validators, so it won't attempt illegal moves

Specs that explicitly pass a `botStrategy` parameter are unaffected and continue to use their provided strategy.

## Test coverage

The changes include two new test cases that verify the default bot behavior works correctly both with and without move validators. Existing tests continue to pass with the new default.

https://claude.ai/code/session_012FUhh6B9MtHv9uwna7Z9cy