### PR TITLE
Serve a redirect instead of the site

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -45,10 +45,14 @@ jobs:
       - name: Build
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: npm run build
+      # `redirect`, not `dist`: this site moved to durer-aion's Pages deploy, and what
+      # jatek.durerinfo.hu serves now is the stub that forwards there. The build above is
+      # kept as a check rather than deleted — its output is simply not published. Reverting
+      # this one line puts the real site back.
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5
         with:
-          path: dist
+          path: redirect
 
   deploy:
     needs: build

--- a/redirect/404.html
+++ b/redirect/404.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="hu">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Átköltöztünk — Dürer játékok</title>
+    <link rel="canonical" href="https://gyakorlo.durerinfo.hu/jatekok/" />
+    <script>
+      // location.hash is the whole point: a fragment never reaches the server, so no
+      // server-side redirect can preserve it. Every deep link on this site is a
+      // fragment (#/game/PileSplitter), so carrying it across in the browser is what
+      // keeps them all working — one line covering every game.
+      //
+      // `replace`, not `assign`: the old address should not sit in history behind the
+      // new one, or Back from the new site lands here and bounces forward again.
+      location.replace('https://gyakorlo.durerinfo.hu/jatekok/' + location.hash);
+    </script>
+    <meta http-equiv="refresh" content="3; url=https://gyakorlo.durerinfo.hu/jatekok/" />
+    <style>
+      body {
+        margin: 0; padding: 3rem 1.25rem;
+        font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+        line-height: 1.6; color: #0f172a; background: #f8fafc;
+      }
+      main { max-width: 34rem; margin: 0 auto; }
+      a { color: #1d4ed8; }
+      @media (prefers-color-scheme: dark) {
+        body { color: #f1f5f9; background: #0f172a; }
+        a { color: #93c5fd; }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Átköltöztünk</h1>
+      <p>
+        A Dürer játékok új címe:
+        <a href="https://gyakorlo.durerinfo.hu/jatekok/">gyakorlo.durerinfo.hu/jatekok/</a>.
+        Néhány másodpercen belül automatikusan odairányítunk.
+      </p>
+      <p>
+        The Dürer practice games have moved to
+        <a href="https://gyakorlo.durerinfo.hu/jatekok/">gyakorlo.durerinfo.hu/jatekok/</a>.
+        You are being redirected.
+      </p>
+    </main>
+  </body>
+</html>

--- a/redirect/CNAME
+++ b/redirect/CNAME
@@ -1,0 +1,1 @@
+jatek.durerinfo.hu

--- a/redirect/index.html
+++ b/redirect/index.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="hu">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Átköltöztünk — Dürer játékok</title>
+    <link rel="canonical" href="https://gyakorlo.durerinfo.hu/jatekok/" />
+    <script>
+      // location.hash is the whole point: a fragment never reaches the server, so no
+      // server-side redirect can preserve it. Every deep link on this site is a
+      // fragment (#/game/PileSplitter), so carrying it across in the browser is what
+      // keeps them all working — one line covering every game.
+      //
+      // `replace`, not `assign`: the old address should not sit in history behind the
+      // new one, or Back from the new site lands here and bounces forward again.
+      location.replace('https://gyakorlo.durerinfo.hu/jatekok/' + location.hash);
+    </script>
+    <meta http-equiv="refresh" content="3; url=https://gyakorlo.durerinfo.hu/jatekok/" />
+    <style>
+      body {
+        margin: 0; padding: 3rem 1.25rem;
+        font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+        line-height: 1.6; color: #0f172a; background: #f8fafc;
+      }
+      main { max-width: 34rem; margin: 0 auto; }
+      a { color: #1d4ed8; }
+      @media (prefers-color-scheme: dark) {
+        body { color: #f1f5f9; background: #0f172a; }
+        a { color: #93c5fd; }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Átköltöztünk</h1>
+      <p>
+        A Dürer játékok új címe:
+        <a href="https://gyakorlo.durerinfo.hu/jatekok/">gyakorlo.durerinfo.hu/jatekok/</a>.
+        Néhány másodpercen belül automatikusan odairányítunk.
+      </p>
+      <p>
+        The Dürer practice games have moved to
+        <a href="https://gyakorlo.durerinfo.hu/jatekok/">gyakorlo.durerinfo.hu/jatekok/</a>.
+        You are being redirected.
+      </p>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## ⛔ Do not merge until `gyakorlo.durerinfo.hu` resolves

**Merging this is the cutover.** It is step 6 of [the Pages consolidation](https://github.com/a-gondolkodas-orome/durer-aion/blob/main/docs/pages-consolidation.md), and until the custom domain exists it would point `jatek.durerinfo.hu` at nothing. Opening it now so it's ready and reviewable, not because it's due.

## Why a page and not a DNS rule

GitHub redirects a repository's default `github.io` URL to **its own** custom domain, but never one custom domain to another. Once durer-aion's CNAME says `gyakorlo`, a request for `jatek.durerinfo.hu` arrives with a Host that Pages doesn't recognise and gets a 404. So the hop has to be built — and the cheapest place is here, since this repository already owns the domain. No DNS record, no new infrastructure.

`location.hash` is why it's a page rather than a server rule: **a fragment never reaches the server**, and every deep link on this site is one. The stub carries it across in the browser, so one line covers every game. `404.html` is the same file, so paths outside the root forward too.

## Verified in Chromium, against a stubbed destination

| requested | lands on |
| --- | --- |
| `/` | `gyakorlo.durerinfo.hu/jatekok/` |
| `/#/game/PileSplitter` | `…/jatekok/#/game/PileSplitter` |
| `/#/game/ChessRook` | `…/jatekok/#/game/ChessRook` |
| `/nonexistent-path` (404) | `…/jatekok/` |

Worth recording how that nearly went wrong: my first check read the *intercepted request* URL and showed the fragment missing on every route. It wasn't — fragments are never sent to the server, so they can't appear there. Reading `page.url()` (the address bar) instead shows them preserved. A less careful check would have "proved" this PR broken.

## Reversibility

The build stays and is still run; only its output stops being published (`path: dist` → `path: redirect`). Putting the real site back is that one line.

## The alternative, if waiting on DNS is annoying

Retarget the stub at `a-gondolkodas-orome.github.io/durer-aion/jatekok/` and this becomes mergeable today — GitHub's own default-domain redirect then carries visitors on to `gyakorlo` once it's configured, with no second edit. The cost is that the canonical practice URL is a `github.io` address for however long that takes, and whatever people copy in the meantime is what spreads. I'd rather wait, but it's a one-line change if you'd rather not.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NP2MxWjCtdAhPHYPBJqU25)_